### PR TITLE
Modernize type hints to use PEP 604 union syntax in balance package ( | )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.12.x (2025-11-16)
+# 0.12.x (2025-11-21)
 
 > TODO: update 0.12.x to 0.13.0 before release.
 
@@ -65,6 +65,25 @@
     (`weighting_methods/cbps.py`, `weighting_methods/ipw.py`,
     `weighting_methods/poststratify.py`, `weighting_methods/rake.py`), and
     datasets module (`datasets/__init__.py`)
+  - **Modernized type hints to PEP 604 syntax**: Updated all type annotations
+    across 11 files to use the newer PEP 604 union syntax (`X | Y` instead of
+    `Union[X, Y]` and `X | None` instead of `Optional[X]`), improving code
+    readability and aligning with Python 3.10+ typing conventions. Updated
+    `from __future__ import` statements to use `annotations` instead of the
+    older `absolute_import, division, print_function, unicode_literals`.
+    Removed unnecessary `Union` and `Optional` imports from `typing`. Files
+    updated: `__init__.py`, `adjustment.py`, `balancedf_class.py`, `cli.py`,
+    `datasets/__init__.py`, `sample_class.py`,
+    `stats_and_plots/weighted_comparisons_stats.py`,
+    `stats_and_plots/weighted_stats.py`, `stats_and_plots/weights_stats.py`,
+    `util.py`, `weighting_methods/ipw.py`.
+  - **Important compatibility note**:
+    Type alias definitions in `typing.py` retain `Union` syntax for Python 3.9
+    compatibility, as the `|` operator for type aliases only works at runtime
+    in Python 3.10+. Added comprehensive inline documentation explaining this
+    limitation and the distinction between type annotations (which support `|`
+    with `from __future__ import annotations`) and type alias assignments
+    (which require `Union` for runtime evaluation in Python 3.9).
   - Fixed missing `Any` import in `weighted_comparisons_plots.py` to resolve
     pyre-fixme[10] error
   - Added comprehensive type annotations for previously untyped parameters and
