### PR TITLE
Bump version to 0.14.0 and condense changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,122 +1,62 @@
-# 0.13.x (TBD)
+# 0.15.x (TBD)
 
 > TODO: update to final version
+
+# 0.14.0 (2025-12-14)
 
 ## New Features
 
 - **Enhanced adjusted sample summary output**
-  - The `Sample.__str__()` method now displays adjustment details when a sample
-    is adjusted, including adjustment method, weight trimming parameters (mean
-    ratio and percentile), design effect (Deff), and effective sample size when
-    available. This provides quick diagnostics at a glance when printing
-    adjusted samples. The helper method `_quick_adjustment_details()`
-    centralizes this logic for reuse across presentation helpers like
-    `summary()` ([#194](https://github.com/facebookresearch/balance/pull/194),
-    [#57](https://github.com/facebookresearch/balance/issues/57)). Tests are
-    added.
-
+  - `Sample.__str__()` now displays adjustment details (method, trimming
+    parameters, design effect, effective sample size) when printing adjusted
+    samples ([#194](https://github.com/facebookresearch/balance/pull/194),
+    [#57](https://github.com/facebookresearch/balance/issues/57)).
 - **Richer `Sample.summary()` diagnostics**
-  - The adjusted sample summary now groups covariate diagnostics together,
-    expands weight diagnostics to report design effect alongside effective
-    sample proportion (ESSP) and effective sample size (ESS), and surfaces
-    weighted outcome means when available. This makes the printed summary a
-    concise snapshot of covariate balance, weight health, and outcome behavior
-    post-adjustment. When the design effect cannot be computed reliably, the
-    summary now reports it as unavailable instead of emitting misleading
-    effective sample diagnostics.
-
-- **Warning of high-cardinality categorical features used as covariates in
-  .adjust()**
-  - Added detection and warnings for high-cardinality categorical features
-    (object, category, string dtypes) before weight fitting when using
-    .adjust(). Categorical features where ≥80% of non-missing values are unique
-    are flagged as potentially not providing meaningful signal. This helps
-    identify problematic columns such as user IDs or other high-cardinality
-    identifiers that may lead to poor weighting performance. Numeric features
-    are not checked, as high cardinality is expected and not problematic for
-    them ([#195](https://github.com/facebookresearch/balance/pull/195),
-    [#65](https://github.com/facebookresearch/balance/issues/65)). Tests are
-    added.
-
+  - Adjusted sample summary now groups covariate diagnostics, reports design
+    effect alongside ESSP/ESS, and surfaces weighted outcome means when
+    available.
+- **Warning of high-cardinality categorical features in `.adjust()`**
+  - Categorical features where ≥80% of values are unique are flagged before
+    weight fitting to help identify problematic columns like user IDs
+    ([#195](https://github.com/facebookresearch/balance/pull/195),
+    [#65](https://github.com/facebookresearch/balance/issues/65)).
 - **Ignored column handling for Sample inputs**
-  - `Sample.from_frame` now accepts an `ignore_columns` parameter for columns
-    that should remain on the underlying dataframe but be excluded from
-    covariate selection and outcome statistics. Ignored columns can be retrieved
-    via the new `Sample.ignored_columns()` helper, enabling metadata passthrough
-    without affecting adjustment or outcome calculations. Validation prevents
-    overlaps with id/weight/outcome columns, enforces string column names, and
-    raises clear errors for missing columns while deduplicating ignore lists in
-    order-preserving fashion.
-  - The `Sample.df` view now includes ignored columns (after outcomes and
-    weights) so downstream consumers receive the full annotated input when
-    pulling the consolidated dataframe.
+  - `Sample.from_frame` accepts `ignore_columns` for columns that should remain
+    on the dataframe but be excluded from covariates and outcome statistics.
+    Ignored columns appear in `Sample.df` and can be retrieved via
+    `Sample.ignored_columns()`.
 
-- **Consolidated diagnostics row construction**
-  - Added a `_concat_metric_val_var()` helper to build diagnostics rows with
-    consistent broadcasting of scalar values, reducing repeated DataFrame
-    concatenation patterns inside `Sample.diagnostics()`. The helper now
-    documents common usage patterns, preserves existing diagnostics when no new
-    rows are supplied, and is covered by unit tests including edge cases such as
-    generator inputs and byte strings.
-  - **Breaking change:** ``Sample.diagnostics()`` for IPW now always emits
-    single-element iteration and intercept summaries plus hyperparameter
-    settings (penalty, solver, and multi-class mode). Downstream consumers
-    expecting the earlier, shorter diagnostics output should update metric
-    counts accordingly.
+## Code Quality & Refactoring
 
-- **Robust scalar coercion for diagnostics**
-  - Centralized scalar-to-float conversion into `balance.util._coerce_scalar`,
-    adding coverage and using it in IPW diagnostics to avoid crashes from
-    unexpected values while still surfacing ``NaN`` for non-coercible inputs.
+- **Consolidated diagnostics helpers**
+  - Added `_concat_metric_val_var()` helper and `balance.util._coerce_scalar`
+    for robust diagnostics row construction and scalar-to-float conversion.
+  - **Breaking change:** `Sample.diagnostics()` for IPW now always emits
+    iteration/intercept summaries plus hyperparameter settings.
 
 ## Bug Fixes
 
 - **Early validation of null weight inputs**
-  - `Sample.from_frame` now raises a descriptive `ValueError` when weights
-    contain `None`, `NaN`, or `pd.NA` values. The error includes the total count
-    of offending rows and a preview of the affected observations to simplify
-    debugging bad inputs.
-- **Percentile weight trimming enforces requested lower bounds across platforms**
-  - `trim_weights()` now computes winsorization thresholds directly via
-    percentile quantiles with explicit clipping bounds, ensuring lower-tail
-    trimming respects the requested cutoff on all supported Python and NumPy
+  - `Sample.from_frame` now raises `ValueError` when weights contain `None`,
+    `NaN`, or `pd.NA` values with count and preview of affected rows.
+- **Percentile weight trimming across platforms**
+  - `trim_weights()` now computes thresholds via percentile quantiles with
+    explicit clipping bounds for consistent behavior across Python/NumPy
     versions.
   - **Breaking change:** percentile-based clipping may shift by roughly one
-    observation at typical limits (for example, 1% clipping on 1..100 now
-    yields bounds of 3 and 98 instead of 2 and 99). If you need to preserve the
-    previous behavior, lower the requested percentiles slightly to reproduce
-    earlier cut points.
-- **IPW diagnostics reflect model settings and avoid deprecated penalties**
-  - The IPW diagnostics now report the classifier's ``multi_class`` setting
-    exactly once and pull key scalar hyperparameters from estimator
-    parameters (including ``l1_ratio`` even when older sklearn versions store
-    it as ``None``). The default sklearn logistic regression is also
-    initialized without the deprecated ``penalty`` argument, eliminating noisy
-    deprecation warnings during test runs.
-  - Diagnostics now normalize scalar values (including the regularization
-    strength) to floats and avoid emitting empty performance sections when no
-    scalar performance metrics are present.
-  - IPW model summaries now explicitly record only deterministic attributes
-    (like ``n_iter_`` and ``intercept_``) and deduplicate metric entries so
-    metric counts remain stable across supported sklearn versions.
+    observation at typical limits.
+- **IPW diagnostics improvements**
+  - Fixed `multi_class` reporting, normalized scalar hyperparameters to floats,
+    removed deprecated `penalty` argument warnings, and deduplicated metric
+    entries for stable counts across sklearn versions.
 
 ## Tests
 
 - **Added Windows and macOS CI testing support**
-  - Expanded GitHub Actions test matrix to run on `ubuntu-latest`,
-    `macos-latest`, and `windows-latest` for all supported Python versions
-    (3.9-3.14), ensuring cross-platform compatibility.
-  - Upgraded GitHub Actions versions (`actions/checkout@v5`,
-    `actions/setup-python@v5`, `actions/setup-node@v5`) for improved reliability
-    and security.
-  - **Cross-platform test fixes to enable Windows and macOS support:**
-    - Added a shared `tempfile_path()` context manager in `testutil.py` that
-      properly handles temporary file creation and cleanup across platforms,
-      resolving Windows file-locking issues in CSV-related tests for both
-      `BalanceDF` and `Sample`.
-    - Configured tests to use the non-interactive matplotlib Agg backend via
-      `conftest.py`, eliminating Tk dependencies and display requirements in
-      plotting tests.
+  - Expanded GitHub Actions to run on `ubuntu-latest`, `macos-latest`, and
+    `windows-latest` for Python 3.9-3.14.
+  - Added `tempfile_path()` context manager for cross-platform temp file
+    handling and configured matplotlib Agg backend via `conftest.py`.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![balance_logo_horizontal](https://raw.githubusercontent.com/facebookresearch/balance/main/website/static/img/balance_logo/PNG/Horizontal/balance_Logo_Horizontal_FullColor_RGB.png)](https://import-balance.org/)
 
-
-# *balance*: a python package for balancing biased data samples
+# _balance_: a python package for balancing biased data samples
 
 <div align="center">
 
@@ -16,28 +15,54 @@
 
 </div>
 
-> [!NOTE]
-> *balance* is currently **in beta** and is actively supported. Follow us [on github](https://github.com/facebookresearch/balance).
+> [!NOTE] _balance_ is currently **in beta** and is actively supported. Follow
+> us [on github](https://github.com/facebookresearch/balance).
 
-## What is *balance*?
+## What is _balance_?
 
-**[*balance*](https://import-balance.org/) is a Python package** offering a simple workflow and methods for **dealing with biased data samples** when looking to infer from them to some population of interest.
+**[_balance_](https://import-balance.org/) is a Python package** offering a
+simple workflow and methods for **dealing with biased data samples** when
+looking to infer from them to some population of interest.
 
-Biased samples often occur in [survey statistics](https://en.wikipedia.org/wiki/Survey_methodology) when respondents present [non-response bias](https://en.wikipedia.org/wiki/Participation_bias) or survey suffers from [sampling bias](https://en.wikipedia.org/wiki/Sampling_bias) (that are not [missing completely at random](https://en.wikipedia.org/wiki/Missing_data#Missing_completely_at_random)). A similar issue arises in [observational studies](https://en.wikipedia.org/wiki/Observational_study) when comparing the treated vs untreated groups, and in any data that suffers from selection bias.
+Biased samples often occur in
+[survey statistics](https://en.wikipedia.org/wiki/Survey_methodology) when
+respondents present
+[non-response bias](https://en.wikipedia.org/wiki/Participation_bias) or survey
+suffers from [sampling bias](https://en.wikipedia.org/wiki/Sampling_bias) (that
+are not
+[missing completely at random](https://en.wikipedia.org/wiki/Missing_data#Missing_completely_at_random)).
+A similar issue arises in
+[observational studies](https://en.wikipedia.org/wiki/Observational_study) when
+comparing the treated vs untreated groups, and in any data that suffers from
+selection bias.
 
-Under the missing at random assumption ([MAR](https://en.wikipedia.org/wiki/Missing_data#Missing_at_random)), bias in samples could sometimes be (at least partially) mitigated by relying on auxiliary information (a.k.a.: "covariates" or "features") that is present for all items in the sample, as well as present in a sample of items from the population. For example, if we want to infer from a sample of respondents to some survey, we may wish to adjust for non-response using demographic information such as age, gender, education, etc. This can be done by weighing the sample to the population using auxiliary information.
+Under the missing at random assumption
+([MAR](https://en.wikipedia.org/wiki/Missing_data#Missing_at_random)), bias in
+samples could sometimes be (at least partially) mitigated by relying on
+auxiliary information (a.k.a.: "covariates" or "features") that is present for
+all items in the sample, as well as present in a sample of items from the
+population. For example, if we want to infer from a sample of respondents to
+some survey, we may wish to adjust for non-response using demographic
+information such as age, gender, education, etc. This can be done by weighing
+the sample to the population using auxiliary information.
 
-The package is intended for researchers who are interested in balancing biased samples, such as the ones coming from surveys, using a Python package. This need may arise by survey methodologists, demographers, UX researchers, market researchers, and generally data scientists, statisticians, and machine learners.
+The package is intended for researchers who are interested in balancing biased
+samples, such as the ones coming from surveys, using a Python package. This need
+may arise by survey methodologists, demographers, UX researchers, market
+researchers, and generally data scientists, statisticians, and machine learners.
 
-More about the methodological background can be found in [Sarig, T., Galili, T., & Eilat, R. (2023). balance – a Python package for balancing biased data samples](https://arxiv.org/abs/2307.06024).
-
+More about the methodological background can be found in
+[Sarig, T., Galili, T., & Eilat, R. (2023). balance – a Python package for balancing biased data samples](https://arxiv.org/abs/2307.06024).
 
 # Installation
 
 ## Requirements
-You need Python 3.9, 3.10, 3.11, 3.12, 3.13, or 3.14 to run *balance*. *balance* can be built and run from Linux, OSX, and Windows.
+
+You need Python 3.9, 3.10, 3.11, 3.12, 3.13, or 3.14 to run _balance_. _balance_
+can be built and run from Linux, OSX, and Windows.
 
 The required Python dependencies are:
+
 ```python
 REQUIRES = [
     # Numpy and pandas: carefully versioned for binary compatibility
@@ -60,19 +85,24 @@ REQUIRES = [
 ]
 ```
 
+See [setup.py](https://github.com/facebookresearch/balance/blob/main/setup.py)
+or
+[pyproject.toml](https://github.com/facebookresearch/balance/blob/main/pyproject.toml)
+for more details.
 
-See [setup.py](https://github.com/facebookresearch/balance/blob/main/setup.py) or [pyproject.toml](https://github.com/facebookresearch/balance/blob/main/pyproject.toml) for more details.
-
-## Installing *balance*
+## Installing _balance_
 
 ### Installing via PyPi
-We recommend installing *balance* from PyPi via pip for the latest stable version:
+
+We recommend installing _balance_ from PyPi via pip for the latest stable
+version:
 
 ```bash
 python -m pip install balance
 ```
 
-Installation will use Python wheels from PyPI, available for [OSX, Linux, and Windows](https://pypi.org/project/balance/#files).
+Installation will use Python wheels from PyPI, available for
+[OSX, Linux, and Windows](https://pypi.org/project/balance/#files).
 
 ### Installing from Source/Git
 
@@ -100,26 +130,36 @@ python -m pip install .[dev]
 
 ## balance's workflow in high-level
 
-The core workflow in [*balance*](https://import-balance.org/) deals with fitting and evaluating weights to a sample. For each unit in the sample (such as a respondent to a survey), balance fits a weight that can be (loosely) interpreted as the number of people from the target population that this respondent represents. This aims to help mitigate the coverage and non-response biases, as illustrated in the following figure.
+The core workflow in [_balance_](https://import-balance.org/) deals with fitting
+and evaluating weights to a sample. For each unit in the sample (such as a
+respondent to a survey), balance fits a weight that can be (loosely) interpreted
+as the number of people from the target population that this respondent
+represents. This aims to help mitigate the coverage and non-response biases, as
+illustrated in the following figure.
 
 ![total_survey_error_img](https://raw.githubusercontent.com/facebookresearch/balance/main/website/docs/docs/img/total_survey_error_flow_v02.png)
 
-
-The weighting of survey data through *balance* is done in the following main steps:
+The weighting of survey data through _balance_ is done in the following main
+steps:
 
 1. Loading data of the respondents of the survey.
 2. Loading data about the target population we would like to correct for.
-3. Diagnostics of the sample covariates so to evaluate whether weighting is needed.
+3. Diagnostics of the sample covariates so to evaluate whether weighting is
+   needed.
 4. Adjusting the sample to the target.
 5. Evaluation of the results.
 6. Use the weights for producing population level estimations.
 7. Saving the output weights.
 
-You can see a step-by-step description (with code) of the above steps in the [General Framework](https://import-balance.org/docs/docs/general_framework/) page.
+You can see a step-by-step description (with code) of the above steps in the
+[General Framework](https://import-balance.org/docs/docs/general_framework/)
+page.
 
-## Code example of using *balance*
+## Code example of using _balance_
 
-You may run the following code to play with *balance*'s basic workflow (these are snippets taken from the [quickstart tutorial](https://import-balance.org/docs/tutorials/quickstart/)):
+You may run the following code to play with _balance_'s basic workflow (these
+are snippets taken from the
+[quickstart tutorial](https://import-balance.org/docs/tutorials/quickstart/)):
 
 We start by loading data, and adjusting it:
 
@@ -141,18 +181,24 @@ sample_with_target = sample.set_target(target)
 
 ```
 
-*You can read more on evaluation of the pre-adjusted data in the [Pre-Adjustment Diagnostics](https://import-balance.org/docs/docs/general_framework/pre_adjustment_diagnostics/) page.*
+_You can read more on evaluation of the pre-adjusted data in the
+[Pre-Adjustment Diagnostics](https://import-balance.org/docs/docs/general_framework/pre_adjustment_diagnostics/)
+page._
 
-Next, we adjust the sample to the population by fitting balancing survey weights:
+Next, we adjust the sample to the population by fitting balancing survey
+weights:
 
 ```python
 # Using ipw to fit survey weights
 adjusted = sample_with_target.adjust()
 ```
 
-*You can read more on adjustment process in the [Adjusting Sample to Population](https://import-balance.org/docs/docs/general_framework/adjusting_sample_to_population/) page.*
+_You can read more on adjustment process in the
+[Adjusting Sample to Population](https://import-balance.org/docs/docs/general_framework/adjusting_sample_to_population/)
+page._
 
-The above code gets us an `adjusted` object with weights. We can evaluate the benefit of the weights to the covariate balance, for example by running:
+The above code gets us an `adjusted` object with weights. We can evaluate the
+benefit of the weights to the covariate balance, for example by running:
 
 ```python
 print(adjusted.summary())
@@ -185,23 +231,28 @@ print(adjusted.outcomes().summary())
     # %      100.0
 adjusted.outcomes().plot()
 ```
+
 ![](https://import-balance.org/assets/images/fig_09_seaborn_outcome_kde_after-26fa9668164349253b2614335961ade9.png)
 
-*You can read more on evaluation of the post-adjusted data in the [Evaluating and using the adjustment weights](https://import-balance.org/docs/docs/general_framework/evaluation_of_results/) page.*
-
+_You can read more on evaluation of the post-adjusted data in the
+[Evaluating and using the adjustment weights](https://import-balance.org/docs/docs/general_framework/evaluation_of_results/)
+page._
 
 Finally, the adjusted data can be downloaded using:
+
 ```python
 adjusted.to_download()  # Or:
 # adjusted.to_csv()
 ```
 
-To see a more detailed step-by-step code example with code output prints and plots (both static and interactive), please go over to the [tutorials section](https://import-balance.org/docs/tutorials/).
-
+To see a more detailed step-by-step code example with code output prints and
+plots (both static and interactive), please go over to the
+[tutorials section](https://import-balance.org/docs/tutorials/).
 
 ## Implemented methods for adjustments
 
-*balance* currently implements various adjustment methods. Click the links to learn more about each:
+_balance_ currently implements various adjustment methods. Click the links to
+learn more about each:
 
 1. [Logistic regression using L1 (LASSO) penalization.](https://import-balance.org/docs/docs/statistical_methods/ipw/)
 2. [Covariate Balancing Propensity Score (CBPS).](https://import-balance.org/docs/docs/statistical_methods/cbps/)
@@ -210,25 +261,34 @@ To see a more detailed step-by-step code example with code output prints and plo
 
 ## Implemented methods for diagnostics/evaluation
 
-For diagnostics the main tools (comparing before, after applying weights, and the target population) are:
+For diagnostics the main tools (comparing before, after applying weights, and
+the target population) are:
 
 1. Plots
-    1. barplots
-    2. density plots (for weights and covariances)
-    3. qq-plots
+   1. barplots
+   2. density plots (for weights and covariances)
+   3. qq-plots
 2. Statistical summaries
-    1. Weights distributions
-        1. [Kish's design effect](https://en.wikipedia.org/wiki/Design_effect#Haphazard_weights_with_estimated_ratio-mean_(%7F'%22%60UNIQ--postMath-0000003A-QINU%60%22'%7F)_-_Kish's_design_effect)
-        2. Main summaries (mean, median, variances, quantiles)
-    2. Covariate distributions
-        1. Absolute Standardized Mean Difference (ASMD). For continuous variables, it is [Cohen's d](https://en.wikipedia.org/wiki/Effect_size#Cohen's_d). Categorical variables are one-hot encoded, Cohen's d is calculated for each category and ASMD for a categorical variable is defined as Cohen's d, average across all categories.
+   1. Weights distributions
+      1. [Kish's design effect](<https://en.wikipedia.org/wiki/Design_effect#Haphazard_weights_with_estimated_ratio-mean_(%7F'%22%60UNIQ--postMath-0000003A-QINU%60%22'%7F)_-_Kish's_design_effect>)
+      2. Main summaries (mean, median, variances, quantiles)
+   2. Covariate distributions
+      1. Absolute Standardized Mean Difference (ASMD). For continuous variables,
+         it is [Cohen's d](https://en.wikipedia.org/wiki/Effect_size#Cohen's_d).
+         Categorical variables are one-hot encoded, Cohen's d is calculated for
+         each category and ASMD for a categorical variable is defined as Cohen's
+         d, average across all categories.
 
-*You can read more on evaluation of the post-adjusted data in the [Evaluating and using the adjustment weights](https://import-balance.org/docs/docs/general_framework/evaluation_of_results/) page.*
-
+_You can read more on evaluation of the post-adjusted data in the
+[Evaluating and using the adjustment weights](https://import-balance.org/docs/docs/general_framework/evaluation_of_results/)
+page._
 
 ## Other resources
-* Presentation: ["Balancing biased data samples with the 'balance' Python package"](https://github.com/facebookresearch/balance/blob/main/website/static/docs/Balancing_biased_data_samples_with_the_balance_Python_package_-_ISA_conference_2023-06-01.pdf) - presented in the Israeli Statistical Association (ISA) conference on June 1st 2023.
 
+- Presentation:
+  ["Balancing biased data samples with the 'balance' Python package"](https://github.com/facebookresearch/balance/blob/main/website/static/docs/Balancing_biased_data_samples_with_the_balance_Python_package_-_ISA_conference_2023-06-01.pdf) -
+  presented in the Israeli Statistical Association (ISA) conference on June
+  1st 2023.
 
 # More details
 
@@ -236,13 +296,22 @@ For diagnostics the main tools (comparing before, after applying weights, and th
 
 You are welcome to:
 
-* Learn more in the [*balance*](https://import-balance.org/) website.
-* Ask for help on: https://github.com/facebookresearch/balance/issues/new?template=support_question.md
-* Submit bug-reports and features' suggestions at: https://github.com/facebookresearch/balance/issues
-* Send a pull request on: https://github.com/facebookresearch/balance. See the [CONTRIBUTING](https://github.com/facebookresearch/balance/blob/main/CONTRIBUTING.md) file for how to help out. And our [CODE OF CONDUCT](https://github.com/facebookresearch/balance/blob/main/LICENSE-DOCUMENTATION) for our expectations from contributors.
+- Learn more in the [_balance_](https://import-balance.org/) website.
+- Ask for help on:
+  https://github.com/facebookresearch/balance/issues/new?template=support_question.md
+- Submit bug-reports and features' suggestions at:
+  https://github.com/facebookresearch/balance/issues
+- Send a pull request on: https://github.com/facebookresearch/balance. See the
+  [CONTRIBUTING](https://github.com/facebookresearch/balance/blob/main/CONTRIBUTING.md)
+  file for how to help out. And our
+  [CODE OF CONDUCT](https://github.com/facebookresearch/balance/blob/main/LICENSE-DOCUMENTATION)
+  for our expectations from contributors.
 
-## Citing *balance*
-Sarig, T., Galili, T., & Eilat, R. (2023). balance – a Python package for balancing biased data samples. [https://arxiv.org/abs/2307.06024](https://arxiv.org/abs/2307.06024)
+## Citing _balance_
+
+Sarig, T., Galili, T., & Eilat, R. (2023). balance – a Python package for
+balancing biased data samples.
+[https://arxiv.org/abs/2307.06024](https://arxiv.org/abs/2307.06024)
 
 ```bibtex
 @misc{sarig2023balance,
@@ -256,21 +325,48 @@ Sarig, T., Galili, T., & Eilat, R. (2023). balance – a Python package for bala
 ```
 
 ## License
-The *balance* package is licensed under the [MIT license](https://github.com/facebookresearch/balance/blob/main/LICENSE), and all the documentation on the site (including text and images) is under [CC-BY](https://github.com/facebookresearch/balance/blob/main/LICENSE-DOCUMENTATION).
+
+The _balance_ package is licensed under the
+[MIT license](https://github.com/facebookresearch/balance/blob/main/LICENSE),
+and all the documentation on the site (including text and images) is under
+[CC-BY](https://github.com/facebookresearch/balance/blob/main/LICENSE-DOCUMENTATION).
 
 # News
 
 You can follow updates on our:
-* [Blog](https://import-balance.org/blog/)
-* [Changelog](https://github.com/facebookresearch/balance/blob/main/CHANGELOG.md)
+
+- [Blog](https://import-balance.org/blog/)
+- [Changelog](https://github.com/facebookresearch/balance/blob/main/CHANGELOG.md)
 
 ## Acknowledgements / People
 
-The *balance* package is actively maintained by people from the [Central Applied Science](https://research.facebook.com/teams/central-applied-science/) team (in
-Menlo Park and Tel Aviv), by [Wesley Lee](https://www.linkedin.com/in/wesley-lee), [Tal Sarig](https://research.facebook.com/people/sarig-tal/), and [Tal Galili](https://research.facebook.com/people/galili-tal/).
+The _balance_ package is actively maintained by people from the
+[Central Applied Science](https://research.facebook.com/teams/central-applied-science/)
+team (in Menlo Park and Tel Aviv), by
+[Wesley Lee](https://www.linkedin.com/in/wesley-lee),
+[Tal Sarig](https://research.facebook.com/people/sarig-tal/), and
+[Tal Galili](https://research.facebook.com/people/galili-tal/).
 
-The *balance* package was (and is) developed by many people, including: [Roee Eilat](https://research.facebook.com/people/eilat-roee/), [Tal Galili](https://research.facebook.com/people/galili-tal/), [Daniel Haimovich](https://research.facebook.com/people/haimovich-daniel/), [Kevin Liou](https://www.linkedin.com/in/kevinycliou), [Steve Mandala](https://research.facebook.com/people/mandala-steve/), [Adam Obeng](https://adamobeng.com/) (author of the initial internal Meta version), [Tal Sarig](https://research.facebook.com/people/sarig-tal/),  [Luke Sonnet](https://www.linkedin.com/in/luke-sonnet), [Sean Taylor](https://seanjtaylor.com), [Barak Yair Reif](https://www.linkedin.com/in/barak-yair-reif-2154365/), and others. If you worked on balance in the past, please email us to be added to this list.
+The _balance_ package was (and is) developed by many people, including:
+[Roee Eilat](https://research.facebook.com/people/eilat-roee/),
+[Tal Galili](https://research.facebook.com/people/galili-tal/),
+[Daniel Haimovich](https://research.facebook.com/people/haimovich-daniel/),
+[Kevin Liou](https://www.linkedin.com/in/kevinycliou),
+[Steve Mandala](https://research.facebook.com/people/mandala-steve/),
+[Adam Obeng](https://adamobeng.com/) (author of the initial internal Meta
+version), [Tal Sarig](https://research.facebook.com/people/sarig-tal/),
+[Luke Sonnet](https://www.linkedin.com/in/luke-sonnet),
+[Sean Taylor](https://seanjtaylor.com),
+[Barak Yair Reif](https://www.linkedin.com/in/barak-yair-reif-2154365/),
+[Soumyadip Sarkar](https://github.com/neuralsorcerer), and others. If you worked
+on balance in the past, please email us to be added to this list.
 
-The *balance* package was open-sourced by [Tal Sarig](https://research.facebook.com/people/sarig-tal/), [Tal Galili](https://research.facebook.com/people/galili-tal/) and [Steve Mandala](https://research.facebook.com/people/mandala-steve/) in late 2022.
+The _balance_ package was open-sourced by
+[Tal Sarig](https://research.facebook.com/people/sarig-tal/),
+[Tal Galili](https://research.facebook.com/people/galili-tal/) and
+[Steve Mandala](https://research.facebook.com/people/mandala-steve/) in
+late 2022.
 
-Branding created by [Dana Beaty](https://www.danabeaty.com/), from the Meta AI Design and Marketing Team. For logo files, see [here](https://github.com/facebookresearch/balance/tree/main/website/static/img/).
+Branding created by [Dana Beaty](https://www.danabeaty.com/), from the Meta AI
+Design and Marketing Team. For logo files, see
+[here](https://github.com/facebookresearch/balance/tree/main/website/static/img/).

--- a/balance/__init__.py
+++ b/balance/__init__.py
@@ -19,7 +19,7 @@ from balance.sample_class import Sample  # noqa
 from balance.util import TruncationFormatter  # noqa
 
 global __version__
-__version__ = "0.13.x"
+__version__ = "0.14.0"
 
 WELCOME_MESSAGE = f"""
 balance (Version {__version__}) loaded:


### PR DESCRIPTION
Summary:
Prepares balance and graviton packages for the 0.14.0 release:

- Updates version strings from 0.13.x to 0.14.0 in both `balance/__init__.py` and `graviton/__init__.py`
- Adds placeholder for upcoming 0.15.x release in CHANGELOG.md
- Condenses the 0.14.0 changelog entry (~120 lines → ~55 lines) to match the concise style of previous release notes while preserving all key information (features, bug fixes, breaking changes, and PR/issue links)

Differential Revision: D89120978


