### PR TITLE
Fix utf-8 file reads on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### New Features
 - Added compatibility for SciPy 1.9.2 and Python 3.11
 
+### Bug Fixes
+- Fixed pip install from source on Windows machines
+
 0.2.0 (2023-01-19)
 ==================
 ### New Features

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ DESCRIPTION = (
 
 def setup_package() -> None:
     """Used for building/installing the balance package."""
-    with open("README.md", "r") as fh:
+    with open("README.md", "r", encoding="utf-8") as fh:
         long_description = fh.read()
 
     setup(


### PR DESCRIPTION
Summary: Our README.md files and similar are utf-8 encoded, which while the default encoding style for Python on linux machines, isn't the expected one on windows

Differential Revision: D42869896

