### PR TITLE
Fix tests for Python 3.11: "ERROR: Dependency "OpenBLAS" not found, tried pkgconfig and cmake"

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install OpenBLAS dependency
+        run: sudo apt-get install -y libopenblas-dev
       - name: Install Pkg + Dependencies
         run: |
           python -m pip install git+https://github.com/bbalasub1/glmnet_python.git@1.0


### PR DESCRIPTION
Summary:
The tests on version 3.11 started to fail.
See:
https://github.com/facebookresearch/balance/actions/runs/4908756465/jobs/8764722959

It appears that the installation of the SciPy package failed due to a missing dependency, OpenBLAS. To resolve this issue I've updated the yml with installing OpenBLAS.

Main error:
```
     Found CMake: /usr/local/bin/cmake (3.26.3)
      Run-time dependency openblas found: NO (tried pkgconfig and cmake)
      Run-time dependency openblas found: NO (tried pkgconfig and cmake)

      ../../scipy/meson.build:130:0: ERROR: Dependency "OpenBLAS" not found, tried pkgconfig and cmake

      A full log can be found at /tmp/pip-install-4rir72bl/scipy_9e4046e28fb74c49acbedce1903f493b/.mesonpy-jvv25u_b/build/meson-logs/meson-log.txt
      + meson setup --native-file=/tmp/pip-install-4rir72bl/scipy_9e4046e28fb74c49acbedce1903f493b/.mesonpy-native-file.ini -Ddebug=false -Doptimization=2 --prefix=/opt/hostedtoolcache/Python/3.11.3/x64 /tmp/pip-install-4rir72bl/scipy_9e4046e28fb74c49acbedce1903f493b /tmp/pip-install-4rir72bl/scipy_9e4046e28fb74c49acbedce1903f493b/.mesonpy-jvv25u_b/build
      Traceback (most recent call last):
        File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-8brgwuwh/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 969, in get_requires_for_build_wheel
          with _project(config_settings) as project:
        File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/contextlib.py", line 137, in __enter__
          return next(self.gen)
                 ^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-8brgwuwh/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 948, in _project
          with Project.with_temp_working_dir(
        File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/contextlib.py", line 137, in __enter__
          return next(self.gen)
                 ^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-8brgwuwh/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 777, in with_temp_working_dir
          yield cls(source_dir, tmpdir, build_dir)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-8brgwuwh/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 682, in __init__
          self._configure(reconfigure=bool(build_dir) and not native_file_mismatch)
        File "/tmp/pip-build-env-8brgwuwh/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 713, in _configure
          self._meson(
        File "/tmp/pip-build-env-8brgwuwh/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 696, in _meson
          return self._proc('meson', *args)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-8brgwuwh/overlay/lib/python3.11/site-packages/mesonpy/__init__.py", line 691, in _proc
          subprocess.check_call(list(args))
        File "/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/subprocess.py", line 413, in check_call
          raise CalledProcessError(retcode, cmd)
      subprocess.CalledProcessError: Command '['meson', 'setup', '--native-file=/tmp/pip-install-4rir72bl/scipy_9e4046e28fb74c49acbedce1903f493b/.mesonpy-native-file.ini', '-Ddebug=false', '-Doptimization=2', '--prefix=/opt/hostedtoolcache/Python/3.11.3/x64', '/tmp/pip-install-4rir72bl/scipy_9e4046e28fb74c49acbedce1903f493b', '/tmp/pip-install-4rir72bl/scipy_9e4046e28fb74c49acbedce1903f493b/.mesonpy-jvv25u_b/build']' returned non-zero exit status 1.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

Notice:  A new release of pip is available: 22.3.1 -> 23.1.2
Notice:  To update, run: pip install --upgrade pip
Error: Process completed with exit code 1.
```

Differential Revision: D45652744

