### PR TITLE
Fix Docusaurus JSX syntax error in balance README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Deploy Website](https://github.com/facebookresearch/balance/actions/workflows/deploy-website.yml/badge.svg)](https://github.com/facebookresearch/balance/actions/workflows/deploy-website.yml?query=branch%3Amain)
 [![Release](https://github.com/facebookresearch/balance/actions/workflows/release.yml/badge.svg)](https://github.com/facebookresearch/balance/actions/workflows/release.yml?query=branch%3Amain)
 [![DOI](https://img.shields.io/badge/DOI-10.48550/arXiv.2307.06024-blue.svg)](https://doi.org/10.48550/arXiv.2307.06024)
-[<img src="https://pepy.tech/badge/balance">](https://pepy.tech/project/balance)
+[![Downloads](https://pepy.tech/badge/balance)](https://pepy.tech/project/balance)
 
 </div>
 


### PR DESCRIPTION
Summary:
The Docusaurus build was failing with a JSX syntax error due to an improperly closed HTML `<img>` tag in the Downloads badge on line 15 of the README.md file.

When Docusaurus processes markdown files, it converts them to JSX, which requires all HTML tags to be either properly closed or self-closing. The Downloads badge was using raw HTML `[<img src="...">](...)` without a proper closing tag, causing the build to fail with:

```
SyntaxError: Expected corresponding JSX closing tag for <img>
```

This change converts the Downloads badge to use proper markdown syntax `[![...](...)](...)`, making it consistent with the other badges in the file and resolving the build error.

Differential Revision: D87176281


