### PR TITLE
Bump scipy to 1.9.2

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,9 +26,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Pkg + Dependencies
-        # libopenblas-dev required for scipy: https://github.com/scipy/scipy/issues/16308
         run: |
-          sudo apt-get install -y libopenblas-dev
           python -m pip install git+https://github.com/bbalasub1/glmnet_python.git@1.0
           python -m pip install .[dev]
       - name: Test with pytest

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ REQUIRES = [
     "numpy",
     "pandas<=1.4.3",
     "ipython",
-    "scipy<=1.9.0",
+    "scipy<=1.9.2",
     "patsy",
     "seaborn<=0.11.1",
     "plotly",


### PR DESCRIPTION
Summary: 1.9.0 works on py3.11, but doesn't have a dedicated wheels builds to use, so you'd need to rebuild scipy fresh. 1.9.2 does have default wheels builds, so let's try supporting that for the best py3.11 experience

Reviewed By: talgalili

Differential Revision: D42831880

