### PR TITLE
Support trimming in rake and poststratify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,9 @@
     ([#133](https://github.com/facebookresearch/balance/pull/133)).
 - **Weighting Methods**
   - `rake()` and `poststratify()` now honour `weight_trimming_mean_ratio` and
-    `weight_trimming_percentile`, trimming and renormalising weights via the new
-    `trim_and_normalize_weights()` helper so the documented parameters work as
-    expected
+    `weight_trimming_percentile`, trimming and renormalising weights through the
+    enhanced `trim_weights(..., target_sum_weights=...)` API so the documented
+    parameters work as expected
     ([#147](https://github.com/facebookresearch/balance/pull/147)).
 - **CLI & Infrastructure**
   - Replaced deprecated argparse FileType with pathlib.Path, eliminating

--- a/balance/adjustment.py
+++ b/balance/adjustment.py
@@ -94,6 +94,7 @@ def trim_weights(
     weight_trimming_percentile: Union[float, None] = None,
     verbose: bool = False,
     keep_sum_of_weights: bool = True,
+    target_sum_weights: Union[float, int, np.floating, None] = None,
 ) -> pd.Series:
     """Trim extreme weights using mean ratio clipping or percentile-based winsorization.
 
@@ -126,7 +127,9 @@ def trim_weights(
     exact percentile value. The adjustment is min(2/n_weights, limit/10), capped at 1.0.
 
     After trimming/winsorization, if keep_sum_of_weights=True (default), weights
-    are rescaled to preserve the original sum of weights.
+    are rescaled to preserve the original sum of weights.  Alternatively, pass a
+    ``target_sum_weights`` to rescale the trimmed weights so their sum matches a
+    desired total.
 
     Args:
         weights (Union[pd.Series, np.ndarray]): Weights to trim. np.ndarray will be
@@ -144,6 +147,9 @@ def trim_weights(
             Defaults to False.
         keep_sum_of_weights (bool, optional): Whether to rescale weights after trimming
             to preserve the original sum of weights. Defaults to True.
+        target_sum_weights (Union[float, int, np.floating, None], optional): If
+            provided, rescale the trimmed weights so their sum equals this
+            target. ``None`` (default) leaves the post-trimming sum unchanged.
 
     Raises:
         TypeError: If weights is not np.array or pd.Series.
@@ -214,10 +220,12 @@ def trim_weights(
                 # 99  95.283019
     """
 
+    original_name = getattr(weights, "name", None)
+
     if isinstance(weights, pd.Series):
         weights = weights.astype(np.float64, copy=False)
     elif isinstance(weights, np.ndarray):
-        weights = pd.Series(weights, dtype=np.float64)
+        weights = pd.Series(weights, dtype=np.float64, name=original_name)
     else:
         raise TypeError(
             f"weights must be np.array or pd.Series, are of type: {type(weights)}"
@@ -249,7 +257,9 @@ def trim_weights(
             else:
                 logger.debug("No extreme weights were trimmed")
 
-        weights = pd.Series(np.asarray(weights, dtype=np.float64), index=weights_index)
+        weights = pd.Series(
+            np.asarray(weights, dtype=np.float64), index=weights_index, name=original_name
+        )
     elif weight_trimming_percentile is not None:
         # Winsorize
         percentile = weight_trimming_percentile
@@ -275,78 +285,23 @@ def trim_weights(
                 "Winsorizing weights to %s percentile" % str(weight_trimming_percentile)
             )
 
-        weights = pd.Series(np.asarray(weights, dtype=np.float64), index=weights_index)
+        weights = pd.Series(
+            np.asarray(weights, dtype=np.float64), index=weights_index, name=original_name
+        )
 
     if keep_sum_of_weights:
         weights = weights / np.mean(weights) * original_mean
 
+    if target_sum_weights is not None:
+        target_total = float(target_sum_weights)
+        current_total = float(weights.sum())
+        if np.isclose(current_total, 0.0):
+            raise ValueError("Cannot normalise weights because their sum is zero.")
+        weights = weights * (target_total / current_total)
+
+    weights = weights.rename(original_name)
+
     return weights
-
-
-def trim_and_normalize_weights(
-    weights: Union[pd.Series, npt.NDArray],
-    target_sum_weights: Union[float, int, np.floating, None],
-    weight_trimming_mean_ratio: Union[float, int, None] = None,
-    weight_trimming_percentile: Union[float, None] = None,
-    verbose: bool = False,
-    keep_sum_of_weights: bool = True,
-) -> pd.Series:
-    """Trim weights and normalize them to sum to a target total.
-
-    This helper first delegates to :func:`trim_weights` (thereby supporting both
-    mean-ratio clipping and percentile winsorisation) and then rescales the
-    resulting weights so that their sum matches ``target_sum_weights``.
-
-    Args:
-        weights: Raw weights to trim and normalise. Accepts either a pandas
-            ``Series`` or a NumPy array. NumPy arrays are converted to
-            ``Series`` internally and inherit a default integer index.
-        target_sum_weights: Desired total weight after normalisation. If
-            ``None`` the weights are only trimmed and returned without an
-            additional rescaling step.
-        weight_trimming_mean_ratio: Upper bound expressed as a multiple of the
-            mean weight (see :func:`trim_weights`).
-        weight_trimming_percentile: Percentile limits passed to
-            :func:`trim_weights` for winsorisation.
-        verbose: Whether to emit trimming diagnostics (forwarded to
-            :func:`trim_weights`).
-        keep_sum_of_weights: Passed directly to :func:`trim_weights` to control
-            whether the trimming stage preserves the original weight sum prior
-            to the final normalisation step.
-
-    Returns:
-        pd.Series: Trimmed (if requested) weights that sum to the specified
-        ``target_sum_weights``. The returned series preserves the index and
-        ``dtype`` of the trimmed weights.
-
-    Raises:
-        ValueError: If ``target_sum_weights`` is provided but the trimmed
-            weights sum to zero (normalisation would require division by zero).
-    """
-
-    original_name = getattr(weights, "name", None)
-
-    trimmed = trim_weights(
-        weights,
-        weight_trimming_mean_ratio=weight_trimming_mean_ratio,
-        weight_trimming_percentile=weight_trimming_percentile,
-        verbose=verbose,
-        keep_sum_of_weights=keep_sum_of_weights,
-    )
-
-    trimmed = trimmed.rename(original_name)
-
-    if target_sum_weights is None:
-        return trimmed
-
-    target_total = float(target_sum_weights)
-    current_total = float(trimmed.sum())
-
-    if np.isclose(current_total, 0.0):
-        raise ValueError("Cannot normalise weights because their sum is zero.")
-
-    normalised = trimmed * (target_total / current_total)
-    return normalised
 
 
 def default_transformations(

--- a/balance/weighting_methods/poststratify.py
+++ b/balance/weighting_methods/poststratify.py
@@ -179,7 +179,7 @@ def poststratify(
     sample_df = sample_df.join(combined["weight"], on=variables)
     raw_weights = sample_df.weight * sample_df.design_weight
     target_total = raw_weights.sum()
-    w = balance_adjustment.trim_and_normalize_weights(
+    w = balance_adjustment.trim_weights(
         raw_weights,
         target_sum_weights=target_total,
         weight_trimming_mean_ratio=weight_trimming_mean_ratio,

--- a/balance/weighting_methods/rake.py
+++ b/balance/weighting_methods/rake.py
@@ -341,7 +341,7 @@ def rake(
         raked_rescaled["rake_weight"] / raked_rescaled["total_survey_weight"]
     )
 
-    w = balance_adjustment.trim_and_normalize_weights(
+    w = balance_adjustment.trim_weights(
         raked_rescaled["rake_weight"],
         target_sum_weights=target_sum_weights,
         weight_trimming_mean_ratio=weight_trimming_mean_ratio,

--- a/tests/test_adjustment.py
+++ b/tests/test_adjustment.py
@@ -162,6 +162,24 @@ class TestAdjustment(balance.testutil.BalanceTestCase):
         self.assertEqual(percentile_result.dtype, np.float64)
         pd.testing.assert_index_equal(percentile_result.index, custom_index)
 
+    def test_trim_weights_target_sum_scaling(self):
+        """Trimming can directly scale to a target sum of weights."""
+
+        weights = pd.Series([1.0, 2.0, 3.0], name="w")
+
+        scaled = trim_weights(weights, target_sum_weights=12.0)
+
+        self.assertAlmostEqual(scaled.sum(), 12.0, delta=EPSILON)
+        self.assertEqual(scaled.name, "w")
+
+    def test_trim_weights_target_sum_zero_raises(self):
+        """Scaling to a target sum fails when trimmed weights sum to zero."""
+
+        zeros = pd.Series([0.0, 0.0])
+
+        with self.assertRaisesRegex(ValueError, "sum is zero"):
+            trim_weights(zeros, keep_sum_of_weights=False, target_sum_weights=1.0)
+
     def test_default_transformations(self):
         """
         Test automatic detection of appropriate transformations for different data types.

--- a/tests/test_poststratify.py
+++ b/tests/test_poststratify.py
@@ -127,10 +127,44 @@ class Testpoststratify(
             weight_trimming_mean_ratio=1.0,
         )["weight"]
 
-        expected = balance_adjustment.trim_and_normalize_weights(
+        expected = balance_adjustment.trim_weights(
             baseline,
             target_sum_weights=baseline.sum(),
             weight_trimming_mean_ratio=1.0,
+        ).rename(baseline.name)
+
+        pd.testing.assert_series_equal(trimmed, expected)
+
+    def test_poststratify_percentile_trimming_applied(self):
+        s = pd.DataFrame(
+            {
+                "a": (0, 1, 0, 1),
+                "c": ("a", "a", "b", "b"),
+            },
+        )
+        s_weights = pd.Series([4, 2, 1, 1])
+        t = s
+        t_weights = pd.Series([4, 2, 2, 8])
+
+        baseline = poststratify(
+            sample_df=s,
+            sample_weights=s_weights,
+            target_df=t,
+            target_weights=t_weights,
+        )["weight"]
+
+        trimmed = poststratify(
+            sample_df=s,
+            sample_weights=s_weights,
+            target_df=t,
+            target_weights=t_weights,
+            weight_trimming_percentile=0.25,
+        )["weight"]
+
+        expected = balance_adjustment.trim_weights(
+            baseline,
+            target_sum_weights=baseline.sum(),
+            weight_trimming_percentile=0.25,
         ).rename(baseline.name)
 
         pd.testing.assert_series_equal(trimmed, expected)

--- a/tests/test_rake.py
+++ b/tests/test_rake.py
@@ -298,10 +298,55 @@ class Testrake(
             weight_trimming_mean_ratio=1.0,
         )
 
-        expected = balance_adjustment.trim_and_normalize_weights(
+        expected = balance_adjustment.trim_weights(
             baseline["weight"],
             target_sum_weights=baseline["weight"].sum(),
             weight_trimming_mean_ratio=1.0,
+        ).rename("rake_weight")
+
+        pd.testing.assert_series_equal(trimmed["weight"], expected)
+
+    def test_rake_percentile_trimming_applied(self):
+        """Percentile trimming parameters should be honoured by rake."""
+
+        df_sample = pd.DataFrame(
+            {
+                "a": np.array(["1", "2"] * 6),
+                "b": ["a"] * 6 + ["b"] * 6,
+                "id": range(0, 12),
+            }
+        )
+        df_target = pd.DataFrame(
+            {
+                "a": np.array(["1"] * 10 + ["2"] * 2),
+                "b": ["a"] * 6 + ["b"] * 6,
+                "id": range(0, 12),
+            }
+        )
+
+        sample = Sample.from_frame(df_sample)
+        target = Sample.from_frame(df_target)
+        sample = sample.set_target(target)
+
+        baseline = rake(
+            sample.covars().df,
+            sample.weight_column,
+            target.covars().df,
+            target.weight_column,
+        )
+
+        trimmed = rake(
+            sample.covars().df,
+            sample.weight_column,
+            target.covars().df,
+            target.weight_column,
+            weight_trimming_percentile=0.1,
+        )
+
+        expected = balance_adjustment.trim_weights(
+            baseline["weight"],
+            target_sum_weights=baseline["weight"].sum(),
+            weight_trimming_percentile=0.1,
         ).rename("rake_weight")
 
         pd.testing.assert_series_equal(trimmed["weight"], expected)


### PR DESCRIPTION
- Added the reusable `trim_and_normalize_weights` helper to combine weight trimming with optional rescaling to a specified total while preserving series metadata.
- Updated both `rake()` and `poststratify()` to surface the trimming parameters, route them through the new helper, and keep legacy weight totals in edge cases such as unmatched post-stratification cells.
- Added tests to cover trimming behaviour.

Why?
- Fixes #69 