### PR TITLE
Add Pyre type checking to GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,6 +55,33 @@ jobs:
       run: |
         ufmt check .
 
+  pyre:
+    # NOTE: .pyre_configuration.external has "ignore_all_errors" for tests/ - this is intentional.
+    # Meta's internal Pyre uses python/typeshed_experimental with permissive pandas stubs
+    # (Axes = ... | list | tuple), but external pyre-check-nightly uses stricter typeshed
+    # stubs that reject tuple/list for DataFrame index/columns. This causes ~85 false-positive
+    # errors in tests that don't occur internally. The main library code (balance/) is still
+    # fully type-checked.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install project dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Install Pyre nightly
+        run: |
+          pip install pyre-check-nightly==0.0.101750936314
+      - name: Pyre type check
+        run: |
+          cp .pyre_configuration.external .pyre_configuration
+          pyre --noninteractive check
+
   test-deploy-website:
     name: Test website build
     runs-on: ubuntu-latest

--- a/.pyre_configuration.external
+++ b/.pyre_configuration.external
@@ -1,0 +1,19 @@
+{
+  "exclude": [
+    "^.*/\\.venv/.*$",
+    "^.*/build/.*$",
+    "^.*/sphinx/.*$",
+    "^.*/website/.*$",
+    "^.*/benchmarks/.*$",
+    "^.*/tutorials/.*$"
+  ],
+  "ignore_all_errors": [
+    "tests/"
+  ],
+  "site_package_search_strategy": "all",
+  "source_directories": [
+    "."
+  ],
+  "strict": false,
+  "version": "0.0.101750936314"
+}


### PR DESCRIPTION
Summary:
This diff adds Pyre type checking to the balance open source project's GitHub Actions CI workflow.

The motivation is to ensure Pyre checks in GitHub Actions match the results from Sandcastle and VS Code within Meta, eliminating false positives/negatives due to configuration or dependency differences.

Changes include:
1. Added `.pyre_configuration.external` with the appropriate settings for external use:
   - `site_package_search_strategy: "all"` to find installed dependencies
   - `strict: false` for easier migration
   - Pinned to nightly version `0.0.101750936314`
   - Exclusions for `.venv`, `build`, `sphinx`, `website`, `benchmarks`, and `tutorials` directories

2. Updated `build-and-test.yml` workflow to add a new `pyre` job that:
   - Uses Python 3.11
   - Installs project dependencies first (before Pyre)
   - Installs the pinned pyre-check-nightly version
   - Runs Pyre type checking in non-interactive mode

Differential Revision: D90319075


