### PR TITLE
Use categorical covariates for distribution metrics (#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 - **Formula support for BalanceDF model matrices**
   - `BalanceDF.model_matrix()` now accepts a `formula` argument to build
     custom model matrices without precomputing them manually.
+- **Categorical distribution metrics without one-hot encoding**
+  - KLD/EMD/CVMD/KS on `BalanceDF.covars()` now operate on raw categorical variables
+    (with NA indicators) instead of one-hot encoded columns.
 
 ## Bug Fixes
 

--- a/balance/util.py
+++ b/balance/util.py
@@ -11,6 +11,7 @@ import logging
 
 from balance.utils.data_transformation import (
     add_na_indicator,
+    add_na_indicator_to_combined,
     auto_aggregate,
     auto_spread,
     drop_na_rows,
@@ -97,6 +98,7 @@ __all__ = [
     "_assert_type",
     "_warn_of_df_dtypes_change",
     "add_na_indicator",
+    "add_na_indicator_to_combined",
     "auto_aggregate",
     "auto_spread",
     "build_model_matrix",

--- a/tests/test_stats_and_plots.py
+++ b/tests/test_stats_and_plots.py
@@ -2213,6 +2213,21 @@ class TestKLDivergence(balance.testutil.BalanceTestCase):
         # Allow some tolerance for numerical computation
         self.assertAlmostEqual(kld_result["category"], abs(expected_kld), places=2)
 
+    def test_kld_warns_on_column_mismatch(self) -> None:
+        from balance.stats_and_plots import weighted_comparisons_stats
+
+        sample_df = pd.DataFrame({"category": ["A", "B", "C"]})
+        target_df = pd.DataFrame({"group": ["A", "B", "C"]})
+
+        with self.assertLogs(
+            weighted_comparisons_stats.logger, level="WARNING"
+        ) as logs:
+            weighted_comparisons_stats.kld(sample_df, target_df)
+
+        self.assertTrue(
+            any("must have the same column names" in message for message in logs.output)
+        )
+
     def test_kld_with_numeric_continuous_data(self) -> None:
         """Test KLD calculation with continuous numeric data.
 

--- a/tutorials/balance_quickstart.ipynb
+++ b/tutorials/balance_quickstart.ipynb
@@ -426,9 +426,9 @@
     "\n",
     "- **EMD (Earth Mover's Distance)** measures the minimum \"cost\" to transform one distribution into another.\n",
     "  (See: https://en.wikipedia.org/wiki/Earth_mover%27s_distance)\n",
-    "- **CVMD (Cram\u00e9r\u2013von Mises distance)** measures the integrated squared difference between the empirical CDFs.\n",
+    "- **CVMD (Cramér–von Mises distance)** measures the integrated squared difference between the empirical CDFs.\n",
     "  (See: https://en.wikipedia.org/wiki/Cram%C3%A9r%E2%80%93von_Mises_criterion)\n",
-    "- **KS (Kolmogorov\u2013Smirnov distance)** measures the maximum absolute difference between the empirical CDFs.\n",
+    "- **KS (Kolmogorov–Smirnov distance)** measures the maximum absolute difference between the empirical CDFs.\n",
     "  (See: https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test)\n",
     "\n",
     "These diagnostics complement **ASMD**, which only compares means. Use EMD/CVMD/KS when you want to check whether weighting aligns the *shape* of covariate distributions (not just their means).\n"
@@ -443,6 +443,86 @@
     "print(sample_with_target.covars().emd().T)\n",
     "print(sample_with_target.covars().cvmd().T)\n",
     "print(sample_with_target.covars().ks().T)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Diagnostics with and without a model matrix\n",
+    "\n",
+    "Distribution diagnostics use raw covariates by default (so categorical variables stay intact).\n",
+    "If you want to compare the **model-matrix** representation instead (e.g., to inspect\n",
+    "how one-hot encoded columns behave), you can build model matrices explicitly and\n",
+    "call the diagnostics on those matrices.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from balance.stats_and_plots import weighted_comparisons_stats\n",
+    "from balance.utils.model_matrix import model_matrix\n",
+    "\n",
+    "sample_covars = sample_with_target.covars()\n",
+    "target_covars = target.covars()\n",
+    "sample_weights = sample_with_target.weights().df.iloc[:, 0]\n",
+    "target_weights = target.weights().df.iloc[:, 0]\n",
+    "\n",
+    "# Raw-covariate diagnostics (default)\n",
+    "print(sample_covars.kld().T)\n",
+    "\n",
+    "# Model-matrix diagnostics (explicit, aligned across sample/target)\n",
+    "model_matrix_output = model_matrix(\n",
+    "    sample_covars.df,\n",
+    "    target_covars.df,\n",
+    "    sample_covars.df.columns.tolist(),\n",
+    "    return_type=\"two\",\n",
+    "    return_var_type=\"dataframe\",\n",
+    ")\n",
+    "sample_mm = model_matrix_output[\"sample\"]\n",
+    "target_mm = model_matrix_output[\"target\"]\n",
+    "kld_mm = weighted_comparisons_stats.kld(\n",
+    "    sample_mm,\n",
+    "    target_mm,\n",
+    "    sample_weights,\n",
+    "    target_weights,\n",
+    ")\n",
+    "print(kld_mm)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example: interaction term without using a model matrix\n",
+    "\n",
+    "If you want an interaction between two categorical variables without building\n",
+    "a full model matrix, you can create a combined category manually and use it\n",
+    "in diagnostics. For example, combine an age bucket with gender:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_df = sample_covars.df.copy()\n",
+    "target_df = target_covars.df.copy()\n",
+    "\n",
+    "sample_df['age_gender'] = sample_df['age_group'].astype(str) + ':' + sample_df['gender'].astype(str)\n",
+    "target_df['age_gender'] = target_df['age_group'].astype(str) + ':' + target_df['gender'].astype(str)\n",
+    "\n",
+    "interaction_kld = weighted_comparisons_stats.kld(\n",
+    "    sample_df[['age_gender']],\n",
+    "    target_df[['age_gender']],\n",
+    "    sample_weights,\n",
+    "    target_weights,\n",
+    ")\n",
+    "print(interaction_kld)\n"
    ]
   },
   {


### PR DESCRIPTION
Summary:
- Updated BalanceDF comparison helpers to allow raw covariate frames with NA indicators, and used them for KLD/EMD/CVMD/KS so categorical variables aren’t one-hot encoded in distribution metrics.
- Closes https://github.com/facebookresearch/balance/issues/306


Differential Revision: D92535792

Pulled By: talgalili


