### PR TITLE
Automate package push on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Deploy
+
+on:
+  release:
+    types: [published]
+  #@nocommit
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Pkg + Dependencies
+        run: |
+          python -m pip install git+https://github.com/bbalasub1/glmnet_python.git@1.0
+          python -m pip install .[dev]
+      - name: Test with pytest
+        run: |
+          python -m pytest -ra
+      - name: Build wheels pkg
+        run: |
+          python setup.py bdist_wheel
+
+
+  deploy:
+    needs: tests # only run if previous step succeeds
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - name: Install Pkg + Dependencies
+      run: |
+        python -m pip install git+https://github.com/bbalasub1/glmnet_python.git@1.0
+        python -m pip install .[dev]
+    - name: Fetch all history for all tags and branches
+      run: git fetch --prune --unshallow
+    - name: Build wheel
+      run: |
+        python setup.py sdist bdist_wheel
+    # - name: Publish a Python distribution to PyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     password: ${{ secrets.PYPI_API_TOKEN }}
+    #     verbose: true


### PR DESCRIPTION
Summary: For future pkg releases to PyPi, we can automate the process via Github Actions. This adds a new action that is triggered on publish of a new release, running unit tests as a final sanity check before a build + PYPi push

Differential Revision: D42547783

