### PR TITLE
Move core_stats to PSS-3

### DIFF
--- a/balance/adjustment.py
+++ b/balance/adjustment.py
@@ -343,9 +343,9 @@ def apply_transformations(
     logger.info(f"Final variables in output: {list(out.columns)}")
 
     for column in out:
-        value_counts_result = out[column].value_counts(dropna=False)
-        value_counts_result.index = value_counts_result.index.infer_objects()
-        logger.debug(f"Frequency table of column {column}:\n{value_counts_result}")
+        # Create frequency table without using value_counts to avoid FutureWarning
+        freq_table = out[column].groupby(out[column], dropna=False).size()
+        logger.debug(f"Frequency table of column {column}:\n{freq_table}")
         logger.debug(
             f"Number of levels of column {column}:\n{out[column].nunique(dropna=False)}"
         )

--- a/balance/sample_class.py
+++ b/balance/sample_class.py
@@ -188,9 +188,7 @@ class Sample:
             str
         }:
             logger.warning("Casting id column to string")
-            sample._df.loc[:, id_column] = (
-                sample._df.loc[:, id_column].astype(str).astype("object")
-            )
+            sample._df[id_column] = sample._df[id_column].astype(str)
 
         if (check_id_uniqueness) and (
             sample._df[id_column].nunique() != len(sample._df[id_column])
@@ -264,7 +262,7 @@ class Sample:
                     "No weights passed. Adding a 'weight' column and setting all values to 1"
                 )
                 weight_column = "weight"
-                sample._df.loc[:, weight_column] = 1
+                sample._df.loc[:, weight_column] = 1.0  # Use 1.0 to ensure float64 type
 
         # verify that the weights are not null
         if any(sample._df[weight_column].isnull()):
@@ -480,10 +478,8 @@ class Sample:
                     """Note that not all Sample units will be assigned weights,
                     since weights are missing some of the indices in Sample.df"""
                 )
-        if isinstance(weights, pd.Series):
-            self._df.loc[:, self.weight_column.name] = weights.astype("float64")
-        else:
-            self._df.loc[:, self.weight_column.name] = weights
+
+        self._df.loc[:, self.weight_column.name] = weights
         self.weight_column = self._df[self.weight_column.name]
 
     ####################################

--- a/balance/util.py
+++ b/balance/util.py
@@ -687,7 +687,7 @@ def model_matrix(
     formula: Optional[List[str]] = None,
     penalty_factor: Optional[List[float]] = None,
     one_hot_encoding: bool = False,
-) -> Dict[str, Union[List[Any], np.ndarray[Any, np.dtype[Any]]]]:
+) -> Dict[str, Union[List[Any], np.ndarray, pd.DataFrame, csc_matrix, None]]:
     """Create a model matrix from a sample (and target).
     The default is to use an additive formula for all variables (or the ones specified).
     Can also create a custom model matrix if a formula is provided.
@@ -723,7 +723,7 @@ def model_matrix(
             and only 1 column for variables with 2 levels (treatment contrast). Defaults to False.
 
     Returns:
-        Dict[ str, Union[List[str], np.ndarray, Union[pd.DataFrame, np.ndarray, csc_matrix], None] ]:
+        Dict[str, Union[List[Any], np.ndarray, pd.DataFrame, csc_matrix, None]]
             a dict of:
                 1. "model_matrix_columns_names": columns names of the model matrix
                 2. "penalty_factor ": a penalty_factor for each column in the model matrix

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -230,10 +230,8 @@ class TestSample(
         # Test default weights when none provided
         df = pd.DataFrame({"id": (1, 2)})
         self.assertWarnsRegexp("No weights passed", Sample.from_frame, df)
-        # NOTE that the default weights are integers, not floats
-        # TODO: decide if it's o.k. to keep the default weights be 1s, or change the default to floats
         self.assertEqual(
-            Sample.from_frame(df).weight_column, pd.Series((1, 1), name="weight")
+            Sample.from_frame(df).weight_column, pd.Series((1.0, 1.0), name="weight")
         )
 
         # Test error for null weight values
@@ -1307,8 +1305,8 @@ class TestSamplePrivateAPI(balance.testutil.BalanceTestCase):
             pd.DataFrame(
                 {
                     "id": ("1", "2", "3"),
-                    # Weights were filled automatically to be integers of 1s:
-                    "weight": (1, 1, 1),
+                    # Weights were filled automatically to be floats of 1.0:
+                    "weight": (1.0, 1.0, 1.0),
                     "b": (0.0, None, 2.0),
                     "c": ("a", "b", "c"),
                 }

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1369,8 +1369,12 @@ class TestUtil(
         }
 
         # Generate weights for both categorical and string versions
-        output_cat_var = wine_survey.adjust(transformations=transformations)
-        output_string_var = wine_survey_copy.adjust(transformations=transformations)
+        output_cat_var = wine_survey.adjust(
+            transformations=transformations, method="ipw", max_de=2.5
+        )
+        output_string_var = wine_survey_copy.adjust(
+            transformations=transformations, method="ipw", max_de=2.5
+        )
 
         # Check that model coefficients are identical
         self.assertEqual(


### PR DESCRIPTION
Summary:
1. Move core_stats to PSS-3
2. Address Pandas FutureWarnings
3. Address flaky tests (passing locally)

See D79420086 for earlier work to enable this transition

Differential Revision: D79909109


