### PR TITLE
Fix GitHub Actions coverage badge workflow git operations

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,12 +59,18 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-          # Fetch the badges branch or create it as an orphan
-          git fetch origin badges:badges 2>/dev/null || git checkout --orphan badges
-          git checkout badges
+          # Always start fresh with orphan branch
+          git checkout --orphan badges-temp
+          git rm -rf . 2>/dev/null || true
 
           # Create badge directory and file
           mkdir -p .github/badges
+          cat > README.md << 'EOF'
+          # Coverage Badges
+
+          This branch stores dynamically generated coverage badges.
+          EOF
+
           python -c "
           import os, json
           coverage = float(os.environ['COVERAGE'])
@@ -74,6 +80,6 @@ jobs:
               json.dump(badge, f)
           "
 
-          git add .github/badges/coverage.json
-          git diff --staged --quiet || git commit -m "Update coverage badge [skip ci]"
-          git push origin badges
+          git add .
+          git commit -m "Update coverage badge to ${COVERAGE}% [skip ci]"
+          git push -f origin badges-temp:badges


### PR DESCRIPTION
Summary:
The coverage badge workflow was failing in GitHub Actions when the remote `badges` branch didn't exist. The flawed conditional logic would create an orphan branch but then fail on the subsequent checkout.

This fix uses an idempotent approach that always creates a fresh orphan branch and force-pushes to the remote, avoiding racy conditional checks and working reliably whether the remote branch exists or not.

Differential Revision: D90937254


