### PR TITLE
Use variance-share rule for large-target warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
     `weighted_median_breakdown_point` now explicitly normalize DataFrame inputs
     to their first column before computation, matching validation behavior and
     returning scalar/Series outputs consistently.
+- **Large-target warning now uses variance contribution instead of fixed row-count cutoffs**
+  - `Sample.adjust()` now warns based on the target's estimated share of two-sample 1/n variance (<=5%) rather than hard-coded row thresholds.
+  - This yields a principled warning criterion tied directly to inferential impact and removes dependence on arbitrary absolute counts.
 
 ## Tests
 

--- a/balance/sample_class.py
+++ b/balance/sample_class.py
@@ -31,6 +31,38 @@ from IPython.lib.display import FileLink
 
 logger: logging.Logger = logging.getLogger(__package__)
 
+# The target's 1/n contribution to total variance is considered negligible
+# once it is at most 5% of the two-sample 1/n variance decomposition.
+NEGLIGIBLE_TARGET_VARIANCE_FRACTION: float = 0.05
+
+
+def _target_variance_component_fraction(sample_n: int, target_n: int) -> float:
+    """Return the fraction of total 1/n variance contributed by the target.
+
+    For two independent samples, standard error often scales with
+    ``1 / n_sample + 1 / n_target``. This helper reports the target's share of
+    that quantity:
+
+    ``(1 / n_target) / (1 / n_sample + 1 / n_target)``.
+
+    Args:
+        sample_n: Number of rows in the sample.
+        target_n: Number of rows in the target.
+
+    Returns:
+        float: Target's variance share in ``[0, 1]``. Returns ``0.0`` for
+            non-positive target sizes and ``1.0`` when sample size is
+            non-positive while target size is positive.
+    """
+    if target_n <= 0:
+        return 0.0
+    if sample_n <= 0:
+        return 1.0
+
+    inv_sample = 1.0 / float(sample_n)
+    inv_target = 1.0 / float(target_n)
+    return inv_target / (inv_sample + inv_target)
+
 
 def _concat_metric_val_var(
     diagnostics: pd.DataFrame,
@@ -1012,21 +1044,24 @@ class Sample:
 
         num_rows_sample = sample_covars_df.shape[0]
         num_rows_target = target_covars_df.shape[0]
+        target_variance_fraction = _target_variance_component_fraction(
+            num_rows_sample, num_rows_target
+        )
         if (
             num_rows_sample > 0
-            # TODO: the values of 100_000 and 10 are arbitrary,
-            #       and should be replaced with a more principled approach (in the far future)
-            and num_rows_target > 100_000
-            and num_rows_target >= 10 * num_rows_sample
+            and num_rows_target > num_rows_sample
+            and target_variance_fraction <= NEGLIGIBLE_TARGET_VARIANCE_FRACTION
         ):
             logger.warning(
                 "Large target detected: %s target rows vs %s sample rows. "
-                "When the target is much larger than the sample (here >10x and >100k rows), "
-                "the target's contribution to variance becomes negligible. "
+                "When the target is much larger than the sample, "
+                "the target's contribution to variance becomes negligible "
+                "(estimated %.2f%% of 1/n variance). "
                 "Standard errors will be driven almost entirely by the sample, "
                 "similar to a one-sample inference setting.",
                 num_rows_target,
                 num_rows_sample,
+                100.0 * target_variance_fraction,
             )
 
         sample_high_card = _detect_high_cardinality_features(sample_covars_df)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -31,7 +31,11 @@ import balance.testutil
 import IPython.display
 import numpy as np
 import pandas as pd
-from balance.sample_class import Sample
+from balance.sample_class import (
+    _target_variance_component_fraction,
+    NEGLIGIBLE_TARGET_VARIANCE_FRACTION,
+    Sample,
+)
 from balance.testutil import tempfile_path
 from balance.util import _assert_type
 
@@ -1847,6 +1851,25 @@ class TestSample_high_cardinality_warnings(balance.testutil.BalanceTestCase):
         )
 
 
+class TestTargetVarianceComponentFraction(balance.testutil.BalanceTestCase):
+    def test_zero_target_rows_returns_zero(self) -> None:
+        self.assertEqual(_target_variance_component_fraction(10, 0), 0.0)
+
+    def test_non_positive_sample_rows_with_positive_target_returns_one(self) -> None:
+        self.assertEqual(_target_variance_component_fraction(0, 10), 1.0)
+        self.assertEqual(_target_variance_component_fraction(-3, 10), 1.0)
+
+    def test_formula_matches_closed_form(self) -> None:
+        sample_n = 1000
+        target_n = 19_000
+        expected = sample_n / (sample_n + target_n)
+        self.assertAlmostEqual(
+            _target_variance_component_fraction(sample_n, target_n),
+            expected,
+        )
+        self.assertAlmostEqual(expected, NEGLIGIBLE_TARGET_VARIANCE_FRACTION)
+
+
 class TestSample_large_target_warning(balance.testutil.BalanceTestCase):
     @staticmethod
     def _build_frame(prefix: str, rows: int) -> pd.DataFrame:
