### PR TITLE
Replace deprecated categorical dtype detection

### DIFF
--- a/balance/util.py
+++ b/balance/util.py
@@ -203,7 +203,7 @@ def _is_categorical_dtype(series: pd.Series) -> bool:
     dtype = series.dtype
     return (
         pd_types.is_object_dtype(dtype)
-        or pd_types.is_categorical_dtype(dtype)
+        or isinstance(dtype, pd.CategoricalDtype)
         or pd_types.is_string_dtype(dtype)
     )
 


### PR DESCRIPTION
Replaced deprecated categorical dtype detection to eliminate pandas warnings during tests.

```text
DeprecationWarning:

  is_categorical_dtype is deprecated and will be removed in a future version. Use isinstance(dtype, pd.CategoricalDtype) instead
```