### PR TITLE
Fix test pollution from global high-cardinality threshold state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,40 @@
 
 """Test configuration shared across pytest runs"""
 
+import os
+from typing import Iterator
+
 import matplotlib
 
 # Force a non-interactive backend so tests do not require a Tk installation.
 matplotlib.use("Agg", force=True)
+
+import balance.utils.pandas_utils as pandas_utils  # noqa: E402
+import pytest  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset_high_cardinality_threshold() -> Iterator[None]:
+    """Reset high-cardinality threshold global state before each test.
+
+    This prevents test pollution when tests modify the global threshold
+    configuration via set_high_cardinality_ratio_threshold() or the
+    BALANCE_HIGH_CARDINALITY_RATIO_THRESHOLD environment variable.
+    """
+    env_key = "BALANCE_HIGH_CARDINALITY_RATIO_THRESHOLD"
+    original_env = os.environ.get(env_key)
+
+    # Reset to clean state before test
+    pandas_utils.set_high_cardinality_ratio_threshold(None)
+    pandas_utils._warned_invalid_high_cardinality_env = False
+    os.environ.pop(env_key, None)
+
+    yield
+
+    # Restore original state after test
+    pandas_utils.set_high_cardinality_ratio_threshold(None)
+    pandas_utils._warned_invalid_high_cardinality_env = False
+    if original_env is None:
+        os.environ.pop(env_key, None)
+    else:
+        os.environ[env_key] = original_env


### PR DESCRIPTION
Summary:
D91132003 introduced global state for the high-cardinality threshold configuration that was causing test pollution on GitHub CI. Tests would pass locally but fail when run in parallel or different order because the global state from one test could affect another.

Added a pytest autouse fixture to reset the threshold configuration and environment variable before and after each test, ensuring test isolation.

Differential Revision: D91198668


