### PR TITLE
Add dataset's csvs to builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,8 @@ def setup_package() -> None:
         python_requires=">=3.7",
         install_requires=REQUIRES,
         packages=find_packages(include=["balance*"]),
+        # Include all csv files
+        package_data={"": ["*.csv"]},
         extras_require={
             "dev": DEV_REQUIRES,
         },


### PR DESCRIPTION
Summary: See https://docs.python.org/3/distutils/setupscript.html#installing-package-data. Package data like csv need to be opted-in to being included with builds

Differential Revision: D43238555