@@ -79,6 +98,13 @@
   - Improved `quantize` function: preserves column ordering and replaces
     assertions with proper TypeError exceptions
     ([#133](https://github.com/facebookresearch/balance/pull/133)).
+- **Statistical Functions**
+  - **Fixed division by zero in `asmd_improvement()`**: Added safety check to
+    prevent RuntimeWarning when `asmd_mean_before` is zero or very close to zero
+    (< 1e-10). The function now returns `0.0` (representing 0% improvement) when
+    the sample was already perfectly matched to the target before adjustment,
+    which is the semantically correct result. This eliminates the "invalid value
+    encountered in scalar divide" warning that appeared in test runs.
 - **Weighting Methods**
   - `rake()` and `poststratify()` now honour `weight_trimming_mean_ratio` and
     `weight_trimming_percentile`, trimming and renormalising weights through the

--- a/balance/__init__.py
+++ b/balance/__init__.py
@@ -5,8 +5,9 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 import logging
-from typing import Optional
 
 from balance.balancedf_class import (  # noqa
     BalanceCovarsDF,  # noqa
@@ -41,7 +42,7 @@ def help() -> None:
 
 
 def setup_logging(
-    logger_name: Optional[str] = __package__,
+    logger_name: str | None = __package__,
     level: str = "INFO",
     removeHandler: bool = True,
 ) -> logging.Logger:

--- a/balance/adjustment.py
+++ b/balance/adjustment.py
@@ -5,11 +5,11 @@
 
 # pyre-strict
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import annotations
 
 import logging
 
-from typing import Any, Callable, Dict, List, Literal, Tuple, Union
+from typing import Any, Callable, Dict, Literal, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -38,9 +38,7 @@ BALANCE_WEIGHTING_METHODS: Dict[str, Callable[..., Any]] = {
 }
 
 
-def _validate_limit(
-    limit: Union[float, int, None], n_weights: int
-) -> Union[float, None]:
+def _validate_limit(limit: float | int | None, n_weights: int) -> float | None:
     """Validate and adjust a percentile limit for use with scipy.stats.mstats.winsorize.
 
     This function prepares percentile limits for winsorization by:
@@ -88,13 +86,13 @@ def _validate_limit(
 
 
 def trim_weights(
-    weights: Union[pd.Series, npt.NDArray],
+    weights: pd.Series | npt.NDArray,
     # TODO: add support to more types of input weights? (e.g. list? other?)
-    weight_trimming_mean_ratio: Union[float, int, None] = None,
-    weight_trimming_percentile: Union[float, None] = None,
+    weight_trimming_mean_ratio: float | int | None = None,
+    weight_trimming_percentile: float | None = None,
     verbose: bool = False,
     keep_sum_of_weights: bool = True,
-    target_sum_weights: Union[float, int, np.floating, None] = None,
+    target_sum_weights: float | int | np.floating | None = None,
 ) -> pd.Series:
     """Trim extreme weights using mean ratio clipping or percentile-based winsorization.
 
@@ -132,22 +130,22 @@ def trim_weights(
     desired total.
 
     Args:
-        weights (Union[pd.Series, np.ndarray]): Weights to trim. np.ndarray will be
+        weights (pd.Series | np.ndarray): Weights to trim. np.ndarray will be
             converted to pd.Series internally.
-        weight_trimming_mean_ratio (Union[float, int], optional): Ratio for upper bound
+        weight_trimming_mean_ratio (float | int | None, optional): Ratio for upper bound
             clipping as mean(weights) * ratio. Mutually exclusive with
             weight_trimming_percentile. Defaults to None.
-        weight_trimming_percentile (Union[float, Tuple[float, float]], optional):
+        weight_trimming_percentile (float | tuple[float, float] | None, optional):
             Percentile limits for winsorization. Value(s) must be between 0 and 1.
             - Single float: Symmetric winsorization on both tails
-            - Tuple[float, float]: (lower_percentile, upper_percentile) for
+            - tuple[float, float]: (lower_percentile, upper_percentile) for
               independent control of each tail
             Mutually exclusive with weight_trimming_mean_ratio. Defaults to None.
         verbose (bool, optional): Whether to log details about the trimming process.
             Defaults to False.
         keep_sum_of_weights (bool, optional): Whether to rescale weights after trimming
             to preserve the original sum of weights. Defaults to True.
-        target_sum_weights (Union[float, int, np.floating, None], optional): If
+        target_sum_weights (float | int | np.floating | None, optional): If
             provided, rescale the trimmed weights so their sum equals this
             target. ``None`` (default) leaves the post-trimming sum unchanged.
 
@@ -309,14 +307,14 @@ def trim_weights(
 
 
 def default_transformations(
-    dfs: Union[Tuple[pd.DataFrame, ...], List[pd.DataFrame]],
+    dfs: tuple[pd.DataFrame, ...] | list[pd.DataFrame],
 ) -> Dict[str, Callable[..., Any]]:
     """
     Apply default transformations to dfs, i.e.
     quantize to numeric columns and fct_lump to non-numeric and boolean
 
     Args:
-        dfs (Union[Tuple[pd.DataFrame, ...], List[pd.DataFrame]]): A list or tuple of dataframes
+        dfs (tuple[pd.DataFrame, ...] | list[pd.DataFrame]): A list or tuple of dataframes
 
     Returns:
         Dict[str, Callable]: Dict of transformations
@@ -339,7 +337,7 @@ def default_transformations(
 
 def apply_transformations(
     dfs: Tuple[pd.DataFrame, ...],
-    transformations: Union[Dict[str, Callable[..., Any]], str, None],
+    transformations: Dict[str, Callable[..., Any]] | str | None,
     drop: bool = True,
 ) -> Tuple[pd.DataFrame, ...]:
     """Apply the transformations specified in transformations to all of the dfs
@@ -357,7 +355,7 @@ def apply_transformations(
 
     Args:
         dfs (Tuple[pd.DataFrame, ...]): The DataFrames on which to operate
-        transformations (Union[Dict[str, Callable], str, None]): Mapping from column name to function to apply.
+        transformations (Dict[str, Callable[..., Any]] | str | None): Mapping from column name to function to apply.
             Transformations of existing columns should be specified as functions
             of those columns (e.g. `lambda x: x*2`), whereas additions of new
             columns should be specified as functions of the DataFrame

--- a/balance/balancedf_class.py
+++ b/balance/balancedf_class.py
@@ -5,8 +5,10 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 import logging
-from typing import Any, Dict, Literal, Optional, Tuple, Union
+from typing import Any, Dict, Literal, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -106,14 +108,14 @@ class BalanceDF:
     @property
     def _weights(
         self: "BalanceDF",
-    ) -> Optional[pd.DataFrame]:
+    ) -> pd.DataFrame | None:
         """Access the weight_column in __sample.
 
         Args:
             self (BalanceDF): Object
 
         Returns:
-            Optional[pd.DataFrame]: The weights (with no column name)
+            pd.DataFrame | None: The weights (with no column name)
         """
         w = self._sample.weight_column
         return w.rename(None)
@@ -123,13 +125,11 @@ class BalanceDF:
         self: "BalanceDF",
     ) -> Dict[
         str,
-        Union[
-            "BalanceDF",
-            "BalanceCovarsDF",
-            "BalanceWeightsDF",
-            "BalanceOutcomesDF",
-            None,
-        ],
+        "BalanceDF"
+        | "BalanceCovarsDF"
+        | "BalanceWeightsDF"
+        | "BalanceOutcomesDF"
+        | None,
     ]:
         """Returns a dict with self and the same type of BalanceDF_child when created from the linked samples.
 
@@ -270,13 +270,11 @@ class BalanceDF:
         BalanceDF_child_method = self.__name
         d: Dict[
             str,
-            Union[
-                "BalanceDF",
-                "BalanceCovarsDF",
-                "BalanceWeightsDF",
-                "BalanceOutcomesDF",
-                None,
-            ],
+            "BalanceDF"
+            | "BalanceCovarsDF"
+            | "BalanceWeightsDF"
+            | "BalanceOutcomesDF"
+            | None,
         ] = {"self": self}
         d.update(
             {
@@ -492,7 +490,7 @@ class BalanceDF:
         )
         return wdf
 
-    def to_download(self: "BalanceDF", tempdir: Optional[str] = None) -> FileLink:
+    def to_download(self: "BalanceDF", tempdir: str | None = None) -> FileLink:
         """Creates a downloadable link of the DataFrame, with ids, of the BalanceDF object.
 
         File name starts with tmp_balance_out_, and some random file name (using :func:`uuid.uuid4`).
@@ -1012,7 +1010,7 @@ class BalanceDF:
     # NOTE: Summary could return also an str in case it is overridden in other children's methods.
     def summary(
         self: "BalanceDF", on_linked_samples: bool = True
-    ) -> Union[pd.DataFrame, str]:
+    ) -> pd.DataFrame | str:
         """
         Returns a summary of the BalanceDF object.
 
@@ -1038,14 +1036,14 @@ class BalanceDF:
 
     def _get_df_and_weights(
         self: "BalanceDF",
-    ) -> Tuple[pd.DataFrame, Optional[npt.NDArray]]:
+    ) -> Tuple[pd.DataFrame, npt.NDArray | None]:
         """Extract covars df (after using model_matrix) and weights from a BalanceDF object.
 
         Args:
             self (BalanceDF): Object
 
         Returns:
-            Tuple[pd.DataFrame, Optional[np.ndarray]]:
+            Tuple[pd.DataFrame, np.ndarray | None]:
                 A pd.DataFrame output from running :func:`model_matrix`, and
                 A np.ndarray of weights from :func:`_weights`, or just None (if there are no weights).
         """
@@ -1119,7 +1117,7 @@ class BalanceDF:
     def asmd(
         self: "BalanceDF",
         on_linked_samples: bool = True,
-        target: Optional["BalanceDF"] = None,
+        target: "BalanceDF" | None = None,
         aggregate_by_main_covar: bool = False,
         **kwargs: Any,
     ) -> pd.DataFrame:
@@ -1246,8 +1244,8 @@ class BalanceDF:
 
     def asmd_improvement(
         self: "BalanceDF",
-        unadjusted: Optional["BalanceDF"] = None,
-        target: Optional["BalanceDF"] = None,
+        unadjusted: "BalanceDF" | None = None,
+        target: "BalanceDF" | None = None,
     ) -> np.float64:
         """Calculates the improvement in mean(asmd) from before to after applying some weight adjustment.
 
@@ -1374,10 +1372,10 @@ class BalanceDF:
 
     def to_csv(
         self: "BalanceDF",
-        path_or_buf: Optional[FilePathOrBuffer] = None,
+        path_or_buf: FilePathOrBuffer | None = None,
         *args: Any,
         **kwargs: Any,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Write df with ids from BalanceDF to a comma-separated values (csv) file.
 
         Uses :func:`pd.DataFrame.to_csv`.
@@ -1414,9 +1412,9 @@ class BalanceOutcomesDF(BalanceDF):
     #       this will also require to update _relative_response_rates a bit.
     def relative_response_rates(
         self: "BalanceOutcomesDF",
-        target: Union[bool, pd.DataFrame] = False,
+        target: bool | pd.DataFrame = False,
         per_column: bool = False,
-    ) -> Optional[pd.DataFrame]:
+    ) -> pd.DataFrame | None:
         """Produces a summary table of number of responses and proportion of completed responses.
 
         See :func:`general_stats.relative_response_rates`.
@@ -1513,7 +1511,7 @@ class BalanceOutcomesDF(BalanceDF):
             self.df, df_target, per_column=per_column
         )
 
-    def target_response_rates(self: "BalanceOutcomesDF") -> Optional[pd.DataFrame]:
+    def target_response_rates(self: "BalanceOutcomesDF") -> pd.DataFrame | None:
         """Calculates relative_response_rates for the target in a Sample object.
 
         See :func:`general_stats.relative_response_rates`.
@@ -1569,7 +1567,7 @@ class BalanceOutcomesDF(BalanceDF):
     #       The BalanceDF.summary method only returns a DataFrame. So it's a question
     #       what is the best way to structure this more generally.
     def summary(
-        self: "BalanceOutcomesDF", on_linked_samples: Optional[bool] = None
+        self: "BalanceOutcomesDF", on_linked_samples: bool | None = None
     ) -> str:
         """Produces summary printable string of a BalanceOutcomesDF object.
 
@@ -1831,8 +1829,8 @@ class BalanceWeightsDF(BalanceDF):
 
     def trim(
         self: "BalanceWeightsDF",
-        ratio: Optional[Union[float, int]] = None,
-        percentile: Optional[float] = None,
+        ratio: float | int | None = None,
+        percentile: float | None = None,
         keep_sum_of_weights: bool = True,
     ) -> None:
         """Trim weights in the sample object.
@@ -1859,7 +1857,7 @@ class BalanceWeightsDF(BalanceDF):
         )
 
     def summary(
-        self: "BalanceWeightsDF", on_linked_samples: Optional[bool] = None
+        self: "BalanceWeightsDF", on_linked_samples: bool | None = None
     ) -> pd.DataFrame:
         """
         Generates a summary of a BalanceWeightsDF object.

--- a/balance/cli.py
+++ b/balance/cli.py
@@ -5,7 +5,7 @@
 
 # pyre-strict
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import annotations
 
 import inspect
 import json
@@ -14,7 +14,7 @@ import logging
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Tuple, Type
 
 import balance
 
@@ -31,21 +31,21 @@ class BalanceCLI:
         self.args: Namespace = args
 
         # Create attributes (to be populated later, which will be used in main)
-        self._transformations: Union[Dict[str, Any], str, None] = None
-        self._formula: Optional[str] = None
+        self._transformations: Dict[str, Any] | str | None = None
+        self._formula: str | None = None
         self._penalty_factor: None = None
         self._one_hot_encoding: bool = False
-        self._max_de: Optional[float] = None
-        self._lambda_min: Optional[float] = None
-        self._lambda_max: Optional[float] = None
-        self._num_lambdas: Optional[int] = None
+        self._max_de: float | None = None
+        self._lambda_min: float | None = None
+        self._lambda_max: float | None = None
+        self._num_lambdas: int | None = None
         self._weight_trimming_mean_ratio: float = 20.0
-        self._logistic_regression_kwargs: Optional[Dict[str, Any]] = None
+        self._logistic_regression_kwargs: Dict[str, Any] | None = None
         self._sample_cls: Type[balance_sample_cls] = balance_sample_cls
         self._sample_package_name: str = __package__
         self._sample_package_version: str = __version__
 
-    def check_input_columns(self, columns: Union[List[str], pd.Index]) -> None:
+    def check_input_columns(self, columns: List[str] | pd.Index) -> None:
         needed_columns = []
         needed_columns.append(self.sample_column())
         needed_columns.append(self.id_column())
@@ -95,7 +95,7 @@ class BalanceCLI:
     def has_keep_columns(self) -> bool:
         return self.args.keep_columns is not None
 
-    def keep_columns(self) -> Optional[List[str]]:
+    def keep_columns(self) -> list[str] | None:
         if self.args.keep_columns:
             return self.args.keep_columns.split(",")
         return None
@@ -106,30 +106,30 @@ class BalanceCLI:
     def keep_row_column(self) -> str:
         return self.args.keep_row_column
 
-    def max_de(self) -> Optional[float]:
+    def max_de(self) -> float | None:
         return self.args.max_de
 
-    def lambda_min(self) -> Optional[float]:
+    def lambda_min(self) -> float | None:
         return self.args.lambda_min
 
-    def lambda_max(self) -> Optional[float]:
+    def lambda_max(self) -> float | None:
         return self.args.lambda_max
 
-    def num_lambdas(self) -> Optional[int]:
+    def num_lambdas(self) -> int | None:
         if self.args.num_lambdas is None:
             return None
         return int(self.args.num_lambdas)
 
-    def transformations(self) -> Optional[str]:
+    def transformations(self) -> str | None:
         if (self.args.transformations is None) or (self.args.transformations == "None"):
             return None
         else:
             return self.args.transformations
 
-    def formula(self) -> Optional[str]:
+    def formula(self) -> str | None:
         return self.args.formula
 
-    def one_hot_encoding(self) -> Optional[bool]:
+    def one_hot_encoding(self) -> bool | None:
         return balance.util._true_false_str_to_bool(self.args.one_hot_encoding)
 
     def standardize_types(self) -> bool:
@@ -138,7 +138,7 @@ class BalanceCLI:
     def weight_trimming_mean_ratio(self) -> float:
         return self.args.weight_trimming_mean_ratio
 
-    def logistic_regression_kwargs(self) -> Optional[Dict[str, Any]]:
+    def logistic_regression_kwargs(self) -> Dict[str, Any] | None:
         raw_kwargs = self.args.ipw_logistic_regression_kwargs
         if raw_kwargs is None:
             return None
@@ -166,16 +166,16 @@ class BalanceCLI:
     def process_batch(
         self,
         batch_df: pd.DataFrame,
-        transformations: Union[Dict[str, Any], str, None] = "default",
-        formula: Optional[str] = None,
+        transformations: Dict[str, Any] | str | None = "default",
+        formula: str | None = None,
         penalty_factor: None = None,
         one_hot_encoding: bool = False,
-        max_de: Optional[float] = 1.5,
-        lambda_min: Optional[float] = 1e-05,
-        lambda_max: Optional[float] = 10,
-        num_lambdas: Optional[int] = 250,
+        max_de: float | None = 1.5,
+        lambda_min: float | None = 1e-05,
+        lambda_max: float | None = 10,
+        num_lambdas: int | None = 250,
         weight_trimming_mean_ratio: float = 20,
-        logistic_regression_kwargs: Optional[Dict[str, Any]] = None,
+        logistic_regression_kwargs: Dict[str, Any] | None = None,
         sample_cls: Type[balance_sample_cls] = balance_sample_cls,
         sample_package_name: str = __package__,
     ) -> Dict[str, pd.DataFrame]:
@@ -554,7 +554,7 @@ class BalanceCLI:
         self.write_outputs(output_df, diagnostics_df)
 
 
-def _float_or_none(value: Union[float, int, str, None]) -> Optional[float]:
+def _float_or_none(value: float | int | str | None) -> float | None:
     """Return a float (if float or int) or None if it's None or "None"
 
     This is so as to be clear that some input returned type is float or None.

--- a/balance/datasets/__init__.py
+++ b/balance/datasets/__init__.py
@@ -5,8 +5,10 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
 import pathlib
-from typing import Literal, Optional, Tuple
+from typing import Literal, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -22,7 +24,7 @@ import pandas as pd
 # TODO: add tests
 def load_sim_data(
     version: str = "01",
-) -> Tuple[Optional[pd.DataFrame], Optional[pd.DataFrame]]:
+) -> Tuple[pd.DataFrame | None, pd.DataFrame | None]:
     """Load simulated data for target and sample of interest
 
     Version 01 returns two dataframes containing the columns gender ("Male", "Female" and nan),
@@ -114,7 +116,7 @@ def load_sim_data(
 
 
 # TODO: add tests
-def load_cbps_data() -> Tuple[Optional[pd.DataFrame], Optional[pd.DataFrame]]:
+def load_cbps_data() -> Tuple[pd.DataFrame | None, pd.DataFrame | None]:
     """Load simulated data for CBPS comparison with R
 
     The code in balance that implements CBPS attempts to mimic the code from the R package CBPS (https://cran.r-project.org/web/packages/CBPS/).
@@ -128,7 +130,7 @@ def load_cbps_data() -> Tuple[Optional[pd.DataFrame], Optional[pd.DataFrame]]:
     And when the `treat` variable is 1, the row belongs to target.
 
     Returns:
-        Tuple[Optional[pd.DataFrame], Optional[pd.DataFrame]]: Two DataFrames containing simulated data for the target and sample of interest.
+        Tuple[pd.DataFrame | None, pd.DataFrame | None]: Two DataFrames containing simulated data for the target and sample of interest.
 
     Example:
         ::
@@ -169,7 +171,7 @@ def load_cbps_data() -> Tuple[Optional[pd.DataFrame], Optional[pd.DataFrame]]:
 
 def load_data(
     source: Literal["sim_data_01", "sim_data_cbps"] = "sim_data_01",
-) -> Tuple[Optional[pd.DataFrame], Optional[pd.DataFrame]]:
+) -> Tuple[pd.DataFrame | None, pd.DataFrame | None]:
     """Returns a tuple of two DataFrames containing simulated data.
 
     To learn more about each dataset, please refer to their help pages:

--- a/balance/sample_class.py
+++ b/balance/sample_class.py
@@ -11,7 +11,7 @@ import collections
 import inspect
 import logging
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Literal, Optional, Union
+from typing import Any, Callable, Dict, List, Literal
 
 import numpy as np
 import pandas as pd
@@ -134,9 +134,9 @@ class Sample:
     def from_frame(
         cls: type["Sample"],
         df: pd.DataFrame,
-        id_column: Optional[str] = None,
-        outcome_columns: Optional[Union[List[str], tuple[str, ...], str]] = None,
-        weight_column: Optional[str] = None,
+        id_column: str | None = None,
+        outcome_columns: List[str] | tuple[str, ...] | str | None = None,
+        weight_column: str | None = None,
         check_id_uniqueness: bool = True,
         standardize_types: bool = True,
         use_deepcopy: bool = True,
@@ -157,13 +157,13 @@ class Sample:
 
         Args:
             df (pd.DataFrame): containing the sample's data
-            id_column (Optional, Optional[str]): the column of the df which contains the respondent's id
+            id_column (str | None): the column of the df which contains the respondent's id
             (should be unique). Defaults to None.
-            outcome_columns (Optional, Optional[Union[list, tuple, str]]): names of columns to treat as outcome
-            weight_column (Optional, Optional[str]): name of column to treat as weight. If not specified, will
+            outcome_columns (list | tuple | str | None): names of columns to treat as outcome
+            weight_column (str | None): name of column to treat as weight. If not specified, will
                 be guessed (either "weight" or "weights"). If not found, a new column will be created ("weight") and filled with 1.0.
-            check_id_uniqueness (Optional, bool): Whether to check if ids are unique. Defaults to True.
-            standardize_types (Optional, bool): Whether to standardize types. Defaults to True.
+            check_id_uniqueness (bool): Whether to check if ids are unique. Defaults to True.
+            standardize_types (bool): Whether to standardize types. Defaults to True.
                 Int64/int64 -> float64
                 Int32/int32 -> float64
                 string -> object
@@ -397,7 +397,7 @@ class Sample:
 
     def model(
         self: "Sample",
-    ) -> Optional[Dict[str, Any]]:
+    ) -> Dict[str, Any] | None:
         """
         Returns the name of the model used to adjust Sample if adjusted.
         Otherwise returns None.
@@ -429,10 +429,9 @@ class Sample:
     ############################################
     def adjust(
         self: "Sample",
-        target: Optional["Sample"] = None,
-        method: Union[
-            Literal["cbps", "ipw", "null", "poststratify", "rake"], Callable[..., Any]
-        ] = "ipw",
+        target: "Sample" | None = None,
+        method: Literal["cbps", "ipw", "null", "poststratify", "rake"]
+        | Callable[..., Any] = "ipw",
         *args: Any,
         **kwargs: Any,
     ) -> "Sample":
@@ -441,7 +440,7 @@ class Sample:
         This function returns a new sample.
 
         Args:
-            target (Optional["Sample"]): Second sample object which should be matched.
+            target ("Sample" | None): Second sample object which should be matched.
                 If None, the set target of the object is used for matching.
             method (str): method for adjustment: cbps, ipw, null, poststratify, rake
 
@@ -475,7 +474,7 @@ class Sample:
 
         return new_sample
 
-    def set_weights(self, weights: Optional[Union[pd.Series, float]]) -> None:
+    def set_weights(self, weights: pd.Series | float | None) -> None:
         """
         Adjusting the weights of a Sample object.
         This will overwrite the weight_column of the Sample.
@@ -483,7 +482,7 @@ class Sample:
         (of Sample.df and weights series)
 
         Args:
-            weights (Optional[Union[pd.Series, float]]): Series of weights to add to sample.
+            weights (pd.Series | float | None): Series of weights to add to sample.
                 If None or float values, the same weight (or None) will be assigned to all units.
 
         Returns:
@@ -1095,8 +1094,8 @@ class Sample:
     ############################################
     def keep_only_some_rows_columns(
         self: "Sample",
-        rows_to_keep: Optional[str] = None,
-        columns_to_keep: Optional[List[str]] = None,
+        rows_to_keep: str | None = None,
+        columns_to_keep: List[str] | None = None,
     ) -> "Sample":
         # TODO: split this into two functions (one for rows and one for columns)
         """
@@ -1108,14 +1107,14 @@ class Sample:
 
         Args:
             self (Sample): a sample object (preferably after adjustment)
-            rows_to_keep (Optional[str], optional): A string with a condition to eval (on some of the columns).
+            rows_to_keep (str | None, optional): A string with a condition to eval (on some of the columns).
                 This will run df.eval(rows_to_keep) which will return a pd.Series of bool by which
                 we will filter the Sample object.
                 This effects both the df of covars AND the weights column (weight_column)
                 AND the outcome column (_outcome_columns), AND the id_column column.
                 Input should be a boolean feature, or a condition such as: 'gender == "Female" & age >= 18'.
                 Defaults to None.
-            columns_to_keep (Optional[List[str]], optional): the covariates of interest.
+            columns_to_keep (List[str] | None, optional): the covariates of interest.
                 Defaults to None, which returns all columns.
 
         Returns:
@@ -1181,14 +1180,14 @@ class Sample:
     ################
     # Saving results
     ################
-    def to_download(self, tempdir: Optional[str] = None) -> FileLink:
+    def to_download(self, tempdir: str | None = None) -> FileLink:
         """Creates a downloadable link of the DataFrame of the Sample object.
 
         File name starts with tmp_balance_out_, and some random file name (using :func:`uuid.uuid4`).
 
         Args:
             self (Sample): Object.
-            tempdir (Optional[str], optional): Defaults to None (which then uses a temporary folder using :func:`tempfile.gettempdir`).
+            tempdir (str | None, optional): Defaults to None (which then uses a temporary folder using :func:`tempfile.gettempdir`).
 
         Returns:
             FileLink: Embedding a local file link in an IPython session, based on path. Using :func:FileLink.
@@ -1196,8 +1195,8 @@ class Sample:
         return balance_util._to_download(self.df, tempdir)
 
     def to_csv(
-        self, path_or_buf: Optional[FilePathOrBuffer] = None, **kwargs: Any
-    ) -> Optional[str]:
+        self, path_or_buf: FilePathOrBuffer | None = None, **kwargs: Any
+    ) -> str | None:
         """Write df with ids from BalanceDF to a comma-separated values (csv) file.
 
         Uses :func:`pd.DataFrame.to_csv`.
@@ -1206,10 +1205,10 @@ class Sample:
 
         Args:
             self: Object.
-            path_or_buf (Optional[FilePathOrBuffer], optional): location where to save the csv.
+            path_or_buf (FilePathOrBuffer | None, optional): location where to save the csv.
 
         Returns:
-            Optional[str]: If path_or_buf is None, returns the resulting csv format as a string. Otherwise returns None.
+            str | None: If path_or_buf is None, returns the resulting csv format as a string. Otherwise returns None.
         """
         if "index" not in kwargs:
             kwargs["index"] = False

--- a/balance/stats_and_plots/weighted_comparisons_stats.py
+++ b/balance/stats_and_plots/weighted_comparisons_stats.py
@@ -5,12 +5,12 @@
 
 # pyre-strict
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import annotations
 
 import collections
 import logging
 import re
-from typing import List, Literal, Union
+from typing import List, Literal
 
 import numpy as np
 import numpy.typing as npt
@@ -121,18 +121,8 @@ def _weights_per_covars_names(covar_names: List[str]) -> pd.DataFrame:
 def asmd(
     sample_df: pd.DataFrame,
     target_df: pd.DataFrame,
-    sample_weights: Union[
-        List[float],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
-    target_weights: Union[
-        List[float],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
+    sample_weights: list[float] | pd.Series | npt.NDArray | None = None,
+    target_weights: list[float] | pd.Series | npt.NDArray | None = None,
     std_type: Literal["target", "sample", "pooled"] = "target",
     aggregate_by_main_covar: bool = False,
 ) -> pd.Series:
@@ -367,24 +357,9 @@ def asmd_improvement(
     sample_before: pd.DataFrame,
     sample_after: pd.DataFrame,
     target: pd.DataFrame,
-    sample_before_weights: Union[
-        List[float],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
-    sample_after_weights: Union[
-        List[float],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
-    target_weights: Union[
-        List[float],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
+    sample_before_weights: list[float] | pd.Series | npt.NDArray | None = None,
+    sample_after_weights: list[float] | pd.Series | npt.NDArray | None = None,
+    target_weights: list[float] | pd.Series | npt.NDArray | None = None,
 ) -> np.float64:
     """Calculates the improvement in mean(asmd) from before to after applying some weight adjustment.
 
@@ -400,6 +375,7 @@ def asmd_improvement(
     Returns:
         np.float64: The improvement is taking the (before_mean_asmd-after_mean_asmd)/before_mean_asmd.
         The asmd is calculated using :func:`asmd`.
+        Returns 0.0 when asmd_mean_before is zero or very close to zero (< 1e-10).
     """
     asmd_mean_before = asmd(
         sample_before, target, sample_before_weights, target_weights
@@ -407,24 +383,19 @@ def asmd_improvement(
     asmd_mean_after = asmd(
         sample_after, target, sample_after_weights, target_weights
     ).loc["mean(asmd)"]
+
+    # Avoid division by zero when asmd_mean_before is zero or very close to zero
+    if np.abs(asmd_mean_before) < 1e-10:
+        return np.float64(0.0)
+
     return (asmd_mean_before - asmd_mean_after) / asmd_mean_before
 
 
 def outcome_variance_ratio(
     df_numerator: pd.DataFrame,
     df_denominator: pd.DataFrame,
-    w_numerator: Union[
-        List[float],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
-    w_denominator: Union[
-        List[float],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
+    w_numerator: list[float] | pd.Series | npt.NDArray | None = None,
+    w_denominator: list[float] | pd.Series | npt.NDArray | None = None,
 ) -> pd.Series:
     """Calculate ratio of weighted variances of two DataFrames
 

--- a/balance/stats_and_plots/weighted_stats.py
+++ b/balance/stats_and_plots/weighted_stats.py
@@ -5,10 +5,10 @@
 
 # pyre-strict
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import annotations
 
 import logging
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -29,19 +29,8 @@ logger: logging.Logger = logging.getLogger(__package__)
 
 
 def _prepare_weighted_stat_args(
-    v: Union[
-        List[Any],
-        pd.Series,
-        pd.DataFrame,
-        npt.NDArray,
-        np.matrix,
-    ],
-    w: Union[
-        List[Any],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
+    v: list[Any] | pd.Series | pd.DataFrame | npt.NDArray | np.matrix,
+    w: list[Any] | pd.Series | npt.NDArray | None = None,
     inf_rm: bool = False,
 ) -> Tuple[pd.DataFrame, pd.Series]:
     """
@@ -120,18 +109,8 @@ def _prepare_weighted_stat_args(
 
 
 def weighted_mean(
-    v: Union[
-        List[Any],
-        pd.Series,
-        pd.DataFrame,
-        np.matrix,
-    ],
-    w: Union[
-        List[Any],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
+    v: list[Any] | pd.Series | pd.DataFrame | np.matrix,
+    w: list[Any] | pd.Series | npt.NDArray | None = None,
     inf_rm: bool = False,
 ) -> pd.Series:
     """
@@ -184,8 +163,8 @@ def weighted_mean(
 
 
 def var_of_weighted_mean(
-    v: Union[List[Any], pd.Series, pd.DataFrame, np.matrix],
-    w: Optional[Union[List[Any], pd.Series, npt.NDArray]] = None,
+    v: list[Any] | pd.Series | pd.DataFrame | np.matrix,
+    w: list[Any] | pd.Series | npt.NDArray | None = None,
     inf_rm: bool = False,
 ) -> pd.Series:
     """
@@ -242,10 +221,10 @@ def var_of_weighted_mean(
 
 
 def ci_of_weighted_mean(
-    v: Union[List[float], pd.Series, pd.DataFrame, npt.NDArray],
-    w: Optional[Union[List[float], pd.Series, npt.NDArray]] = None,
+    v: list[float] | pd.Series | pd.DataFrame | npt.NDArray,
+    w: list[float] | pd.Series | npt.NDArray | None = None,
     conf_level: float = 0.95,
-    round_ndigits: Optional[int] = None,
+    round_ndigits: int | None = None,
     inf_rm: bool = False,
 ) -> pd.Series:
     """
@@ -328,19 +307,8 @@ def ci_of_weighted_mean(
 
 
 def weighted_var(
-    v: Union[
-        List[Any],
-        pd.Series,
-        pd.DataFrame,
-        npt.NDArray,
-        np.matrix,
-    ],
-    w: Union[
-        List[Any],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
+    v: list[Any] | pd.Series | pd.DataFrame | npt.NDArray | np.matrix,
+    w: list[Any] | pd.Series | npt.NDArray | None = None,
     inf_rm: bool = False,
 ) -> pd.Series:
     """
@@ -378,18 +346,8 @@ def weighted_var(
 
 
 def weighted_sd(
-    v: Union[
-        List[Any],
-        pd.Series,
-        pd.DataFrame,
-        np.matrix,
-    ],
-    w: Union[
-        List[Any],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
+    v: list[Any] | pd.Series | pd.DataFrame | np.matrix,
+    w: list[Any] | pd.Series | npt.NDArray | None = None,
     inf_rm: bool = False,
 ) -> pd.Series:
     """Calculate the sample weighted standard deviation
@@ -408,24 +366,9 @@ def weighted_sd(
 
 
 def weighted_quantile(
-    v: Union[
-        List[Any],
-        pd.Series,
-        pd.DataFrame,
-        npt.NDArray,
-        np.matrix,
-    ],
-    quantiles: Union[
-        List[Any],
-        pd.Series,
-        npt.NDArray,
-    ],
-    w: Union[
-        List[Any],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
+    v: list[Any] | pd.Series | pd.DataFrame | npt.NDArray | np.matrix,
+    quantiles: list[Any] | pd.Series | npt.NDArray,
+    w: list[Any] | pd.Series | npt.NDArray | None = None,
     inf_rm: bool = False,
 ) -> pd.DataFrame:
     """
@@ -459,12 +402,7 @@ def weighted_quantile(
 
 def descriptive_stats(
     df: pd.DataFrame,
-    weights: Union[
-        List[Any],
-        pd.Series,
-        npt.NDArray,
-        None,
-    ] = None,
+    weights: list[Any] | pd.Series | npt.NDArray | None = None,
     stat: str = "mean",
     # relevant only if stat is None
     weighted: bool = True,
@@ -620,9 +558,9 @@ def descriptive_stats(
 
 
 def relative_frequency_table(
-    df: Union[pd.DataFrame, pd.Series],
-    column: Optional[str] = None,
-    w: Optional[pd.Series] = None,
+    df: pd.DataFrame | pd.Series,
+    column: str | None = None,
+    w: pd.Series | None = None,
 ) -> pd.DataFrame:
     """Creates a relative frequency table by aggregating over a categorical column (`column`) - optionally weighted by `w`.
     I.e.: produce the proportion (or weighted proportion) of rows that appear in each category, relative to the total number of rows (or sum of weights).

--- a/balance/stats_and_plots/weights_stats.py
+++ b/balance/stats_and_plots/weights_stats.py
@@ -5,10 +5,10 @@
 
 # pyre-strict
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -23,13 +23,7 @@ logger: logging.Logger = logging.getLogger(__package__)
 
 
 def _check_weights_are_valid(
-    w: Union[
-        List[Any],
-        pd.Series,
-        npt.NDArray,
-        pd.DataFrame,
-        None,
-    ],
+    w: list[Any] | pd.Series | npt.NDArray | pd.DataFrame | None,
 ) -> None:
     """Check weights.
 
@@ -146,16 +140,10 @@ def nonparametric_skew(w: pd.Series) -> float:
 
 def prop_above_and_below(
     w: pd.Series,
-    below: Union[Tuple[float, ...], List[float], None] = (
-        1 / 10,
-        1 / 5,
-        1 / 3,
-        1 / 2,
-        1,
-    ),
-    above: Union[Tuple[float, ...], List[float], None] = (1, 2, 3, 5, 10),
+    below: tuple[float, ...] | list[float] | None = (1 / 10, 1 / 5, 1 / 3, 1 / 2, 1),
+    above: tuple[float, ...] | list[float] | None = (1, 2, 3, 5, 10),
     return_as_series: bool = True,
-) -> Union[pd.Series, Dict[Any, Any], None]:
+) -> pd.Series | dict[Any, Any] | None:
     # TODO (p2): look more in the literature (are there references for using this vs another, or none at all?)
     #            update the doc with insights, once done.
     """
@@ -171,11 +159,11 @@ def prop_above_and_below(
 
     Args:
         w (pd.Series): A pandas series of weights (float, non negative) values.
-        below (Union[Tuple[float, ...], List[float], None], optional):
+        below (tuple[float, ...] | list[float] | None, optional):
             values to check which proportion of normalized weights are *below* them.
             Using None returns None.
             Defaults to (1/10, 1/5, 1/3, 1/2, 1).
-        above (Union[Tuple[float, ...], List[float], None], optional):
+        above (tuple[float, ...] | list[float] | None, optional):
             values to check which proportion of normalized weights are *above* (or equal) to them.
             Using None returns None.
             Defaults to (1, 2, 3, 5, 10).
@@ -184,7 +172,7 @@ def prop_above_and_below(
             Defaults to True.
 
     Returns:
-        Union[pd.Series, Dict]:
+        pd.Series | dict:
         If return_as_series is True we get pd.Series with proportions of (normalized weights)
         that are below/above some numbers, the index indicates which threshold was checked
         (the values in the index are rounded up to 3 points for printing purposes).

--- a/balance/typing.py
+++ b/balance/typing.py
@@ -7,9 +7,17 @@
 
 from __future__ import annotations
 
-# LICENSE file in the root directory of this source tree.
-
 from pathlib import Path
-from typing import AnyStr, IO
+from typing import AnyStr, IO, Union
 
-FilePathOrBuffer = str | Path | IO[AnyStr]
+# NOTE: Type aliases must use Union instead of | syntax for Python 3.9 compatibility.
+# While `from __future__ import annotations` enables PEP 604 syntax (|) in function
+# and variable annotations, it does NOT work for type alias assignments because these
+# are evaluated at runtime. The | operator for unions only works at runtime in Python 3.10+.
+#
+# Example of what works vs what doesn't in Python 3.9:
+#   ✓ def foo(x: str | int) -> str | None:  # Works with __future__ import
+#   ✓ variable: str | None = None           # Works with __future__ import
+#   ✗ TypeAlias = str | int                 # Runtime error in Python 3.9
+#   ✓ TypeAlias = Union[str, int]           # Works in all versions
+FilePathOrBuffer = Union[str, Path, IO[AnyStr]]

--- a/balance/util.py
+++ b/balance/util.py
@@ -5,8 +5,9 @@
 
 # pyre-strict
 
-import collections.abc
+from __future__ import annotations
 
+import collections
 import copy
 import logging
 import tempfile
@@ -14,7 +15,7 @@ import uuid
 import warnings
 from functools import reduce
 from itertools import combinations
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
@@ -79,7 +80,7 @@ def _isinstance_sample(obj: Any) -> bool:
     return isinstance(obj, sample_class.Sample)
 
 
-def guess_id_column(dataset: pd.DataFrame, column_name: Optional[str] = None) -> str:
+def guess_id_column(dataset: pd.DataFrame, column_name: str | None = None) -> str:
     """
     Guess the id column of a given dataset.
     Possible values for guess: 'id'.
@@ -399,7 +400,7 @@ class one_hot_encoding_greater_2:
 
 
 def process_formula(
-    formula: str, variables: List[str], factor_variables: Optional[List[str]] = None
+    formula: str, variables: list[str], factor_variables: list[str] | None = None
 ) -> ModelDesc:
     """Process a formula string:
         1. Expand .  notation using dot_expansion function
@@ -470,7 +471,7 @@ def process_formula(
 def build_model_matrix(
     df: pd.DataFrame,
     formula: str = ".",
-    factor_variables: Optional[List[str]] = None,
+    factor_variables: List[str] | None = None,
     return_sparse: bool = False,
 ) -> Dict[str, Any]:
     """Build a model matrix from a formula (using patsy.dmatrix)
@@ -579,9 +580,9 @@ def build_model_matrix(
 
 
 def _prepare_input_model_matrix(
-    sample: Union[pd.DataFrame, Any],
-    target: Union[pd.DataFrame, Any, None] = None,
-    variables: Optional[List[str]] = None,
+    sample: pd.DataFrame | Any,
+    target: pd.DataFrame | Any | None = None,
+    variables: List[str] | None = None,
     add_na: bool = True,
     fix_columns_names: bool = True,
 ) -> Dict[str, Any]:
@@ -592,9 +593,9 @@ def _prepare_input_model_matrix(
         - Add na indicator if required.
 
     Args:
-        sample (Union[pd.DataFrame, Any]): This can either be a DataFrame or a Sample object. TODO: add text.
-        target (Union[pd.DataFrame, Any, None], optional): This can either be a DataFrame or a Sample object.. Defaults to None.
-        variables (Optional[List], optional): Defaults to None. TODO: add text.
+        sample (pd.DataFrame | Any): This can either be a DataFrame or a Sample object. TODO: add text.
+        target (pd.DataFrame | Any | None, optional): This can either be a DataFrame or a Sample object.. Defaults to None.
+        variables (List[str] | None, optional): Defaults to None. TODO: add text.
         add_na (bool, optional): Defaults to True. TODO: add text.
         fix_columns_names (bool, optional): Defaults to True. If to fix the column names of the DataFrame by changing special characters to '_'.
 
@@ -685,40 +686,39 @@ def _prepare_input_model_matrix(
 
 
 def model_matrix(
-    sample: Union[pd.DataFrame, Any],
-    target: Union[pd.DataFrame, Any, None] = None,
-    variables: Optional[List[str]] = None,
+    sample: pd.DataFrame | Any,
+    target: pd.DataFrame | Any | None = None,
+    variables: List[str] | None = None,
     add_na: bool = True,
     return_type: str = "two",
     return_var_type: str = "dataframe",
-    formula: Optional[Union[str, List[str]]] = None,
-    penalty_factor: Optional[List[float]] = None,
+    formula: str | List[str] | None = None,
+    penalty_factor: List[float] | None = None,
     one_hot_encoding: bool = False,
-) -> Dict[str, Union[List[Any], np.ndarray, pd.DataFrame, csc_matrix, None]]:
+) -> Dict[str, List[Any] | np.ndarray | pd.DataFrame | csc_matrix | None]:
     """Create a model matrix from a sample (and target).
     The default is to use an additive formula for all variables (or the ones specified).
     Can also create a custom model matrix if a formula is provided.
 
     Args:
-        sample (Union[pd.DataFrame, Any]): The Samples from which to create the model matrix. This can either be a DataFrame or a Sample object.
-        target (Union[pd.DataFrame, Any, None], optional): See sample. Defaults to None. This can either be a DataFrame or a Sample object.
-        variables (Optional[List]): the names of the variables to include (when 'None' then
+        sample (pd.DataFrame | Any): The Samples from which to create the model matrix. This can either be a DataFrame or a Sample object.
+        target (pd.DataFrame | Any | None, optional): See sample. Defaults to None. This can either be a DataFrame or a Sample object.
+        variables (List[str] | None): the names of the variables to include (when 'None' then
             all joint variables to target and sample are used). Defaults to None.
         add_na (bool, optional): whether to call add_na_indicator on the data before constructing
             the matrix.If add_na = True, then the function add_na_indicator is applied,
             i.e. if a column in the DataFrame contains NAs, replace these with 0 or "_NA", and
             add another column of an indicator variable for which rows were NA.
-            If add_na is False, observations with any missing data will be
             omitted from the model. Defaults to True.
         return_type (str, optional): whether to return a single matrix ('one'), or a dict of
             sample and target matrices. Defaults to "two".
         return_var_type (str, optional): whether to return a "dataframe" (pd.dataframe) a "matrix" (np.ndarray)
             (i.e. only values of the output dataframe), or a "sparse" matrix. Defaults to "dataframe".
-        formula (Optional[List[str]], optional): according to what formula to construct the matrix. If no formula is provided an
+        formula (str | List[str] | None, optional): according to what formula to construct the matrix. If no formula is provided an
             additive formula is applied. This may be a string or a list of strings
             representing different parts of the formula that will be concated together.
             Default is None, which will create an additive formula from the available variables. Defaults to None.
-        penalty_factor (Optional[List[float]], optional): the penalty used in the sklearn function in ipw. The penalty
+        penalty_factor (List[float] | None, optional): the penalty used in the sklearn function in ipw. The penalty
             should have the same length as the formula list. If not provided,
             assume the same penalty for all variables. Defaults to None.
         one_hot_encoding (bool, optional): whether to encode all factor variables in the model matrix with
@@ -730,7 +730,7 @@ def model_matrix(
             and only 1 column for variables with 2 levels (treatment contrast). Defaults to False.
 
     Returns:
-        Dict[str, Union[List[Any], np.ndarray, pd.DataFrame, csc_matrix, None]]
+        Dict[str, List[Any] | np.ndarray | pd.DataFrame | csc_matrix | None]
             a dict of:
                 1. "model_matrix_columns_names": columns names of the model matrix
                 2. "penalty_factor ": a penalty_factor for each column in the model matrix
@@ -929,11 +929,11 @@ def model_matrix(
 
 # TODO: add type hinting
 def qcut(
-    s: Union[np.ndarray, pd.Series],
-    q: Union[int, float],
+    s: np.ndarray | pd.Series,
+    q: int | float,
     duplicates: str = "drop",
     **kwargs: Any,
-) -> Union[np.ndarray, pd.Series]:
+) -> np.ndarray | pd.Series:
     """Discretize variable into equal-sized buckets based quantiles.
     This is a wrapper to pandas qcut function.
 
@@ -954,10 +954,10 @@ def qcut(
 
 
 def quantize(
-    df: Union[pd.DataFrame, pd.Series],
+    df: pd.DataFrame | pd.Series,
     q: int = 10,
-    variables: Optional[List[str]] = None,
-) -> Union[pd.DataFrame, np.ndarray, pd.Series]:
+    variables: List[str] | None = None,
+) -> pd.DataFrame | np.ndarray | pd.Series:
     """Cut numeric variables of a DataFrame into quantiles buckets
 
     Args:
@@ -1090,10 +1090,10 @@ def _process_series_for_missing_mask(series: pd.Series) -> pd.Series:
 
 
 def _safe_replace_and_infer(
-    data: Union[pd.Series, pd.DataFrame],
-    to_replace: Optional[Any] = None,
-    value: Optional[Any] = None,
-) -> Union[pd.Series, pd.DataFrame]:
+    data: pd.Series | pd.DataFrame,
+    to_replace: Any | None = None,
+    value: Any | None = None,
+) -> pd.Series | pd.DataFrame:
     """
     Helper function to safely replace values and infer object dtypes
     while avoiding pandas deprecation warnings.
@@ -1118,8 +1118,8 @@ def _safe_replace_and_infer(
 
 
 def _safe_fillna_and_infer(
-    data: Union[pd.Series, pd.DataFrame], value: Optional[Any] = None
-) -> Union[pd.Series, pd.DataFrame]:
+    data: pd.Series | pd.DataFrame, value: Any | None = None
+) -> pd.Series | pd.DataFrame:
     """
     Helper function to safely fill NaN values and infer object dtypes
     while avoiding pandas deprecation warnings.
@@ -1144,7 +1144,7 @@ def _safe_fillna_and_infer(
 
 def _safe_groupby_apply(
     data: pd.DataFrame,
-    groupby_cols: Union[str, List[str]],
+    groupby_cols: str | List[str],
     apply_func: Callable[..., Any],
 ) -> pd.Series:
     """
@@ -1310,7 +1310,7 @@ def rm_mutual_nas(*args: Any) -> List[Any]:
     )
     nonmissing_mask = ~missing_mask
 
-    def _return_type_creation_function(x: Any) -> Union[Callable, Any]:
+    def _return_type_creation_function(x: Any) -> Callable | Any:
         # The numpy.ndarray constructor doesn't take the same arguments as np.array
         if isinstance(x, np.ndarray):
             return lambda obj: np.array(obj, dtype=x.dtype)
@@ -1345,8 +1345,8 @@ def rm_mutual_nas(*args: Any) -> List[Any]:
 # TODO: (p2) create choose_variables_df that only works with pd.DataFrames as input, and wrap it with something that deals with Sample.
 #       This would help clarify the logic of each function.
 def choose_variables(
-    *dfs: Union[pd.DataFrame, Any],
-    variables: Optional[Union[List[str], set[str]]] = None,
+    *dfs: pd.DataFrame | Any,
+    variables: List[str] | set[str] | None = None,
     df_for_var_order: int = 0,
 ) -> List[str]:
     """
@@ -1358,8 +1358,8 @@ def choose_variables(
              1 means the order from the second df, etc.
 
     Args:
-         *dfs (Union[pd.DataFrame, Any]): One or more pandas.DataFrames or balance.Samples.
-         variables (Optional[Union[List, set]]): The variables to choose from. If None, returns all joint variables found
+         *dfs (pd.DataFrame | Any): One or more pandas.DataFrames or balance.Samples.
+         variables (List[str] | set[str] | None): The variables to choose from. If None, returns all joint variables found
              in the input dataframes. Defaults to None.
          df_for_var_order (int): Index of the dataframe used to determine the order of the variables in the output list.
              Defaults to 0. This is used only if the `variables` argument is not a list (e.g.: a set or None).
@@ -1450,7 +1450,7 @@ def choose_variables(
 
 
 def auto_spread(
-    data: pd.DataFrame, features: Optional[List[str]] = None, id_: str = "id"
+    data: pd.DataFrame, features: List[str] | None = None, id_: str = "id"
 ) -> pd.DataFrame:
     """Automatically transform a 'long' DataFrame into a 'wide' DataFrame
     by guessing which column should be used as a key, treating all
@@ -1509,7 +1509,7 @@ def auto_aggregate(
     # NOTE: we use str as default since using a lambda function directly would make this argument mutable -
     # so if one function call would change it, another function call would get the revised aggfunc argument.
     # Thus, using str is important so to keep our function idempotent.
-    aggfunc: Union[str, Callable[..., Any]] = "sum",
+    aggfunc: str | Callable[..., Any] = "sum",
 ) -> pd.DataFrame:
     # The default aggregation function is a lambda around sum(x), because as of
     # Pandas 0.22.0, Series.sum of an all-na Series is 0, not nan
@@ -1804,7 +1804,7 @@ class TruncationFormatter(logging.Formatter):
 ################################################################################
 def _to_download(
     df: pd.DataFrame,
-    tempdir: Optional[str] = None,
+    tempdir: str | None = None,
 ) -> FileLink:
     """Creates a downloadable link of the DataFrame (df).
 
@@ -1812,7 +1812,7 @@ def _to_download(
 
     Args:
         self (BalanceDF): Object.
-        tempdir (Optional[str], optional): Defaults to None (which then uses a temporary folder using :func:`tempfile.gettempdir`).
+        tempdir (str | None, optional): Defaults to None (which then uses a temporary folder using :func:`tempfile.gettempdir`).
 
     Returns:
         FileLink: Embedding a local file link in an IPython session, based on path. Using :func:FileLink.
@@ -1919,7 +1919,7 @@ def _true_false_str_to_bool(x: str) -> bool:
 
 def _are_dtypes_equal(
     dt1: pd.Series, dt2: pd.Series
-) -> Dict[str, Union[bool, pd.Series, set[Any]]]:
+) -> Dict[str, bool | pd.Series | set[Any]]:
     """Returns True if both dtypes are the same and False otherwise.
 
     If dtypes have an unequal set of items, the comparison will only be about the same set of keys.

--- a/balance/weighting_methods/ipw.py
+++ b/balance/weighting_methods/ipw.py
@@ -5,12 +5,11 @@
 
 # pyre-strict
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import annotations
 
 import copy
 import logging
-
-from typing import Any, cast, Dict, List, Optional, Tuple, Union
+from typing import Any, cast, Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -36,7 +35,7 @@ logger: logging.Logger = logging.getLogger(__package__)
 # TODO: Improve interpretability of model coefficients, as variables are no longer zero-centered.
 def model_coefs(
     model: ClassifierMixin,
-    feature_names: Optional[List[str]] = None,
+    feature_names: list[str] | None = None,
 ) -> Dict[str, Any]:
     """Extract coefficient-like information from sklearn classifiers.
 
@@ -106,7 +105,7 @@ def _compute_deviance(
     y: np.ndarray,
     pred: np.ndarray,
     model_weights: np.ndarray,
-    labels: Optional[List[int]] = None,
+    labels: list[int] | None = None,
 ) -> float:
     """Compute deviance (2 * log loss).
 
@@ -216,8 +215,8 @@ def weights_from_link(
     balance_classes: bool,
     sample_weights: pd.Series,
     target_weights: pd.Series,
-    weight_trimming_mean_ratio: Union[None, float, int] = None,
-    weight_trimming_percentile: Optional[float] = None,
+    weight_trimming_mean_ratio: None | float | int = None,
+    weight_trimming_percentile: float | None = None,
     keep_sum_of_weights: bool = True,
 ) -> pd.Series:
     """Transform link predictions into weights, by exponentiating them, and optionally balancing the classes and trimming
@@ -398,7 +397,7 @@ def ipw(
     sample_weights: pd.Series,
     target_df: pd.DataFrame,
     target_weights: pd.Series,
-    variables: Optional[List[str]] = None,
+    variables: list[str] | None = None,
     # TODO: change 'model' to be Union[Optional[ClassifierMixin], str]
     #       in which the default will be
     # LogisticRegression(
@@ -412,23 +411,23 @@ def ipw(
     # a user could then just update the LogisticRegression by providing a different LogisticRegression implementation
     # Or any other sklearn classifier (e.g. RandomForestClassifier)
     model: str = "sklearn",
-    weight_trimming_mean_ratio: Optional[Union[int, float]] = 20,
-    weight_trimming_percentile: Optional[float] = None,
+    weight_trimming_mean_ratio: int | float | None = 20,
+    weight_trimming_percentile: float | None = None,
     balance_classes: bool = True,
     transformations: str = "default",
     na_action: str = "add_indicator",
-    max_de: Optional[float] = None,
+    max_de: float | None = None,
     lambda_min: float = 1e-05,
     lambda_max: float = 10,
     num_lambdas: int = 250,
-    formula: Union[str, List[str], None] = None,
-    penalty_factor: Optional[List[float]] = None,
+    formula: str | list[str] | None = None,
+    penalty_factor: list[float] | None = None,
     one_hot_encoding: bool = False,
     # TODO: This is set to be false in order to keep reproducibility of works that uses balance.
     # The best practice is for this to be true.
-    logistic_regression_kwargs: Optional[Dict[str, Any]] = None,
+    logistic_regression_kwargs: Dict[str, Any] | None = None,
     random_seed: int = 2020,
-    sklearn_model: Optional[ClassifierMixin] = None,
+    sklearn_model: ClassifierMixin | None = None,
     *args: Any,
     **kwargs: Any,
 ) -> Dict[str, Any]:
@@ -553,9 +552,7 @@ def ipw(
 
     logger.info("Building model matrix")
     # Convert formula to List[str] if it's a single string
-    formula_list: Optional[List[str]] = (
-        [formula] if isinstance(formula, str) else formula
-    )
+    formula_list: list[str] | None = [formula] if isinstance(formula, str) else formula
     model_matrix_output = balance_util.model_matrix(
         sample_df,
         target_df,
@@ -658,8 +655,8 @@ def ipw(
             lr_kwargs.update(logistic_regression_kwargs)
 
         lr = LogisticRegression(**lr_kwargs)
-        fits: List[Optional[ClassifierMixin]] = [None for _ in range(len(lambdas))]
-        links: List[Optional[np.ndarray]] = [None for _ in range(len(lambdas))]
+        fits: list[ClassifierMixin | None] = [None for _ in range(len(lambdas))]
+        links: list[np.ndarray | None] = [None for _ in range(len(lambdas))]
         prop_dev = [np.nan for _ in range(len(lambdas))]
         dev = [np.nan for _ in range(len(lambdas))]
         cv_dev_mean = [np.nan for _ in range(len(lambdas))]
@@ -723,8 +720,8 @@ def ipw(
         X_matrix = _convert_to_dense_array(X_matrix)
 
         lambdas = np.array([np.nan])
-        fits: List[Optional[ClassifierMixin]] = [None]
-        links: List[Optional[np.ndarray]] = [None]
+        fits: list[ClassifierMixin | None] = [None]
+        links: list[np.ndarray | None] = [None]
         prop_dev = [np.nan]
         dev = [np.nan]
         cv_dev_mean = [np.nan]


### PR DESCRIPTION
Summary:
Updated type annotations across the balance package to use the newer PEP 604 union syntax (`X | Y`) instead of the older `typing.Union` and `typing.Optional` syntax. This modernization improves code readability and aligns with Python 3.10+ typing conventions.

Key changes:
- Replaced `Union[X, Y]` with `X | Y`
- Replaced `Optional[X]` with `X | None`
- Updated `from __future__ import` statements to use `annotations` instead of the older `absolute_import, division, print_function, unicode_literals`
- Removed unnecessary `Union` and `Optional` imports from `typing`

All changes are backward compatible with Python 3.9 as `from __future__ import annotations` enables deferred evaluation of type hints, allowing the new syntax to work properly. This modernization affects 11 files across the balance package including core modules like `adjustment.py`, `balancedf_class.py`, `sample_class.py`, and various stats and weighting methods.

Differential Revision: D87614454


