### PR TITLE
Add export NODE_OPTIONS=--openssl-legacy-provider to build script

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,4 +67,4 @@ jobs:
           python -m pip install git+https://github.com/bbalasub1/glmnet_python.git@1.0
           python -m pip install .[dev]
       - name: Build website
-        run: NODE_OPTIONS=--openssl-legacy-provider bash ./scripts/make_docs.sh
+        run: bash ./scripts/make_docs.sh

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -19,7 +19,7 @@ jobs:
           python -m pip install git+https://github.com/bbalasub1/glmnet_python.git@1.0
           python -m pip install .[dev]
       - name: Build website
-        run: NODE_OPTIONS=--openssl-legacy-provider bash ./scripts/make_docs.sh
+        run: bash ./scripts/make_docs.sh
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
       - name: Deploy to GitHub Pages

--- a/scripts/make_docs.sh
+++ b/scripts/make_docs.sh
@@ -54,4 +54,4 @@ yarn
 echo "-----------------------------------"
 echo "Building static Docusaurus site"
 echo "-----------------------------------"
-yarn build
+NODE_OPTIONS=--openssl-legacy-provider yarn build


### PR DESCRIPTION
Summary: See https://fburl.com/ncva8n2b. Newer versions of node have deprecated legacy openssl libraries, but unfortunately, Docusarurus still has deps on those libraries. Hence we need to set these flags. We already were setting them during builds, but let's move these into the script so anyone gets this setting automatically

Differential Revision: D41357785

