### PR TITLE
Relax `seaborn` pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ REQUIRES = [
     "ipython",
     "scipy<=1.9.2",
     "patsy",
-    "seaborn<=0.11.1",
+    "seaborn<=0.13",
     "plotly",
     "matplotlib",
     "statsmodels",


### PR DESCRIPTION
This is preventing me from installing `balance` in an analytics env so I thought I'd put in a PR to see if it broke anything.

The latest `seaborn` is [`v0.12.2`](https://github.com/mwaskom/seaborn/releases/tag/v0.12.2).