@@ -1891,7 +1914,7 @@ class TestSample_large_target_warning(balance.testutil.BalanceTestCase):
 
         self.assertTrue(any("Large target detected" in log for log in logs))
 
-    def test_no_warning_when_target_not_large_enough(self) -> None:
+    def test_warns_when_target_variance_share_is_negligible(self) -> None:
         sample_df = self._build_frame("s", 1000)
         target_df = self._build_frame("t", 100_000)
 
@@ -1902,9 +1925,9 @@ class TestSample_large_target_warning(balance.testutil.BalanceTestCase):
             lambda: _assert_type(sample.adjust(target, method="null"))
         )
 
-        self.assertFalse(any("Large target detected" in log for log in logs))
+        self.assertTrue(any("Large target detected" in log for log in logs))
 
-    def test_warns_at_exact_ten_to_one_ratio(self) -> None:
+    def test_no_warning_when_target_share_is_not_negligible(self) -> None:
         sample_df = self._build_frame("s", 10_000)
         target_df = self._build_frame("t", 100_001)
 
@@ -1915,9 +1938,22 @@ class TestSample_large_target_warning(balance.testutil.BalanceTestCase):
             lambda: _assert_type(sample.adjust(target, method="null"))
         )
 
+        self.assertFalse(any("Large target detected" in log for log in logs))
+
+    def test_warns_at_negligible_variance_boundary(self) -> None:
+        sample_df = self._build_frame("s", 1_000)
+        target_df = self._build_frame("t", 19_000)
+
+        sample = Sample.from_frame(sample_df, id_column="id", weight_column="weight")
+        target = Sample.from_frame(target_df, id_column="id", weight_column="weight")
+
+        logs = self._collect_warnings(
+            lambda: _assert_type(sample.adjust(target, method="null"))
+        )
+
         self.assertTrue(any("Large target detected" in log for log in logs))
 
-    def test_no_warning_when_target_under_ten_to_one_ratio(self) -> None:
+    def test_no_warning_when_target_variance_share_exceeds_threshold(self) -> None:
         sample_df = self._build_frame("s", 10_001)
         target_df = self._build_frame("t", 100_001)
 
@@ -1946,6 +1982,47 @@ class TestSample_large_target_warning(balance.testutil.BalanceTestCase):
     def test_no_warning_when_sample_empty(self) -> None:
         sample_df = self._build_frame("s", 0)
         target_df = self._build_frame("t", 100_001)
+
+        sample = Sample.from_frame(sample_df, id_column="id", weight_column="weight")
+        target = Sample.from_frame(target_df, id_column="id", weight_column="weight")
+
+        logs = self._collect_warnings(
+            lambda: _assert_type(sample.adjust(target, method="null"))
+        )
+
+        self.assertFalse(any("Large target detected" in log for log in logs))
+
+    def test_no_warning_just_below_negligible_variance_boundary(self) -> None:
+        sample_df = self._build_frame("s", 1_000)
+        target_df = self._build_frame("t", 18_999)
+
+        sample = Sample.from_frame(sample_df, id_column="id", weight_column="weight")
+        target = Sample.from_frame(target_df, id_column="id", weight_column="weight")
+
+        logs = self._collect_warnings(
+            lambda: _assert_type(sample.adjust(target, method="null"))
+        )
+
+        self.assertFalse(any("Large target detected" in log for log in logs))
+
+    def test_warning_reports_estimated_variance_share(self) -> None:
+        sample_df = self._build_frame("s", 1_000)
+        target_df = self._build_frame("t", 19_000)
+
+        sample = Sample.from_frame(sample_df, id_column="id", weight_column="weight")
+        target = Sample.from_frame(target_df, id_column="id", weight_column="weight")
+
+        logs = self._collect_warnings(
+            lambda: _assert_type(sample.adjust(target, method="null"))
+        )
+
+        large_target_logs = [log for log in logs if "Large target detected" in log]
+        self.assertTrue(large_target_logs)
+        self.assertIn("estimated 5.00% of 1/n variance", large_target_logs[0])
+
+    def test_no_warning_when_target_is_empty(self) -> None:
+        sample_df = self._build_frame("s", 100)
+        target_df = self._build_frame("t", 0)
 
         sample = Sample.from_frame(sample_df, id_column="id", weight_column="weight")
         target = Sample.from_frame(target_df, id_column="id", weight_column="weight")


### PR DESCRIPTION
Replaced the arbitrary large-target warning heuristic in `Sample.adjust()` with a principled variance-share rule:
 - Added `NEGLIGIBLE_TARGET_VARIANCE_FRACTION = 0.05`.
 - Added `_target_variance_component_fraction(sample_n, target_n)` to compute the target’s share of the two-sample `1/n` variance term.
 - Updated warning trigger logic to fire when target variance contribution is negligible (<=5%) instead of fixed `>100k` and `>=10x` cutoffs.
 - Updated the warning text to report the estimated target variance share percentage.