### PR TITLE
Include poststratify tutorial in docs build

### DIFF
--- a/scripts/make_docs.sh
+++ b/scripts/make_docs.sh
@@ -77,9 +77,12 @@ if [[ $ONLY_DOCUSAURUS == false ]]; then
   echo "-----------------------------------"
   echo "Building tutorial HTML"
   echo "-----------------------------------"
+  mkdir -p website/static/html/tutorials
   jupyter nbconvert tutorials/balance_quickstart.ipynb --execute --to html \
     --output-dir website/static/html/tutorials
   jupyter nbconvert tutorials/balance_quickstart_cbps.ipynb --execute --to html \
+    --output-dir website/static/html/tutorials
+  jupyter nbconvert tutorials/balance_quickstart_poststratify.ipynb --execute --to html \
     --output-dir website/static/html/tutorials
   jupyter nbconvert tutorials/balance_quickstart_rake.ipynb --execute --to html \
     --output-dir website/static/html/tutorials

--- a/website/docs/tutorials/balance_transformations_and_formulas.mdx
+++ b/website/docs/tutorials/balance_transformations_and_formulas.mdx
@@ -1,8 +1,9 @@
 ---
-title: balance_transformations_and_formulas
-sidebar_position: 5
+title: Balance Transformations and Formulas
+sidebar_position: 6
 hide_table_of_contents: true
 hide_title: true
+sidebar_label: Transformations and Formulas
 ---
 
 import HTMLLoader from '@site/src/components/HTMLLoader';

--- a/website/docs/tutorials/comparing_cbps_in_r_vs_python_using_sim_data.mdx
+++ b/website/docs/tutorials/comparing_cbps_in_r_vs_python_using_sim_data.mdx
@@ -1,8 +1,9 @@
 ---
-title: Comparing_cbps_in_r_vs_python_using_sim_data
-sidebar_position: 6
+title: Comparing CBPS in R vs Python Using Simulated Data
+sidebar_position: 7
 hide_table_of_contents: true
 hide_title: true
+sidebar_label: Comparing CBPS in R vs Python
 ---
 
 import HTMLLoader from '@site/src/components/HTMLLoader';

--- a/website/docs/tutorials/quickstart_cbps.mdx
+++ b/website/docs/tutorials/quickstart_cbps.mdx
@@ -1,8 +1,9 @@
 ---
-title: Quickstart_cbps
+title: Quickstart CBPS
 sidebar_position: 3
 hide_table_of_contents: true
 hide_title: true
+sidebar_label: Quickstart (CBPS)
 ---
 
 import HTMLLoader from '@site/src/components/HTMLLoader';

--- a/website/docs/tutorials/quickstart_poststratify.mdx
+++ b/website/docs/tutorials/quickstart_poststratify.mdx
@@ -1,8 +1,9 @@
 ---
-title: Quickstart_poststratify
+title: Quickstart Poststratify
 sidebar_position: 5
 hide_table_of_contents: true
 hide_title: true
+sidebar_label: Quickstart (Poststratify)
 ---
 
 import HTMLLoader from '@site/src/components/HTMLLoader';

--- a/website/docs/tutorials/quickstart_rake.mdx
+++ b/website/docs/tutorials/quickstart_rake.mdx
@@ -1,8 +1,9 @@
 ---
-title: Quickstart_rake
+title: Quickstart Rake
 sidebar_position: 4
 hide_table_of_contents: true
 hide_title: true
+sidebar_label: Quickstart (Rake)
 ---
 
 import HTMLLoader from '@site/src/components/HTMLLoader';


### PR DESCRIPTION
Made sure the docs build script creates the tutorials HTML output directory and generates HTML for the poststratify quickstart notebook so the tutorial page is published correctly. Also cleaned up title formatting.