### PR TITLE
Fix edit URL

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -35,7 +35,7 @@ const katex = require('rehype-katex');
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: fbContent({
             internal: 'https://www.internalfb.com/intern/diffusion/FBS/browse/master/fbcode/core_stats/balance/parent_balance/website',
-            external: 'https://github.com/facebookresearch/balance/website',
+            external: 'https://github.com/facebookresearch/balance/tree/main/website',
           }),
           remarkPlugins: [math],
           rehypePlugins: [katex],


### PR DESCRIPTION
Summary: The edit page button is busted due to the base URL being incorrect in docusaurus. Let's fix it to link to the proper github URL for the repo docs

Differential Revision: D41744949

