### PR TITLE
Monkey-patch scipy.random() to numpy.random()

### DIFF
--- a/balance/__init__.py
+++ b/balance/__init__.py
@@ -14,7 +14,7 @@ from balance.balancedf_class import (  # noqa
 )
 from balance.datasets import load_data  # noqa
 from balance.sample_class import Sample  # noqa
-from balance.util import TruncationFormatter
+from balance.util import TruncationFormatter  # noqa
 
 # TODO: which objects do we want to explicitly externalize?
 # TODO: verify this works.

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ REQUIRES = [
     "numpy",
     "pandas<=1.4.3",
     "ipython",
-    "scipy<=1.8.1",
+    "scipy<=1.9.0",
     "patsy",
     "seaborn<=0.11.1",
     "plotly",


### PR DESCRIPTION
Summary: See https://github.com/facebookresearch/balance/issues/19. scipy 1.9.0 is the min version for 3.11, but glmnet_python still uses deprecated methods not supported in scipy 1.9.0, particularly numpy.random(). Let's try monkeypatching it to see if this unblocks usage of scipy 1.9.0 downstream in glmnet

Differential Revision: D42804148

