### PR TITLE
Update release.yml - remove 3.11 from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10'] # , '3.11']
       fail-fast: false
     steps:
       - name: Checkout


### PR DESCRIPTION
balance no longer supports 3.11, so removing it from deployment to pypi