### PR TITLE
Improve CBPS logit stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > TODO: update to final version
 
+## Bug Fixes
+
+- **Numerically stable CBPS probabilities**
+  - The CBPS helper now uses a stable logistic transform to avoid exponential
+    overflow warnings during probability computation in constraint checks.
+
 # 0.14.0 (2025-12-14)
 
 ## New Features

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 
 </div>
 
-> [!NOTE] _balance_ is currently **in beta** and is actively supported. Follow
-> us [on github](https://github.com/facebookresearch/balance).
+> [!NOTE] 
+> _balance_ is currently **in beta** and is actively supported. Follow us [on github](https://github.com/facebookresearch/balance).
 
 ## What is _balance_?
 

--- a/balance/weighting_methods/cbps.py
+++ b/balance/weighting_methods/cbps.py
@@ -27,6 +27,7 @@ import statsmodels.api as sm
 from balance import adjustment as balance_adjustment, util as balance_util
 from balance.stats_and_plots.weights_stats import design_effect
 from scipy.sparse import csc_matrix
+from scipy.special import expit
 
 logger: logging.Logger = logging.getLogger(__package__)
 
@@ -48,7 +49,7 @@ def logit_truncated(
     Returns:
         np.ndarray: numpy array of computed probablities
     """
-    probs = 1.0 / (1 + np.exp(-1 * (np.matmul(X, beta))))
+    probs = expit(np.matmul(X, beta))
     return np.minimum(np.maximum(probs, truncation_value), 1 - truncation_value)
 
 


### PR DESCRIPTION
- Swapped the CBPS logit probability computation to use the numerically stable `expit` helper, preventing overflow warnings during constraint evaluation.
- Updated **NOTE** format to display properly in markdown.

Why?
```bash
=============================== warnings summary ===============================
tests/test_cbps.py::Testcbps::test_cbps_constraints
tests/test_cbps.py::Testcbps::test_cbps_constraints
  /Users/runner/work/balance/balance/balance/weighting_methods/cbps.py:51: RuntimeWarning:
  
  overflow encountered in exp
```