### PR TITLE
Raise error when weights contain None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@
     weights) so downstream consumers receive the full annotated input when
     pulling the consolidated dataframe.
 
+## Bug Fixes
+
+- **Early validation of null weight inputs**
+  - `Sample.from_frame` now raises a descriptive `ValueError` when weights
+    contain `None`, `NaN`, or `pd.NA` values. The error includes the total count
+    of offending rows and a preview of the affected observations to simplify
+    debugging bad inputs.
+
 ## Tests
 
 - **Added Windows and macOS CI testing support**

--- a/balance/sample_class.py
+++ b/balance/sample_class.py
@@ -404,10 +404,15 @@ class Sample:
                     )
 
         # verify that the weights are not null
-        if any(sample._df[weight_column].isnull()):
+        null_weights = sample._df[weight_column].isnull()
+        if any(null_weights):
+            null_weight_rows = sample._df.loc[null_weights].head()
+            null_weight_rows_count = int(null_weights.sum())
             raise ValueError(
-                "Null values are not allowed in the weight_column. "
-                + "If you wish to remove an observation, either remove it from the df, or use a weight of 0."
+                "Null values (including None) are not allowed in the weight_column. "
+                + "If you wish to remove an observation, either remove it from the df, or use a weight of 0. "
+                + f"Found {null_weight_rows_count} row(s) with null weights. Preview (up to 5 rows):\n"
+                + null_weight_rows.to_string(index=False)
             )
 
         # verify that the weights are numeric


### PR DESCRIPTION
Added explicit detection of null/None weights that raises a descriptive error and previews affected rows to aid debugging. Also added proper tests.

Why?
- Fixes #78 