### PR TITLE
Replace assert patterns with none_throws helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,8 +68,8 @@
     (`parent_balance/tests/test_adjust_null.py`,
     `parent_balance/tests/test_adjustment.py`,
     `parent_balance/tests/test_cbps.py`, `parent_balance/tests/test_cli.py`,
-    `parent_balance/tests/test_datasets.py`,
-    `parent_balance/tests/test_ipw.py`, `parent_balance/tests/test_logging.py`,
+    `parent_balance/tests/test_datasets.py`, `parent_balance/tests/test_ipw.py`,
+    `parent_balance/tests/test_logging.py`,
     `parent_balance/tests/test_poststratify.py`,
     `parent_balance/tests/test_rake.py`, `parent_balance/tests/test_sample.py`,
     `parent_balance/tests/test_stats_and_plots.py`,
@@ -108,6 +108,15 @@
   - Fixed type casts and narrowed types where appropriate
   - Initialized optional variables to handle pyre-fixme[61] issues
   - Updated method signatures to match parent class interfaces
+  - **Replaced assert-based type narrowing with `_verify_value_type()` helper**:
+    Refactored code to use the `_verify_value_type()` utility function instead
+    of bare `assert x is not None` statements for type narrowing. This improves
+    code clarity, provides better error messages, and follows best practices for
+    pyre-strict mode. Enhanced `_verify_value_type()` in `testutil.py` with
+    optional type checking via `isinstance()` and improved overload signatures.
+    Changes applied to test files (`test_datasets.py`, `test_sample.py`,
+    `test_stats_and_plots.py`, `test_testutil.py`, `test_util.py`,
+    `test_weighted_comparisons_plots.py`) and production code (`ipw.py`).
 
 ## Bug Fixes
 

--- a/balance/testutil.py
+++ b/balance/testutil.py
@@ -8,24 +8,63 @@
 import io
 import re
 import sys
-
 import unittest
 from contextlib import contextmanager
-from typing import Any, Callable, Generator, Optional, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    Optional,
+    overload,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
-# Generic type variable used for none_throws to preserve type information
+# Generic type variable used for _verify_value_type to preserve type information
 T = TypeVar("T")
 
 
-# TODO: move to use this function throughout the tests
-def none_throws(optional: Optional[T]) -> T:
-    """Assert that optional value is not None and return it."""
+@overload
+def _verify_value_type(  # noqa: E704
+    optional: Optional[Any],
+    expected_type: Type[T],
+) -> T: ...
+
+
+@overload
+def _verify_value_type(  # noqa: E704
+    optional: Optional[T],
+    expected_type: None = None,
+) -> T: ...
+
+
+def _verify_value_type(
+    optional: Optional[T],
+    expected_type: Optional[Union[Type[Any], Tuple[Type[Any], ...]]] = None,
+) -> T:
+    """Assert that optional value is not None and return it.
+
+    Args:
+        optional: The optional value to check
+        expected_type: Optional type or tuple of types to check with isinstance()
+
+    Returns:
+        The non-None value
+
+    Raises:
+        ValueError: If optional is None
+        TypeError: If expected_type is provided and isinstance check fails
+    """
     if optional is None:
         raise ValueError("Unexpected None value")
+    if expected_type is not None and not isinstance(optional, expected_type):
+        raise TypeError(f"Expected type {expected_type}, got {type(optional).__name__}")
     return optional
 
 

--- a/balance/weighting_methods/ipw.py
+++ b/balance/weighting_methods/ipw.py
@@ -20,6 +20,7 @@ from balance.stats_and_plots.weighted_comparisons_stats import (
     asmd_improvement as compute_asmd_improvement,
 )
 from balance.stats_and_plots.weights_stats import design_effect
+from balance.testutil import _verify_value_type
 
 from scipy.sparse import csc_matrix, csr_matrix, issparse
 from sklearn.base import ClassifierMixin, clone
@@ -803,7 +804,7 @@ def ipw(
     )
 
     logger.info(f"Chosen lambda: {best_s}")
-    assert best_model is not None, "best_model should not be None at this point"
+    best_model = _verify_value_type(best_model)
     performance = model_coefs(
         best_model,
         feature_names=list(X_matrix_columns_names),

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -11,6 +11,7 @@ import balance.testutil
 import numpy as np
 
 from balance.datasets import load_data
+from balance.testutil import _verify_value_type
 
 
 class TestDatasets(
@@ -19,8 +20,8 @@ class TestDatasets(
     def test_load_data(self) -> None:
         target_df, sample_df = load_data()
 
-        assert sample_df is not None
-        assert target_df is not None
+        sample_df = _verify_value_type(sample_df)
+        target_df = _verify_value_type(target_df)
 
         self.assertEqual(sample_df.shape, (1000, 5))
         self.assertEqual(target_df.shape, (10000, 5))
@@ -58,8 +59,8 @@ class TestDatasets(
     def test_load_data_cbps(self) -> None:
         target_df, sample_df = load_data("sim_data_cbps")
 
-        assert sample_df is not None
-        assert target_df is not None
+        sample_df = _verify_value_type(sample_df)
+        target_df = _verify_value_type(target_df)
 
         self.assertEqual(sample_df.shape, (246, 7))
         self.assertEqual(target_df.shape, (254, 7))

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -33,7 +33,7 @@ import numpy as np
 import pandas as pd
 
 from balance.sample_class import Sample
-from balance.testutil import none_throws
+from balance.testutil import _verify_value_type
 
 
 # Test sample fixtures - shared across multiple test methods
@@ -486,7 +486,7 @@ class TestSample_base_and_adjust_methods(
         a = s.adjust(t, max_de=None, method="null")
         m = a.model()
 
-        self.assertEqual(none_throws(m)["method"], "null_adjustment")
+        self.assertEqual(_verify_value_type(m)["method"], "null_adjustment")
 
     def test_Sample_model_ipw_adjustment(self) -> None:
         """Test model information for IPW adjustment method.
@@ -500,12 +500,12 @@ class TestSample_base_and_adjust_methods(
         a = s.adjust(t, max_de=None)
         m = a.model()
 
-        self.assertEqual(none_throws(m)["method"], "ipw")
+        self.assertEqual(_verify_value_type(m)["method"], "ipw")
 
         # Test structure of IPW output
-        self.assertTrue("perf" in none_throws(m).keys())
-        self.assertTrue("fit" in none_throws(m).keys())
-        self.assertTrue("coefs" in none_throws(m)["perf"].keys())
+        self.assertTrue("perf" in _verify_value_type(m).keys())
+        self.assertTrue("fit" in _verify_value_type(m).keys())
+        self.assertTrue("coefs" in _verify_value_type(m)["perf"].keys())
 
     def test_Sample_model_matrix(self) -> None:
         """Test model matrix generation for samples.

--- a/tests/test_stats_and_plots.py
+++ b/tests/test_stats_and_plots.py
@@ -13,6 +13,7 @@ import balance.testutil
 
 import numpy as np
 import pandas as pd
+from balance.testutil import _verify_value_type
 
 
 class TestBalance_weights_stats(
@@ -98,8 +99,7 @@ class TestBalance_weights_stats(
         # Test with identical values
         result1 = prop_above_and_below(pd.Series((1, 1, 1, 1)))
         self.assertIsNotNone(result1)
-        assert result1 is not None  # Type narrowing for pyre
-        assert isinstance(result1, pd.Series)  # Type narrowing for pyre
+        result1 = _verify_value_type(result1, pd.Series)  # Type narrowing for pyre
         self.assertEqual(
             result1.astype(int).to_list(),
             [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
@@ -108,8 +108,7 @@ class TestBalance_weights_stats(
         # Test with varying values
         result2 = prop_above_and_below(pd.Series((1, 2, 3, 4)))
         self.assertIsNotNone(result2)
-        assert result2 is not None  # Type narrowing for pyre
-        assert isinstance(result2, pd.Series)  # Type narrowing for pyre
+        result2 = _verify_value_type(result2, pd.Series)  # Type narrowing for pyre
         self.assertEqual(
             result2.to_list(),
             [0.0, 0.0, 0.0, 0.25, 0.5, 0.5, 0.0, 0.0, 0.0, 0.0],
@@ -120,8 +119,7 @@ class TestBalance_weights_stats(
             pd.Series((1, 2, 3, 4)), below=(0.1, 0.5), above=(2, 3)
         )
         self.assertIsNotNone(result)
-        assert result is not None  # Type narrowing for pyre
-        assert isinstance(result, pd.Series)  # Type narrowing for pyre
+        result = _verify_value_type(result, pd.Series)  # Type narrowing for pyre
         self.assertEqual(result.to_list(), [0.0, 0.25, 0.0, 0.0])
         self.assertEqual(
             result.index.to_list(),
@@ -138,7 +136,7 @@ class TestBalance_weights_stats(
             pd.Series((1, 2, 3, 4)), return_as_series=False
         )
         self.assertIsNotNone(result_dict)
-        assert result_dict is not None  # Type narrowing for pyre
+        result_dict = _verify_value_type(result_dict)
         expected = {
             "below": [0.0, 0.0, 0.0, 0.25, 0.5],
             "above": [0.5, 0.0, 0.0, 0.0, 0.0],

--- a/tests/test_testutil.py
+++ b/tests/test_testutil.py
@@ -258,3 +258,88 @@ class TestTestUtil_BalanceTestCase_Print(
         # as logging handlers can change (e.g. in PyTest)
         # assertPrintsRegexp() works with both stdout and stderr output
         self.assertPrintsRegexp("abc", lambda: print("abcde", file=sys.stderr))
+
+
+class TestNoneThrows(
+    balance.testutil.BalanceTestCase,
+):
+    """Test cases for the _verify_value_type utility function."""
+
+    def test__verify_value_type_returns_non_none_value(self) -> None:
+        """Test that _verify_value_type returns the value when it is not None."""
+        value = "test_value"
+        result = balance.testutil._verify_value_type(value)
+        self.assertEqual(result, "test_value")
+
+    def test__verify_value_type_raises_value_error_on_none(self) -> None:
+        """Test that _verify_value_type raises ValueError when value is None."""
+        with self.assertRaises(ValueError) as context:
+            balance.testutil._verify_value_type(None)
+        self.assertIn("Unexpected None value", str(context.exception))
+
+    def test__verify_value_type_with_correct_type_single_type(self) -> None:
+        """Test that _verify_value_type accepts value with correct single type."""
+        df = pd.DataFrame({"a": [1, 2, 3]})
+        result = balance.testutil._verify_value_type(df, pd.DataFrame)
+        self.assertIsInstance(result, pd.DataFrame)
+        self.assertEqual(result, df)
+
+    def test__verify_value_type_with_incorrect_type_single_type(self) -> None:
+        """Test that _verify_value_type raises TypeError when value has incorrect single type."""
+        value = "not a dataframe"
+        with self.assertRaises(TypeError) as context:
+            balance.testutil._verify_value_type(value, pd.DataFrame)
+        self.assertIn("Expected type", str(context.exception))
+        self.assertIn("DataFrame", str(context.exception))
+        self.assertIn("str", str(context.exception))
+
+    def test__verify_value_type_with_correct_type_tuple_of_types(self) -> None:
+        """Test that _verify_value_type accepts value when it matches one of multiple types."""
+        # Test with string (first type in tuple)
+        str_value = "test"
+        # pyre-fixme[6]: Tuple types work at runtime but overloads don't support union narrowing
+        result_str = balance.testutil._verify_value_type(str_value, (str, int))
+        self.assertEqual(result_str, "test")
+
+        # Test with int (second type in tuple)
+        int_value = 42
+        # pyre-fixme[6]: Tuple types work at runtime but overloads don't support union narrowing
+        result_int = balance.testutil._verify_value_type(int_value, (str, int))
+        self.assertEqual(result_int, 42)
+
+    def test__verify_value_type_with_incorrect_type_tuple_of_types(self) -> None:
+        """Test that _verify_value_type raises TypeError when value doesn't match any type in tuple."""
+        value = 3.14  # float, not in (str, int)
+        with self.assertRaises(TypeError) as context:
+            # pyre-fixme[6]: Tuple types work at runtime but overloads don't support union narrowing
+            balance.testutil._verify_value_type(value, (str, int))
+        self.assertIn("Expected type", str(context.exception))
+        self.assertIn("float", str(context.exception))
+
+    def test__verify_value_type_without_type_check(self) -> None:
+        """Test that _verify_value_type works without type checking (backward compatibility)."""
+        # Test with various types without type checking
+        self.assertEqual(balance.testutil._verify_value_type("test"), "test")
+        self.assertEqual(balance.testutil._verify_value_type(42), 42)
+        self.assertEqual(balance.testutil._verify_value_type([1, 2, 3]), [1, 2, 3])
+
+    def test__verify_value_type_with_none_and_type_check(self) -> None:
+        """Test that _verify_value_type raises ValueError for None even when type checking is enabled."""
+        # ValueError should be raised before TypeError check
+        with self.assertRaises(ValueError) as context:
+            balance.testutil._verify_value_type(None, pd.DataFrame)
+        self.assertIn("Unexpected None value", str(context.exception))
+
+    def test__verify_value_type_with_numpy_array(self) -> None:
+        """Test that _verify_value_type works with numpy arrays."""
+        arr = np.array([1, 2, 3])
+        result = balance.testutil._verify_value_type(arr, np.ndarray)
+        self.assertIsInstance(result, np.ndarray)
+        np.testing.assert_array_equal(result, arr)
+
+    def test__verify_value_type_with_pandas_series(self) -> None:
+        """Test that _verify_value_type works with pandas Series."""
+        series = pd.Series([1, 2, 3])
+        result = balance.testutil._verify_value_type(series, pd.Series)
+        self.assertIsInstance(result, pd.Series)
+        pd.testing.assert_series_equal(result, series)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -18,6 +18,7 @@ import pandas as pd
 # TODO: remove the use of balance_util in most cases, and just import the functions to be tested directly
 from balance import util as balance_util
 from balance.sample_class import Sample
+from balance.testutil import _verify_value_type
 
 from numpy import dtype
 
@@ -433,8 +434,7 @@ class TestUtil(
             }
         )
         r = balance_util.model_matrix(s)
-        sample_result_433 = r["sample"]
-        assert sample_result_433 is not None
+        sample_result_433 = _verify_value_type(r["sample"])
         self.assertEqual(sample_result_433, e, lazy=True)
         self.assertTrue(r["target"] is None)
 
@@ -449,9 +449,7 @@ class TestUtil(
             }
         )
         r = balance_util.model_matrix(s_df[["a", "b", "c"]])
-        sample_result_447 = r["sample"]
-        assert sample_result_447 is not None
-        assert isinstance(sample_result_447, pd.DataFrame)
+        sample_result_447 = _verify_value_type(r["sample"], pd.DataFrame)
         self.assertEqual(sample_result_447.sort_index(axis=1), e, lazy=True)
 
         # Tests on a single sample with a target
@@ -487,10 +485,8 @@ class TestUtil(
         )
         sample_result_480 = r["sample"]
         target_result_481 = r["target"]
-        assert sample_result_480 is not None
-        assert target_result_481 is not None
-        assert isinstance(sample_result_480, pd.DataFrame)
-        assert isinstance(target_result_481, pd.DataFrame)
+        sample_result_480 = _verify_value_type(sample_result_480, pd.DataFrame)
+        target_result_481 = _verify_value_type(target_result_481, pd.DataFrame)
         self.assertEqual(sample_result_480.sort_index(axis=1), e_s, lazy=True)
         self.assertEqual(target_result_481.sort_index(axis=1), e_t, lazy=True)
 
@@ -503,10 +499,8 @@ class TestUtil(
         )
         sample_result_494 = r["sample"]
         target_result_495 = r["target"]
-        assert sample_result_494 is not None
-        assert target_result_495 is not None
-        assert isinstance(sample_result_494, pd.DataFrame)
-        assert isinstance(target_result_495, pd.DataFrame)
+        sample_result_494 = _verify_value_type(sample_result_494, pd.DataFrame)
+        target_result_495 = _verify_value_type(target_result_495, pd.DataFrame)
         self.assertEqual(sample_result_494.sort_index(axis=1), e_s, lazy=True)
         self.assertEqual(target_result_495.sort_index(axis=1), e_t, lazy=True)
 
@@ -546,9 +540,7 @@ class TestUtil(
             "c___c[b]": {0: 0.0, 1: 1.0, 2: 0.0},
             "id": {0: 1.0, 1: 2.0, 2: 3.0},
         }
-        sample_result_536 = r["sample"]
-        assert sample_result_536 is not None
-        assert isinstance(sample_result_536, pd.DataFrame)
+        sample_result_536 = _verify_value_type(r["sample"], pd.DataFrame)
         self.assertEqual(sample_result_536.to_dict(), exp)
 
         # Tests that we can handle multiple columns what would be turned to have the same column name
@@ -584,9 +576,7 @@ class TestUtil(
             "b1__3[c]": {0: 0.0, 1: 0.0, 2: 1.0},
             "id": {0: 1.0, 1: 2.0, 2: 3.0},
         }
-        sample_result_571 = r["sample"]
-        assert sample_result_571 is not None
-        assert isinstance(sample_result_571, pd.DataFrame)
+        sample_result_571 = _verify_value_type(r["sample"], pd.DataFrame)
         self.assertEqual(sample_result_571.to_dict(), exp)
 
     def test_model_matrix_arguments(self) -> None:
@@ -634,9 +624,7 @@ class TestUtil(
         self.assertWarnsRegexp(
             "Dropping all rows with NAs", balance_util.model_matrix, s, add_na=False
         )
-        sample_add_na = r["sample"]
-        assert sample_add_na is not None
-        assert isinstance(sample_add_na, pd.DataFrame)
+        sample_add_na = _verify_value_type(r["sample"], pd.DataFrame)
         self.assertEqual(sample_add_na.sort_index(axis=1), e)
         self.assertTrue(r["target"] is None)
 
@@ -660,22 +648,19 @@ class TestUtil(
                 "c[c]": (0.0, 0.0, 0.0, 1.0),
             }
         )
-        assert r_one is not None
-        assert isinstance(r_one, pd.DataFrame)
+        r_one = _verify_value_type(r_one, pd.DataFrame)
         self.assertEqual(r_one.sort_index(axis=1), pd.concat((e_s, e_t)), lazy=True)
 
         # Test return_var_type argument
         r_df = balance_util.model_matrix(
             s, t, return_type="one", return_var_type="dataframe"
         )["model_matrix"]
-        assert r_df is not None
-        assert isinstance(r_df, pd.DataFrame)
+        r_df = _verify_value_type(r_df, pd.DataFrame)
         self.assertEqual(r_df.sort_index(axis=1), pd.concat((e_s, e_t)), lazy=True)
         r_mat = balance_util.model_matrix(
             s, t, return_type="one", return_var_type="matrix"
         )
-        model_matrix_mat = r_mat["model_matrix"]
-        assert model_matrix_mat is not None
+        model_matrix_mat = _verify_value_type(r_mat["model_matrix"])
         self.assertEqual(
             model_matrix_mat,
             pd.concat((e_s, e_t))
@@ -685,9 +670,7 @@ class TestUtil(
         r_sparse = balance_util.model_matrix(
             s, t, return_type="one", return_var_type="sparse"
         )
-        model_matrix_sparse = r_sparse["model_matrix"]
-        assert model_matrix_sparse is not None
-        assert isinstance(model_matrix_sparse, csc_matrix)
+        model_matrix_sparse = _verify_value_type(r_sparse["model_matrix"], csc_matrix)
         self.assertEqual(
             model_matrix_sparse.toarray(),
             pd.concat((e_s, e_t))
@@ -701,24 +684,24 @@ class TestUtil(
         self.assertTrue(type(model_matrix_sparse) is csc_matrix)
 
         # Test formula argument
-        result_a_plus_b = balance_util.model_matrix(s, formula="a + b")["sample"]
-        assert result_a_plus_b is not None
-        assert isinstance(result_a_plus_b, pd.DataFrame)
+        result_a_plus_b = _verify_value_type(
+            balance_util.model_matrix(s, formula="a + b")["sample"], pd.DataFrame
+        )
         self.assertEqual(
             result_a_plus_b.sort_index(axis=1),
             pd.DataFrame({"a": (0.0, 1.0, 2.0), "b": (0.0, 0.0, 2.0)}),
         )
 
-        result_b = balance_util.model_matrix(s, formula="b ")["sample"]
-        assert result_b is not None
-        assert isinstance(result_b, pd.DataFrame)
+        result_b = _verify_value_type(
+            balance_util.model_matrix(s, formula="b ")["sample"], pd.DataFrame
+        )
         self.assertEqual(
             result_b.sort_index(axis=1),
             pd.DataFrame({"b": (0.0, 0.0, 2.0)}),
         )
-        result_a_times_c = balance_util.model_matrix(s, formula="a * c ")["sample"]
-        assert result_a_times_c is not None
-        assert isinstance(result_a_times_c, pd.DataFrame)
+        result_a_times_c = _verify_value_type(
+            balance_util.model_matrix(s, formula="a * c ")["sample"], pd.DataFrame
+        )
         self.assertEqual(
             result_a_times_c.sort_index(axis=1),
             pd.DataFrame(
@@ -730,9 +713,9 @@ class TestUtil(
                 }
             ),
         )
-        result_a_b_list = balance_util.model_matrix(s, formula=["a", "b"])["sample"]
-        assert result_a_b_list is not None
-        assert isinstance(result_a_b_list, pd.DataFrame)
+        result_a_b_list = _verify_value_type(
+            balance_util.model_matrix(s, formula=["a", "b"])["sample"], pd.DataFrame
+        )
         self.assertEqual(
             result_a_b_list.sort_index(axis=1),
             pd.DataFrame({"a": (0.0, 1.0, 2.0), "b": (0.0, 0.0, 2.0)}),
@@ -774,9 +757,7 @@ class TestUtil(
             }
         )
         r = balance_util.model_matrix(s, one_hot_encoding=True)
-        sample_result_750 = r["sample"]
-        assert sample_result_750 is not None
-        assert isinstance(sample_result_750, pd.DataFrame)
+        sample_result_750 = _verify_value_type(r["sample"], pd.DataFrame)
         self.assertEqual(sample_result_750.sort_index(axis=1), e, lazy=True)
 
     def test_qcut(self) -> None:
@@ -1478,8 +1459,8 @@ class TestUtil(
         # Check that model coefficients are identical
         output_cat_var_model = output_cat_var.model()
         output_string_var_model = output_string_var.model()
-        assert output_cat_var_model is not None
-        assert output_string_var_model is not None
+        output_cat_var_model = _verify_value_type(output_cat_var_model)
+        output_string_var_model = _verify_value_type(output_string_var_model)
         self.assertEqual(
             output_cat_var_model["perf"]["coefs"],
             output_string_var_model["perf"]["coefs"],

--- a/tests/test_weighted_comparisons_plots.py
+++ b/tests/test_weighted_comparisons_plots.py
@@ -17,6 +17,7 @@ import numpy as np
 import pandas as pd
 from balance.stats_and_plots import weighted_comparisons_plots, weighted_stats
 from balance.stats_and_plots.weighted_comparisons_plots import DataFrameWithWeight
+from balance.testutil import _verify_value_type
 
 
 class Test_weighted_comparisons_plots(balance.testutil.BalanceTestCase):
@@ -196,8 +197,7 @@ class Test_weighted_comparisons_plots(balance.testutil.BalanceTestCase):
             library="seaborn",
             return_axes=True,
         )
-        assert plot_result is not None
-        assert isinstance(plot_result, list)
+        plot_result = _verify_value_type(plot_result, list)
         plot_axes = plot_result[0]
 
         # Verify that the returned object is a matplotlib Axes
@@ -371,8 +371,7 @@ class Test_weighted_comparisons_plots(balance.testutil.BalanceTestCase):
                 dist_type=dist_type,
                 return_axes=True,
             )
-            assert plot_result is not None
-            assert isinstance(plot_result, list)
+            plot_result = _verify_value_type(plot_result, list)
             axes_types.append(type(plot_result[0]))
 
         # Verify all returned objects are matplotlib Axes subclasses
@@ -430,8 +429,7 @@ class Test_weighted_comparisons_plots(balance.testutil.BalanceTestCase):
 
         # Verify dictionary structure and contents
         self.assertEqual(type(dict_of_figures), dict)
-        assert dict_of_figures is not None
-        assert isinstance(dict_of_figures, dict)
+        dict_of_figures = _verify_value_type(dict_of_figures, dict)
         self.assertEqual(
             sorted(dict_of_figures.keys()),
             ["v1", "v2", "v3"],


### PR DESCRIPTION
Summary:
Replace assert-based type narrowing patterns with the `none_throws()` helper function across test files and production code for better type safety and consistency.

This change improves code quality by using the existing `none_throws()` utility function instead of bare assert statements for type narrowing. The `none_throws()` function provides clearer semantics and better error messages while achieving the same type narrowing effect.

Changes:
- Replaced `assert x is not None` followed by usage with `x = none_throws(x)` pattern
- Updated test_datasets.py, test_stats_and_plots.py, test_util.py, and test_weighted_comparisons_plots.py
- Updated production code in ipw.py to use the same pattern
- Added imports for `none_throws` where needed

This is a refactoring that maintains the same runtime behavior while improving code clarity and following best practices for type narrowing in pyre-strict mode.

Differential Revision: D87815328


