### PR TITLE
Fix Python 3.9 compatibility by adding annotations future import

### DIFF
--- a/balance/weighting_methods/adjust_null.py
+++ b/balance/weighting_methods/adjust_null.py
@@ -5,7 +5,13 @@
 
 # pyre-strict
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    annotations,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import logging
 


### PR DESCRIPTION
Summary:
The balance library was failing to import in Python 3.9 due to using the `|` union operator in type hints, which is only supported in Python 3.10+. The error manifested as:

```
TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'type'
```

This occurred in the type annotation `dict[str, dict[str, str] | pd.Series]` in the `adjust_null` function.

The fix adds `annotations` to the `from __future__ import` statement, which enables PEP 563 postponed evaluation of annotations. This causes all type hints to be stored as strings and evaluated lazily, making the Python 3.10+ union syntax compatible with Python 3.9.

Differential Revision: D87538672


