### PR TITLE
Add tutorials and documentation for post-stratification (#140)

### DIFF
--- a/tutorials/balance_quickstart_poststratify.ipynb
+++ b/tutorials/balance_quickstart_poststratify.ipynb
@@ -1,0 +1,483 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "84b1d98f",
+   "metadata": {},
+   "source": [
+    "# balance Quickstart (post-stratify): Matching known cell totals\n",
+    "\n",
+    "This notebook demonstrates how to apply post-stratification with the ``balance`` package. We start by matching a single marginal distribution and then show how the same function can match the joint distribution of two variables without falling back to raking.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "977acc22",
+   "metadata": {},
+   "source": [
+    "## 1. Load simulated data\n",
+    "\n",
+    "The helper :func:`balance.load_data` function returns a pair of simulated datasets: the target population and a biased sample. We'll use unit design weights in this tutorial so the weighted sums can be interpreted as counts.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f3284a72",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-11-12T07:59:38.238675Z",
+     "iopub.status.busy": "2025-11-12T07:59:38.238441Z",
+     "iopub.status.idle": "2025-11-12T07:59:40.439563Z",
+     "shell.execute_reply": "2025-11-12T07:59:40.438847Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO (2025-11-12 07:59:40,403) [__init__/<module> (line 69)]: Using balance version 0.12.1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Welcome to balance (Version 0.12.1)!\n",
+      "An open-source Python package for balancing biased data samples.\n",
+      "\n",
+      "📖 Documentation: https://import-balance.org/\n",
+      "🛠️ Get Help / Report Issues: https://github.com/facebookresearch/balance/issues/\n",
+      "📄 Citation:\n",
+      "    Sarig, T., Galili, T., & Eilat, R. (2023).\n",
+      "    balance - a Python package for balancing biased data samples.\n",
+      "    https://arxiv.org/abs/2307.06024\n",
+      "\n",
+      "Tip: You can access this information at any time with balance.help()\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>gender</th>\n",
+       "      <th>age_group</th>\n",
+       "      <th>income</th>\n",
+       "      <th>happiness</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>100000</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>45+</td>\n",
+       "      <td>10.183951</td>\n",
+       "      <td>61.706333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>100001</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>45+</td>\n",
+       "      <td>6.036858</td>\n",
+       "      <td>79.123670</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>100002</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>35-44</td>\n",
+       "      <td>5.226629</td>\n",
+       "      <td>44.206949</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>100003</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>45+</td>\n",
+       "      <td>5.752147</td>\n",
+       "      <td>83.985716</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>100004</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>25-34</td>\n",
+       "      <td>4.837484</td>\n",
+       "      <td>49.339713</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       id gender age_group     income  happiness\n",
+       "0  100000   Male       45+  10.183951  61.706333\n",
+       "1  100001   Male       45+   6.036858  79.123670\n",
+       "2  100002   Male     35-44   5.226629  44.206949\n",
+       "3  100003    NaN       45+   5.752147  83.985716\n",
+       "4  100004    NaN     25-34   4.837484  49.339713"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from balance import load_data\n",
+    "from balance.weighting_methods.poststratify import poststratify\n",
+    "import pandas as pd\n",
+    "\n",
+    "target_df, sample_df = load_data()\n",
+    "target_df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bc01d97",
+   "metadata": {},
+   "source": [
+    "## 2. Post-stratify on a single variable\n",
+    "\n",
+    "We first adjust the sample so that its gender distribution matches the target population. Rows with missing gender are dropped to satisfy the default ``strict_matching=True`` requirement that every sample cell be present in the target.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "540b8406",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-11-12T07:59:40.442250Z",
+     "iopub.status.busy": "2025-11-12T07:59:40.441930Z",
+     "iopub.status.idle": "2025-11-12T07:59:40.476797Z",
+     "shell.execute_reply": "2025-11-12T07:59:40.475212Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO (2025-11-12 07:59:40,451) [adjustment/apply_transformations (line 305)]: Adding the variables: []\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO (2025-11-12 07:59:40,451) [adjustment/apply_transformations (line 306)]: Transforming the variables: ['gender']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO (2025-11-12 07:59:40,456) [adjustment/apply_transformations (line 343)]: Final variables in output: ['gender']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>weighted_sample</th>\n",
+       "      <th>target_population</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gender</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Female</th>\n",
+       "      <td>4551.0</td>\n",
+       "      <td>4551</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Male</th>\n",
+       "      <td>4551.0</td>\n",
+       "      <td>4551</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        weighted_sample  target_population\n",
+       "gender                                    \n",
+       "Female           4551.0               4551\n",
+       "Male             4551.0               4551"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sample_gender = sample_df.dropna(subset=[\"gender\"])\n",
+    "target_gender = target_df.dropna(subset=[\"gender\"])\n",
+    "\n",
+    "gender_result = poststratify(\n",
+    "    sample_df=sample_gender[[\"gender\"]],\n",
+    "    sample_weights=pd.Series(1, index=sample_gender.index),\n",
+    "    target_df=target_gender[[\"gender\"]],\n",
+    "    target_weights=pd.Series(1, index=target_gender.index),\n",
+    ")\n",
+    "\n",
+    "gender_weights = sample_gender.assign(weight=gender_result[\"weight\"])\n",
+    "gender_summary = pd.concat(\n",
+    "    [\n",
+    "        gender_weights.groupby(\"gender\")[\"weight\"].sum().rename(\"weighted_sample\"),\n",
+    "        target_gender.groupby(\"gender\").size().rename(\"target_population\"),\n",
+    "    ],\n",
+    "    axis=1,\n",
+    ")\n",
+    "gender_summary\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0974546",
+   "metadata": {},
+   "source": [
+    "The weighted sample counts now reproduce the target population counts. Dividing by the column totals would show that the sample proportions also match the target proportions.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d498223",
+   "metadata": {},
+   "source": [
+    "## 3. Post-stratify on the joint distribution of two variables\n",
+    "\n",
+    "Post-stratification can use multiple variables simultaneously. In that case the function computes a weight per *cell* defined by the unique combination of those variables. This is different from raking, which iteratively matches the marginals of each variable.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e7bdeacf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-11-12T07:59:40.479052Z",
+     "iopub.status.busy": "2025-11-12T07:59:40.478826Z",
+     "iopub.status.idle": "2025-11-12T07:59:40.525547Z",
+     "shell.execute_reply": "2025-11-12T07:59:40.524526Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO (2025-11-12 07:59:40,488) [adjustment/apply_transformations (line 305)]: Adding the variables: []\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO (2025-11-12 07:59:40,490) [adjustment/apply_transformations (line 306)]: Transforming the variables: ['gender', 'age_group']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO (2025-11-12 07:59:40,500) [adjustment/apply_transformations (line 343)]: Final variables in output: ['gender', 'age_group']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>weighted_sample</th>\n",
+       "      <th>target_population</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gender</th>\n",
+       "      <th>age_group</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"4\" valign=\"top\">Female</th>\n",
+       "      <th>18-24</th>\n",
+       "      <td>876.0</td>\n",
+       "      <td>876</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25-34</th>\n",
+       "      <td>1360.0</td>\n",
+       "      <td>1360</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>35-44</th>\n",
+       "      <td>1370.0</td>\n",
+       "      <td>1370</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>45+</th>\n",
+       "      <td>945.0</td>\n",
+       "      <td>945</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"4\" valign=\"top\">Male</th>\n",
+       "      <th>18-24</th>\n",
+       "      <td>905.0</td>\n",
+       "      <td>905</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25-34</th>\n",
+       "      <td>1355.0</td>\n",
+       "      <td>1355</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>35-44</th>\n",
+       "      <td>1347.0</td>\n",
+       "      <td>1347</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>45+</th>\n",
+       "      <td>944.0</td>\n",
+       "      <td>944</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  weighted_sample  target_population\n",
+       "gender age_group                                    \n",
+       "Female 18-24                876.0                876\n",
+       "       25-34               1360.0               1360\n",
+       "       35-44               1370.0               1370\n",
+       "       45+                  945.0                945\n",
+       "Male   18-24                905.0                905\n",
+       "       25-34               1355.0               1355\n",
+       "       35-44               1347.0               1347\n",
+       "       45+                  944.0                944"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "covariates = [\"gender\", \"age_group\"]\n",
+    "sample_cells = sample_df.dropna(subset=covariates)\n",
+    "target_cells = target_df.dropna(subset=covariates)\n",
+    "\n",
+    "joint_result = poststratify(\n",
+    "    sample_df=sample_cells[covariates],\n",
+    "    sample_weights=pd.Series(1, index=sample_cells.index),\n",
+    "    target_df=target_cells[covariates],\n",
+    "    target_weights=pd.Series(1, index=target_cells.index),\n",
+    ")\n",
+    "\n",
+    "joint_weights = sample_cells.assign(weight=joint_result[\"weight\"])\n",
+    "joint_summary = pd.concat(\n",
+    "    [\n",
+    "        joint_weights.groupby(covariates)[\"weight\"].sum().rename(\"weighted_sample\"),\n",
+    "        target_cells.groupby(covariates).size().rename(\"target_population\"),\n",
+    "    ],\n",
+    "    axis=1,\n",
+    ")\n",
+    "joint_summary\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28424d53",
+   "metadata": {},
+   "source": [
+    "Each row corresponds to a unique combination of gender and age group. The equality between the two columns confirms that ``poststratify`` matched the full joint distribution without reverting to raking.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/website/docs/docs/statistical_methods/poststratify.md
+++ b/website/docs/docs/statistical_methods/poststratify.md
@@ -53,6 +53,69 @@ Similarly, we can compute the weight for people from each cell in the table:
 
 
 
+## Examples
+
+Below are two short code examples that show how to run ``balance.weighting_methods.poststratify`` on the simulated data shipped
+with the package. They rely on ``balance.load_data`` so you can copy-paste the
+cells into a notebook, or refer to the new
+
+> **Tip:** For clarity we drop rows where any of the adjustment variables are
+> missing, because the default ``strict_matching=True`` requires that every
+> combination observed in the sample also appears in the target data.
+
+### Matching a single variable
+
+````python
+import pandas as pd
+from balance import load_data
+from balance.weighting_methods.poststratify import poststratify
+
+target_df, sample_df = load_data()
+
+sample_gender = sample_df.dropna(subset=["gender"])
+target_gender = target_df.dropna(subset=["gender"])
+
+result = poststratify(
+    sample_df=sample_gender[["gender"]],
+    sample_weights=pd.Series(1, index=sample_gender.index),
+    target_df=target_gender[["gender"]],
+    target_weights=pd.Series(1, index=target_gender.index),
+)
+
+weighted = sample_gender.assign(weight=result["weight"])
+display(weighted.groupby("gender")["weight"].sum())
+````
+
+The grouped sum reproduces the target population counts (because we pass unit
+design weights): each gender sums to ``4551`` in this dataset. You can divide
+by the total weight to recover the target proportions.
+
+### Matching the joint distribution of two variables
+
+````python
+covariates = ["gender", "age_group"]
+sample_cells = sample_df.dropna(subset=covariates)
+target_cells = target_df.dropna(subset=covariates)
+
+result = poststratify(
+    sample_df=sample_cells[covariates],
+    sample_weights=pd.Series(1, index=sample_cells.index),
+    target_df=target_cells[covariates],
+    target_weights=pd.Series(1, index=target_cells.index),
+)
+
+weighted = sample_cells.assign(weight=result["weight"])
+display(weighted.groupby(covariates)["weight"].sum().unstack())
+````
+
+This second example uses the same two categorical variables but keeps their
+joint cells intact. The pivoted table matches the census counts for each cell
+(e.g. ``Female`` aged ``25-34`` totals ``1360`` and ``Male`` aged ``18-24``
+totals ``905``). Unlike raking, which iteratively matches the marginal
+distributions of each variable, ``poststratify`` calculates weights per cell so
+that the final weighted sample matches the full two-dimensional distribution.
+
+
 ## References
 - More about post-stratification: [Introduction to post-stratification](https://docs.wfp.org/api/documents/WFP-0000121326/download/)
 - Kolenikov, Stas. 2016. “Post-Stratification or Non-Response Adjustment?” Survey Practice 9 (3). https://doi.org/10.29115/SP-2016-0014.


### PR DESCRIPTION
Summary:
Changes:
- Expanded the `poststratify` docstring to clarify its cell-based weighting logic, strict-matching behavior, and added runnable one- and two-variable examples.
- Added post-stratification examples to the statistical methods page to demonstrate matching single and joint distributions while noting that the method does not revert to raking.
- Also published a dedicated post-stratify tutorial notebook and linked it into the tutorials navigation for easy discovery.

Why?
- Closes https://github.com/facebookresearch/balance/issues/111


Differential Revision: D86856112

Pulled By: talgalili


