### PR TITLE
update setup.py to be less restrictive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,12 +12,12 @@ REQUIRES = [
     # Numpy and pandas: carefully versioned for binary compatibility
     "numpy>=1.21.0,<2.0; python_version<'3.12'",
     "numpy>=1.24.0,<2.1; python_version>='3.12'",
-    "pandas>=1.5.0,<2.1.0; python_version<'3.12'",
-    "pandas>=2.0.0,<2.3.0; python_version>='3.12'",
+    "pandas>=1.5.0,<2.4.0; python_version<'3.12'",
+    "pandas>=2.0.0,<2.4.0; python_version>='3.12'",
     # Scientific stack
-    "scipy>=1.7.0,<1.11.0; python_version<'3.12'",
-    "scipy>=1.11.0,<1.13.0; python_version>='3.12'",
-    "scikit-learn>=1.0.0,<1.3.0; python_version<'3.12'",
+    "scipy>=1.7.0,<1.14.0; python_version<'3.12'",
+    "scipy>=1.11.0,<1.14.0; python_version>='3.12'",
+    "scikit-learn>=1.0.0,<1.4.0; python_version<'3.12'",
     "scikit-learn>=1.3.0,<1.5.0; python_version>='3.12'",
     "ipython",
     "patsy",


### PR DESCRIPTION
Summary:
## Summary:
Updated the REQUIRES variable in the setup.py file of the parent_balance package to selectively loosen the version constraints on key scientific Python packages while maintaining compatibility. The changes allow for newer minor versions that are backward compatible:

- **Pandas**: Updated to `>=1.5.0,<2.4.0` (Python < 3.12) and `>=2.0.0,<2.4.0` (Python >=3.12)
- **SciPy**: Updated to `>=1.7.0,<1.14.0` (Python < 3.12) and `>=1.11.0,<1.14.0` (Python >=3.12)
- **Scikit-learn**: Updated to `>=1.0.0,<1.4.0` (Python < 3.12)

These changes provide more flexibility for users while maintaining backward compatibility with the existing codebase.

Differential Revision: D79962390


