### PR TITLE
Enhanced type safety for weighted comparisons plotting functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,13 @@
     limitation and the distinction between type annotations (which support `|`
     with `from __future__ import annotations`) and type alias assignments
     (which require `Union` for runtime evaluation in Python 3.9).
+  - **Enhanced type safety for plotting functions**: Replaced loose dictionary
+    type hints with structured `TypedDict` definition (`DataFrameWithWeight`)
+    for better type checking in `weighted_comparisons_plots.py`. Added
+    `SampleName` type alias to precisely specify valid sample name literals.
+    Removed numerous `# pyre-ignore` comments by properly handling type casts
+    and narrowing types. Added validation for plotly `dist_type` parameter to
+    raise clear errors when unsupported types are used.
   - Fixed missing `Any` import in `weighted_comparisons_plots.py` to resolve
     pyre-fixme[10] error
   - Added comprehensive type annotations for previously untyped parameters and


### PR DESCRIPTION
Summary:
Improved type safety in `weighted_comparisons_plots.py` and its test file by replacing loose dictionary type hints with structured TypedDict definitions and proper type aliases.

**Key Changes:**

1. **Added structured types**: Created `DataFrameWithWeight` TypedDict to replace `Dict[str, pd.DataFrame | pd.Series]` for better type checking and clearer intent
2. **Added SampleName type alias**: Defined valid sample name literals ("sample", "unadjusted", "self", "adjusted", "target") to catch invalid values at type check time
3. **Enhanced `_plotly_marker_color` validation**: Added explicit dist_type validation for plotly that raises clear ValueError when unsupported types (hist, ecdf) are used
4. **Replaced pyre-ignore with proper type handling**:
   - Used proper type casts with SampleName for marker color functions
   - Added type assertions for plot results before indexing
   - Used type: ignore with arg-type comments for intentional test error cases
   - Replaced tuple attribute access with index notation to avoid pyre errors
5. **Improved test clarity**: Added explicit type annotations for test data structures and helper variables

**Why this matters:**
- Eliminates 15+ pyre-ignore comments with proper type handling
- Makes API expectations explicit via TypedDict structure
- Catches type errors at check time rather than runtime
- Maintains Python 3.9 compatibility using Union syntax in TypedDict

**Compatibility note:**
Uses Union syntax (not |) in TypedDict and type alias definitions for Python 3.9 runtime compatibility, as these are evaluated at runtime and cannot use the | operator in Python 3.9.

Differential Revision: D87725450


