### PR TITLE
Add strict_matching option to poststratify

### DIFF
--- a/tests/test_poststratify.py
+++ b/tests/test_poststratify.py
@@ -216,3 +216,13 @@ class Testpoststratify(
             ValueError, "all combinations of cells in sample_df must be in target_df"
         ):
             poststratify(s, s_weights, t, t_weights)
+
+        # Check that strict_matching=False works
+        result = poststratify(
+            sample_df=s,
+            sample_weights=s_weights,
+            target_df=t,
+            target_weights=t_weights,
+            strict_matching=False,
+        )["weight"]
+        self.assertEqual(result, pd.Series([2.0, 0.0]))


### PR DESCRIPTION
Summary: Add strict_matching option to poststratify, to allow users to bypass the case when all combinations of cells in sample_df must be in target_df

Differential Revision: D79670637


