### PR TITLE
Add ASCII text plotting for LLM-friendly distribution comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,25 @@
   - Columns that are explicitly mentioned — the id column, weight column,
     covariate columns, and outcome columns — are **not** ignored.
 
+## New Features
+
+- **ASCII comparative histogram (`ascii_comparative_hist`)**
+  - Added a new plot function that compares multiple distributions against a
+    baseline using inline visual indicators: `█` for shared mass, `▒` for excess,
+    and `]` for deficit relative to the baseline. Uses visually distinct fill
+    characters (`█`, `▒`, `▐`, `░`) for better readability when comparing
+    multiple datasets.
+
 ## Documentation
 
+- **ASCII plot docstring examples and `library="balance"` docs**
+  - Added rendered text-plot examples to `ascii_plot_bar`, `ascii_plot_hist`,
+    and `ascii_plot_dist` docstrings. Documented that `library="balance"` only
+    supports `dist_type="hist_ascii"` in `plot_dist()` and `BalanceDF.plot()`.
+- **Updated quickstart tutorial with ASCII plot examples**
+  - Added cells to `balance_quickstart.ipynb` showing adjusted vs unadjusted
+    ASCII plots, including numeric variable histograms and comparative
+    histograms.
 - **Improved `keep_columns` documentation**
   - Updated docstrings for `has_keep_columns()`, `keep_columns()`, and the
     `--keep_columns` argument to clarify that keep columns control which columns
@@ -28,6 +45,10 @@
 
 ## Tests
 
+- **Added end-to-end adjustment test with ASCII plot output**
+  - `TestAsciiPlotsAdjustmentEndToEnd` runs the full `Sample.from_frame()` →
+    `set_target()` → `adjust()` → `covars().plot(library="balance")` pipeline
+    and asserts exact expected ASCII output.
 - **Expanded warning coverage for `Sample.from_frame()` ID inference**
   - Added assertions that validate all three expected warnings are emitted when inferring an `id` column and default weights, including ID guessing, ID string casting, and automatic weight creation.
 - **Added focused unit coverage for IPW helpers**

--- a/balance/balancedf_class.py
+++ b/balance/balancedf_class.py
@@ -618,11 +618,13 @@ class BalanceDF:
         self: "BalanceDF",
         on_linked_samples: bool = True,
         **kwargs: Any,
-    ) -> list[Any] | npt.NDArray[Any] | dict[str, Figure] | None:
+    ) -> list[Any] | npt.NDArray[Any] | dict[str, Figure] | str | None:
         """Plots the variables in the df of the BalanceDF object.
 
         See :func:`weighted_comparisons_plots.plot_dist` for details of various arguments that can be passed.
-        The default plotting engine is plotly, but seaborn can be used for static plots.
+        The default plotting engine is plotly, but seaborn can be used for static plots, or "balance"
+        can be used for ASCII text output suitable for LLM consumption (only dist_type="hist_ascii" is supported
+        with library="balance").
 
         This function is inherited as is when invoking BalanceDFCovars.plot, but some modifications are made when
         preparing the data for BalanceDFOutcomes.plot and BalanceDFWeights.plot.
@@ -634,9 +636,10 @@ class BalanceDF:
             **kwargs: passed to :func:`weighted_comparisons_plots.plot_dist`.
 
         Returns:
-            Union[Union[List, np.ndarray], Dict[str, Figure], None]:
+            Union[Union[List, np.ndarray], Dict[str, Figure], str, None]:
                 If library="plotly" then returns a dictionary containing plots if return_dict_of_figures is True. None otherwise.
                 If library="seaborn" then returns None, unless return_axes is True. Then either a list or an np.array of matplotlib axis.
+                If library="balance" then returns a string with the ASCII text output.
 
         Examples:
         .. code-block:: python
@@ -680,6 +683,9 @@ class BalanceDF:
 
                 # Returning plotly qq plots:
                 s3_null.covars().plot(dist_type = "qq")
+
+                # ASCII text output (suitable for LLM consumption):
+                s3_null.covars().plot(library = "balance", dist_type = "hist_ascii")
         """
         if on_linked_samples:
             dfs_to_add = self._BalanceDF_child_from_linked_samples()
@@ -2522,7 +2528,7 @@ class BalanceDFWeights(BalanceDF):
     # TODO: maybe add better control if there are no weights for unadjusted or target (the current default shows them in the legend, but not in the figure)
     def plot(
         self: "BalanceDFWeights", on_linked_samples: bool = True, **kwargs: Any
-    ) -> list[Any] | npt.NDArray[Any] | dict[str, Figure] | None:
+    ) -> list[Any] | npt.NDArray[Any] | dict[str, Figure] | str | None:
         """Plots kde (kernal density estimation) of the weights in a BalanceDFWeights object using seaborn (as default).
 
         It's possible to use other plots using dist_type with arguments such as "hist", "kde" (default), "qq", and "ecdf".

--- a/balance/stats_and_plots/ascii_plots.py
+++ b/balance/stats_and_plots/ascii_plots.py
@@ -1,0 +1,703 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from balance.stats_and_plots.weighted_comparisons_plots import (
+    DataFrameWithWeight,
+    naming_legend,
+)
+from balance.stats_and_plots.weighted_stats import relative_frequency_table
+from balance.stats_and_plots.weights_stats import _check_weights_are_valid
+from balance.util import choose_variables, rm_mutual_nas
+
+logger: logging.Logger = logging.getLogger(__package__)
+
+# Characters used to distinguish datasets in ASCII bars.
+# Each dataset gets a unique character from this list.
+BAR_CHARS: List[str] = ["█", "▒", "▐", "░", "▄", "▀"]
+
+
+def _weighted_histogram(
+    values: pd.Series,
+    weights: Optional[pd.Series],
+    bin_edges: npt.NDArray[np.floating],
+) -> npt.NDArray[np.floating]:
+    """Computes a weighted histogram and normalizes counts to proportions.
+
+    Args:
+        values: The numeric data values.
+        weights: Optional weights. If None, uniform weights are used.
+        bin_edges: Pre-computed bin edges (length n_bins + 1).
+
+    Returns:
+        Array of proportions for each bin (sums to 1.0, or all zeros if empty).
+    """
+    _check_weights_are_valid(weights)
+    weights_arr: Optional[npt.NDArray[np.floating]] = None
+    if weights is not None:
+        weights_arr = np.asarray(weights, dtype=float)
+    counts, _ = np.histogram(values, bins=bin_edges, weights=weights_arr)
+    total = counts.sum()
+    if total > 0:
+        return counts / total
+    return np.zeros_like(counts, dtype=float)
+
+
+def _render_horizontal_bars(
+    label: str,
+    proportions: Dict[str, float],
+    legend_names: List[str],
+    bar_width: int,
+    max_value: float,
+    label_width: int,
+) -> str:
+    """Renders a group of horizontal bars for one category or bin.
+
+    Each dataset gets its own line with a distinct character and a percentage
+    label at the end.
+
+    Args:
+        label: The category label or bin range string.
+        proportions: Dict mapping dataset legend name to its proportion value.
+        legend_names: Ordered list of legend names for consistent ordering.
+        bar_width: Maximum character width of the longest bar.
+        max_value: The maximum proportion value across all bars (used for scaling).
+        label_width: Character width reserved for the label column.
+
+    Returns:
+        Multi-line string of the grouped bars for this label.
+    """
+    lines: List[str] = []
+    for i, name in enumerate(legend_names):
+        prop = proportions.get(name, 0.0)
+        char = BAR_CHARS[i % len(BAR_CHARS)]
+        if max_value > 0:
+            bar_len = int(round((prop / max_value) * bar_width))
+        else:
+            bar_len = 0
+        bar = char * bar_len
+        if i == 0:
+            prefix = label.ljust(label_width)
+        else:
+            prefix = " " * label_width
+        lines.append(f"{prefix} | {bar} ({prop:.1%})")
+    return "\n".join(lines)
+
+
+def _build_legend(legend_names: List[str]) -> str:
+    """Builds a legend string mapping characters to dataset names.
+
+    Args:
+        legend_names: Ordered list of dataset legend names.
+
+    Returns:
+        A two-line legend string: the first line maps bar characters to
+        dataset names; the second explains how to interpret bar lengths.
+    """
+    parts: List[str] = []
+    for i, name in enumerate(legend_names):
+        char = BAR_CHARS[i % len(BAR_CHARS)]
+        parts.append(f"{char} {name}")
+    return (
+        "Legend: "
+        + "  ".join(parts)
+        + "\nBar lengths are proportional to weighted frequency within each dataset."
+    )
+
+
+def ascii_plot_bar(
+    dfs: List[DataFrameWithWeight],
+    names: List[str],
+    column: str,
+    weighted: bool = True,
+    bar_width: int = 40,
+    dist_type: Optional[str] = None,
+) -> str:
+    """Produces an ASCII grouped barplot for a single categorical variable.
+
+    Uses :func:`relative_frequency_table` to compute weighted proportions for
+    each dataset, then renders grouped horizontal bars.
+
+    How to read the output:
+        Each row is a category value. Within a row, each dataset gets its
+        own bar drawn with a distinct fill character (``█``, ``▓``, etc.).
+
+        - The percentage at the end of each bar is the weighted proportion
+          of that category within its dataset (i.e., proportions within
+          each dataset sum to 100%).
+        - Bar lengths are scaled so that the longest bar across all
+          datasets spans the full ``bar_width``.
+
+    Args:
+        dfs: List of DataFrameWithWeight dicts.
+        names: Names for each DataFrame (e.g., ["self", "target"]).
+        column: The categorical column name to plot.
+        weighted: Whether to use weights. Defaults to True.
+        bar_width: Maximum character width for bars. Defaults to 40.
+        dist_type: Accepted for compatibility but only "hist_ascii" is supported.
+            A warning is logged if any other value is passed.
+
+    Returns:
+        ASCII barplot text for this variable.
+
+    Example:
+        ::
+
+            >>> df_a = pd.DataFrame({"color": ["red", "blue", "blue", "green"]})
+            >>> df_b = pd.DataFrame({"color": ["red", "red", "blue", "green"]})
+            >>> dfs = [
+            ...     {"df": df_a, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+            ...     {"df": df_b, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+            ... ]
+            >>> print(ascii_plot_bar(dfs, names=["self", "target"],
+            ...       column="color", bar_width=20))
+            === color (categorical) ===
+            <BLANKLINE>
+            Category | sample  population
+                     |
+            blue     | ████████████████████ (50.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒ (25.0%)
+            green    | ██████████ (25.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒ (25.0%)
+            red      | ██████████ (25.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (50.0%)
+            <BLANKLINE>
+            Legend: █ sample  ▒ population
+            Bar lengths are proportional to weighted frequency within each dataset.
+            <BLANKLINE>
+    """
+    if dist_type is not None and dist_type != "hist_ascii":
+        logger.warning(
+            f"ASCII plots only support dist_type='hist_ascii'. "
+            f"Ignoring dist_type='{dist_type}' and using 'hist_ascii'."
+        )
+    legend_names: List[str] = [naming_legend(n, names) for n in names]
+
+    # Compute proportions per dataset
+    all_props: List[pd.DataFrame] = []
+    for ii, d in enumerate(dfs):
+        a_series = d["df"][column]
+        _w = d["weight"]
+        if weighted and _w is not None:
+            a_series, _w = rm_mutual_nas(a_series, _w)
+            a_series.name = column
+        freq_table = relative_frequency_table(a_series, w=_w if weighted else None)
+        freq_table["dataset"] = legend_names[ii]
+        all_props.append(freq_table)
+
+    combined = pd.concat(all_props, ignore_index=True)
+
+    # Get all unique categories in stable order
+    categories: List[str] = list(combined[column].unique())
+
+    # Find max proportion for bar scaling
+    max_value: float = float(combined["prop"].max()) if len(combined) > 0 else 1.0
+
+    # Compute label width
+    label_width = max(len(str(c)) for c in categories) if categories else 8
+    label_width = max(label_width, 8)  # minimum width for "Category"
+
+    # Build output
+    lines: List[str] = []
+    lines.append(f"=== {column} (categorical) ===")
+    lines.append("")
+
+    # Header
+    header_label = "Category".ljust(label_width)
+    lines.append(f"{header_label} | {'  '.join(legend_names)}")
+    lines.append(f"{' ' * label_width} |")
+
+    for cat in categories:
+        cat_data = combined[combined[column] == cat]
+        proportions: Dict[str, float] = {}
+        for _, row in cat_data.iterrows():
+            proportions[row["dataset"]] = float(row["prop"])
+        lines.append(
+            _render_horizontal_bars(
+                str(cat), proportions, legend_names, bar_width, max_value, label_width
+            )
+        )
+
+    lines.append("")
+    lines.append(_build_legend(legend_names))
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def ascii_plot_hist(
+    dfs: List[DataFrameWithWeight],
+    names: List[str],
+    column: str,
+    weighted: bool = True,
+    n_bins: int = 10,
+    bar_width: int = 40,
+    dist_type: Optional[str] = None,
+) -> str:
+    """Produces an ASCII histogram for a single numeric variable.
+
+    Computes weighted histogram bins across all datasets using a shared
+    bin range, then renders grouped horizontal bars for each bin.
+
+    How to read the output:
+        Each row is a numeric bin range. Within a row, each dataset gets
+        its own bar drawn with a distinct fill character (``█``, ``▓``, etc.).
+
+        - The percentage at the end of each bar is the weighted proportion
+          of observations falling in that bin within its dataset (i.e.,
+          proportions within each dataset sum to 100%).
+        - Bar lengths are scaled so that the longest bar across all
+          datasets spans the full ``bar_width``.
+
+    Args:
+        dfs: List of DataFrameWithWeight dicts.
+        names: Names for each DataFrame (e.g., ["self", "target"]).
+        column: The numeric column name to plot.
+        weighted: Whether to use weights. Defaults to True.
+        n_bins: Number of histogram bins. Defaults to 10.
+        bar_width: Maximum character width for bars. Defaults to 40.
+        dist_type: Accepted for compatibility but only "hist_ascii" is supported.
+            A warning is logged if any other value is passed.
+
+    Returns:
+        ASCII histogram text for this variable.
+
+    Example:
+        ::
+
+            >>> df_a = pd.DataFrame({"age": [10.0, 20.0, 30.0, 40.0]})
+            >>> df_b = pd.DataFrame({"age": [10.0, 10.0, 10.0, 40.0]})
+            >>> dfs = [
+            ...     {"df": df_a, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+            ...     {"df": df_b, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+            ... ]
+            >>> print(ascii_plot_hist(dfs, names=["self", "target"],
+            ...       column="age", n_bins=2, bar_width=20))
+            === age (numeric) ===
+            <BLANKLINE>
+            Bin            | sample  population
+                           |
+            [10.00, 25.00) | █████████████ (50.0%)
+                           | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (75.0%)
+            [25.00, 40.00] | █████████████ (50.0%)
+                           | ▒▒▒▒▒▒▒ (25.0%)
+            <BLANKLINE>
+            Legend: █ sample  ▒ population
+            Bar lengths are proportional to weighted frequency within each dataset.
+            <BLANKLINE>
+    """
+    if dist_type is not None and dist_type != "hist_ascii":
+        logger.warning(
+            f"ASCII plots only support dist_type='hist_ascii'. "
+            f"Ignoring dist_type='{dist_type}' and using 'hist_ascii'."
+        )
+    legend_names: List[str] = [naming_legend(n, names) for n in names]
+
+    # Collect all values to determine shared bin range
+    all_values: List[pd.Series] = []
+    all_weights: List[Optional[pd.Series]] = []
+    for d in dfs:
+        a_series = d["df"][column]
+        _w = d["weight"]
+        if weighted and _w is not None:
+            a_series, _w = rm_mutual_nas(a_series, _w)
+        else:
+            a_series = a_series.dropna()
+        all_values.append(a_series)
+        all_weights.append(_w if weighted else None)
+
+    # Compute shared bin edges
+    combined_values = pd.concat(all_values, ignore_index=True)
+    if len(combined_values) == 0:
+        return f"=== {column} (numeric) ===\n\nNo data available.\n"
+
+    global_min = float(combined_values.min())
+    global_max = float(combined_values.max())
+
+    # Handle edge case where all values are the same
+    if global_min == global_max:
+        global_min = global_min - 0.5
+        global_max = global_max + 0.5
+
+    bin_edges = np.linspace(global_min, global_max, n_bins + 1)
+
+    # Compute histograms per dataset
+    hist_data: List[npt.NDArray[np.floating]] = []
+    for vals, wts in zip(all_values, all_weights):
+        hist_data.append(_weighted_histogram(vals, wts, bin_edges))
+
+    # Build bin labels
+    bin_labels: List[str] = []
+    for i in range(n_bins):
+        left = bin_edges[i]
+        right = bin_edges[i + 1]
+        bracket_right = "]" if i == n_bins - 1 else ")"
+        bin_labels.append(f"[{left:,.2f}, {right:,.2f}{bracket_right}")
+
+    # Find max proportion for bar scaling
+    max_value: float = max(float(h.max()) for h in hist_data) if hist_data else 1.0
+
+    # Compute label width
+    label_width = max(len(lbl) for lbl in bin_labels) if bin_labels else 8
+    label_width = max(label_width, 3)  # minimum width for "Bin"
+
+    # Build output
+    lines: List[str] = []
+    lines.append(f"=== {column} (numeric) ===")
+    lines.append("")
+
+    # Header
+    header_label = "Bin".ljust(label_width)
+    lines.append(f"{header_label} | {'  '.join(legend_names)}")
+    lines.append(f"{' ' * label_width} |")
+
+    for bi, lbl in enumerate(bin_labels):
+        proportions: Dict[str, float] = {}
+        for di, name in enumerate(legend_names):
+            proportions[name] = float(hist_data[di][bi])
+        lines.append(
+            _render_horizontal_bars(
+                lbl, proportions, legend_names, bar_width, max_value, label_width
+            )
+        )
+
+    lines.append("")
+    lines.append(_build_legend(legend_names))
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def ascii_comparative_hist(
+    dfs: List[DataFrameWithWeight],
+    names: List[str],
+    column: str,
+    weighted: bool = True,
+    n_bins: int = 10,
+    bar_width: int = 20,
+) -> str:
+    """Produces a columnar, baseline-relative ASCII histogram.
+
+    The first dataset is the baseline. Subsequent datasets show bars split
+    into segments that indicate how each bin compares to the baseline.
+
+    How to read the output:
+        Each row is a bin range. The first column is the baseline dataset,
+        shown with solid ``█`` bars. For every other column:
+
+        - ``█`` (solid fill) = the portion of the bar that matches the
+          baseline proportion. This is the "common" part.
+        - ``▒`` (medium shade) = the portion that **exceeds** the baseline.
+          The bin has more mass than the baseline in this range.
+        - ``   ]`` (right bracket) = a **deficit** relative to the baseline.
+          The gap before the bracket shows how much mass is missing compared to
+          the baseline in this range.
+        - A number without any bar means the percentage is too small to
+          render at the chosen ``bar_width``.
+
+        All percentages are normalized so each column sums to 100%.
+
+    Args:
+        dfs: List of DataFrameWithWeight dicts. The first entry is used as
+            the baseline for comparison.
+        names: Names for each DataFrame (e.g., ["Target", "Sample"]).
+        column: The numeric column name to plot.
+        weighted: Whether to use weights. Defaults to True.
+        n_bins: Number of histogram bins. Defaults to 10.
+        bar_width: Maximum character width for bars. Defaults to 20.
+
+    Returns:
+        ASCII comparative histogram text.
+
+    Example:
+        ::
+
+            >>> print(ascii_comparative_hist(dfs, names=["Target", "Sample"],
+            ...       column="income", n_bins=2, bar_width=20))
+            Range          | Target (%)         | Sample (%)
+            ---------------------------------------------------------------
+            [10.00, 25.00) | █████████████ 50.0 | █████████████▒▒▒▒▒▒▒ 75.0
+            [25.00, 40.00] | █████████████ 50.0 | ███████     ] 25.0
+            ---------------------------------------------------------------
+            Total          | 100.0              | 100.0
+
+        In the Sample column above, bin [10, 25) shows ``▒`` excess
+        (75% vs 50% baseline) while bin [25, 40] shows ``     ]``
+        deficit (25% vs 50% baseline).
+    """
+    legend_names: List[str] = [naming_legend(n, names) for n in names]
+
+    # Collect all values to determine shared bin range
+    all_values: List[pd.Series] = []
+    all_weights: List[Optional[pd.Series]] = []
+    for d in dfs:
+        a_series = d["df"][column]
+        _w = d["weight"]
+        if weighted and _w is not None:
+            a_series, _w = rm_mutual_nas(a_series, _w)
+        else:
+            a_series = a_series.dropna()
+        all_values.append(a_series)
+        all_weights.append(_w if weighted else None)
+
+    # Compute shared bin edges
+    combined_values = pd.concat(all_values, ignore_index=True)
+    if len(combined_values) == 0:
+        return "No data available."
+
+    global_min = float(combined_values.min())
+    global_max = float(combined_values.max())
+
+    if global_min == global_max:
+        global_min = global_min - 0.5
+        global_max = global_max + 0.5
+
+    bin_edges = np.linspace(global_min, global_max, n_bins + 1)
+
+    # Compute histograms per dataset (as percentages)
+    hist_pcts: List[List[float]] = []
+    for vals, wts in zip(all_values, all_weights):
+        props = _weighted_histogram(vals, wts, bin_edges)
+        hist_pcts.append([float(p) * 100.0 for p in props])
+
+    # Find max percentage across all datasets and bins for bar scaling
+    max_pct: float = max(
+        (pct for pcts in hist_pcts for pct in pcts),
+        default=0.0,
+    )
+
+    # Build bin labels
+    bin_labels: List[str] = []
+    for i in range(n_bins):
+        left = bin_edges[i]
+        right = bin_edges[i + 1]
+        bracket_right = "]" if i == n_bins - 1 else ")"
+        bin_labels.append(f"[{left:,.2f}, {right:,.2f}{bracket_right}")
+
+    # Baseline percentages (first dataset)
+    baseline_pcts = hist_pcts[0]
+
+    # Build cell strings for each dataset x bin
+    # cell_strings[dataset_idx][bin_idx] = "bar_chars pct"
+    cell_strings: List[List[str]] = []
+    for di in range(len(hist_pcts)):
+        cells: List[str] = []
+        for bi in range(n_bins):
+            pct = hist_pcts[di][bi]
+            if max_pct > 0:
+                bar_len = round((pct / max_pct) * bar_width)
+            else:
+                bar_len = 0
+
+            if di == 0:
+                # Baseline: simple filled bars
+                bar = "█" * bar_len
+            else:
+                base_pct = baseline_pcts[bi]
+                if max_pct > 0:
+                    baseline_len = round((base_pct / max_pct) * bar_width)
+                else:
+                    baseline_len = 0
+
+                if bar_len >= baseline_len:
+                    bar = "█" * baseline_len + "▒" * (bar_len - baseline_len)
+                else:
+                    deficit = baseline_len - bar_len
+                    if deficit >= 2:
+                        bar = "█" * bar_len + " " * (deficit - 1) + "]"
+                    else:
+                        bar = "█" * bar_len + "]"
+
+            pct_str = f"{pct:.1f}"
+            if bar:
+                cells.append(f"{bar} {pct_str}")
+            else:
+                cells.append(pct_str)
+        cell_strings.append(cells)
+
+    # Compute column widths
+    col_widths: List[int] = []
+    for di in range(len(legend_names)):
+        header_w = len(f"{legend_names[di]} (%)")
+        max_cell_w = max(len(cell_strings[di][bi]) for bi in range(n_bins))
+        col_widths.append(max(header_w, max_cell_w))
+
+    # Range column width
+    range_header = "Range"
+    range_width = max(len(range_header), max(len(lbl) for lbl in bin_labels))
+
+    # Build output
+    lines: List[str] = []
+
+    # Header row
+    header_parts = [range_header.ljust(range_width)]
+    for di in range(len(legend_names)):
+        header_parts.append(f"{legend_names[di]} (%)".ljust(col_widths[di]))
+    lines.append(" | ".join(header_parts))
+
+    # Separator
+    sep_width = range_width + sum(col_widths) + 3 * len(col_widths)
+    lines.append("-" * sep_width)
+
+    # Data rows
+    for bi in range(n_bins):
+        row_parts = [bin_labels[bi].ljust(range_width)]
+        for di in range(len(legend_names)):
+            row_parts.append(cell_strings[di][bi].ljust(col_widths[di]))
+        lines.append(" | ".join(row_parts))
+
+    # Separator
+    lines.append("-" * sep_width)
+
+    # Total row
+    total_parts = ["Total".ljust(range_width)]
+    for di in range(len(hist_pcts)):
+        total_val = sum(hist_pcts[di])
+        total_parts.append(f"{total_val:.1f}".ljust(col_widths[di]))
+    lines.append(" | ".join(total_parts))
+
+    # Legend (only when there are non-baseline columns)
+    if len(legend_names) > 1:
+        lines.append("")
+        lines.append(
+            f"Key: █ = shared with {legend_names[0]}," " ▒ = excess,    ] = deficit"
+        )
+
+    return "\n".join(lines)
+
+
+def ascii_plot_dist(
+    dfs: List[DataFrameWithWeight],
+    names: Optional[List[str]] = None,
+    variables: Optional[List[str]] = None,
+    numeric_n_values_threshold: int = 15,
+    weighted: bool = True,
+    n_bins: int = 10,
+    bar_width: int = 40,
+    dist_type: Optional[str] = None,
+) -> str:
+    """Produces ASCII text comparing weighted distributions across datasets.
+
+    Iterates over variables, classifying each as categorical or numeric
+    (using the same logic as :func:`seaborn_plot_dist`), then delegates to
+    :func:`ascii_plot_bar` or :func:`ascii_plot_hist` respectively.
+
+    The output is both printed to stdout and returned as a string.
+
+    Args:
+        dfs: List of DataFrameWithWeight dicts.
+        names: Names for each DataFrame (e.g., ["self", "unadjusted", "target"]).
+            If None, defaults to "df_0", "df_1", etc.
+        variables: Subset of variables to plot. None means all.
+        numeric_n_values_threshold: Columns with fewer unique values than this
+            are treated as categorical. Defaults to 15.
+        weighted: Whether to use weights. Defaults to True.
+        n_bins: Number of bins for numeric histograms. Defaults to 10.
+        bar_width: Maximum character width for the longest bar. Defaults to 40.
+        dist_type: Accepted for compatibility but only "hist_ascii" is supported.
+            A warning is logged if any other value is passed.
+
+    Returns:
+        The full ASCII output text.
+
+    Examples:
+        ::
+
+            >>> import pandas as pd
+            >>> from balance.stats_and_plots.ascii_plots import ascii_plot_dist
+            >>> df_a = pd.DataFrame({
+            ...     "color": ["red", "blue", "blue", "green"],
+            ...     "age": [10.0, 20.0, 30.0, 40.0],
+            ... })
+            >>> df_b = pd.DataFrame({
+            ...     "color": ["red", "red", "blue", "green"],
+            ...     "age": [10.0, 10.0, 10.0, 40.0],
+            ... })
+            >>> dfs = [
+            ...     {"df": df_a, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+            ...     {"df": df_b, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+            ... ]
+            >>> print(ascii_plot_dist(dfs, names=["self", "target"],
+            ...       numeric_n_values_threshold=0, n_bins=2, bar_width=20))
+            === color (categorical) ===
+            <BLANKLINE>
+            Category | sample  population
+                     |
+            blue     | ████████████████████ (50.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒ (25.0%)
+            green    | ██████████ (25.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒ (25.0%)
+            red      | ██████████ (25.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (50.0%)
+            <BLANKLINE>
+            Legend: █ sample  ▒ population
+            Bar lengths are proportional to weighted frequency within each dataset.
+            <BLANKLINE>
+            === age (numeric) ===
+            <BLANKLINE>
+            Bin            | sample  population
+                           |
+            [10.00, 25.00) | █████████████ (50.0%)
+                           | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (75.0%)
+            [25.00, 40.00] | █████████████ (50.0%)
+                           | ▒▒▒▒▒▒▒ (25.0%)
+            <BLANKLINE>
+            Legend: █ sample  ▒ population
+            Bar lengths are proportional to weighted frequency within each dataset.
+    """
+    if dist_type is not None and dist_type != "hist_ascii":
+        logger.warning(
+            f"ASCII plots only support dist_type='hist_ascii'. "
+            f"Ignoring dist_type='{dist_type}' and using 'hist_ascii'."
+        )
+    if names is None:
+        names = [f"df_{i}" for i in range(len(dfs))]
+
+    variables = choose_variables(*(d["df"] for d in dfs), variables=variables)
+    logger.debug(f"ASCII plotting variables {variables}")
+
+    numeric_variables = dfs[0]["df"].select_dtypes(exclude=["object"]).columns.values
+
+    output_parts: List[str] = []
+
+    for o in variables:
+        # Find the maximum number of non-missing unique values across all dfs
+        n_values = max(len(set(rm_mutual_nas(d["df"].loc[:, o].values))) for d in dfs)
+        if n_values == 0:
+            logger.warning(f"No nonmissing values for variable '{o}', skipping")
+            continue
+
+        categorical = (o not in numeric_variables) or (
+            n_values < numeric_n_values_threshold
+        )
+
+        if categorical:
+            output_parts.append(
+                ascii_plot_bar(dfs, names, o, weighted=weighted, bar_width=bar_width)
+            )
+        else:
+            output_parts.append(
+                ascii_plot_hist(
+                    dfs,
+                    names,
+                    o,
+                    weighted=weighted,
+                    n_bins=n_bins,
+                    bar_width=bar_width,
+                )
+            )
+
+    result = "\n".join(output_parts)
+    print(result)
+    return result

--- a/balance/stats_and_plots/weighted_comparisons_plots.py
+++ b/balance/stats_and_plots/weighted_comparisons_plots.py
@@ -1368,15 +1368,16 @@ def plot_dist(
     variables: Optional[List[str]] = None,
     numeric_n_values_threshold: int = 15,
     weighted: bool = True,
-    dist_type: Optional[Literal["kde", "hist", "qq", "ecdf"]] = None,
-    library: Literal["plotly", "seaborn"] = "plotly",
+    dist_type: Optional[Literal["kde", "hist", "qq", "ecdf", "hist_ascii"]] = None,
+    library: Literal["plotly", "seaborn", "balance"] = "plotly",
     ylim: Optional[Tuple[float, float]] = None,
     **kwargs: Any,
-) -> List[plt.Axes] | npt.NDArray | Dict[str, go.Figure] | None:
-    """Plots the variables of a DataFrame by using either seaborn or plotly.
+) -> List[plt.Axes] | npt.NDArray | Dict[str, go.Figure] | str | None:
+    """Plots the variables of a DataFrame by using either seaborn, plotly, or ASCII text.
 
     If using plotly then using kde (or qq) plots for numeric variables and bar plots for categorical variables. Uses :func:`plotly_plot_dist`.
     If using seaborn then various types of plots are possible for the variables (see dist_type for details). Uses :func:`seaborn_plot_dist`
+    If using balance then ASCII text histograms and barplots are printed to stdout. Uses :func:`ascii_plot_dist`.
 
     Args:
         dfs (List[Dict[str, Union[pd.DataFrame, pd.Series]]]): a list (of length 1 or more) of dictionaries which describe the DataFrames and weights
@@ -1392,21 +1393,24 @@ def plot_dist(
         variables (Optional[List[str]], optional): a list of variables to use for plotting. Default (i.e.: if None) is to use the list of all variables.
         numeric_n_values_threshold (int, optional): How many numbers should be in a column so that it is considered to be a "category"? Defaults to 15.
         weighted (bool, optional): If to use the weights with the plots. Defaults to True.
-        dist_type (Literal["kde", "hist", "qq", "ecdf"], optional): The type of plot to draw. The 'qq' and 'kde' options are available for library="plotly",
-            While all options are available if using library="seaborn". Defaults to "kde".
-        library (Literal["plotly", "seaborn"], optional): Whichever library to use for the plot. Defaults to "plotly".
+        dist_type (Literal["kde", "hist", "qq", "ecdf", "hist_ascii"], optional): The type of plot to draw. The 'qq' and 'kde' options are available for library="plotly",
+            while all options except hist_ascii are available if using library="seaborn". The 'hist_ascii' option is used with library="balance";
+            it is the only dist_type supported when library="balance". Defaults to "kde".
+        library (Literal["plotly", "seaborn", "balance"], optional): Whichever library to use for the plot.
+            Use "balance" for ASCII text output suitable for LLM consumption (only dist_type="hist_ascii" is supported). Defaults to "plotly".
         ylim (Optional[Tuple[float, float]], optional): A tuple with two float values representing the lower and upper limits of the y-axis.
             If not provided, the y-axis range is determined automatically. Defaults to None.
             passed to bar plots only.
         **kwargs: Additional keyword arguments to pass to plotly_plot_dist or seaborn_plot_dist.
 
     Raises:
-        ValueError: if library is not in ("plotly", "seaborn").
+        ValueError: if library is not in ("plotly", "seaborn", "balance").
 
     Returns:
-        Union[Union[List, np.ndarray], Dict[str, go.Figure], None]:
+        Union[Union[List, np.ndarray], Dict[str, go.Figure], str, None]:
             If library="plotly" then returns a dictionary containing plots if return_dict_of_figures is True. None otherwise.
             If library="seaborn" then returns None, unless return_axes is True. Then either a list or an np.array of matplotlib axis.
+            If library="balance" then returns a string with the ASCII text output.
 
     Examples:
         ::
@@ -1445,8 +1449,10 @@ def plot_dist(
             plot_dist(dfs1, names=["self", "unadjusted", "target"], ylim = (0,1))
             plot_dist(dfs1, names=["self", "unadjusted", "target"], library="seaborn", dist_type = "qq", ylim = (0,1))
     """
-    if library not in ("plotly", "seaborn"):
-        raise ValueError(f"library must be either 'plotly' or 'seaborn', is {library}")
+    if library not in ("plotly", "seaborn", "balance"):
+        raise ValueError(
+            f"library must be 'plotly', 'seaborn', or 'balance', is {library}"
+        )
 
     #  Set default names for samples
     # TODO: this will work only with seaborn. Will need to change to something that also works for plotly.
@@ -1454,13 +1460,23 @@ def plot_dist(
         names = [f"sample {i}" for i in range(1, len(dfs) + 1)]
 
     if library == "seaborn":
+        dist_type_for_seaborn: Literal["kde", "hist", "qq", "ecdf"] | None = None
+        if dist_type is None:
+            dist_type_for_seaborn = None
+        elif dist_type in ("kde", "hist", "qq", "ecdf"):
+            dist_type_for_seaborn = dist_type  # pyre-ignore[9]
+        else:
+            raise ValueError(
+                f"seaborn library does not support dist_type='{dist_type}'. "
+                f"Use dist_type='kde', 'hist', 'qq', or 'ecdf' with seaborn, or use library='balance' for ASCII output."
+            )
         return seaborn_plot_dist(
             dfs=dfs,
             names=names,
             variables=variables,
             numeric_n_values_threshold=numeric_n_values_threshold,
             weighted=weighted,
-            dist_type=dist_type,
+            dist_type=dist_type_for_seaborn,
             ylim=ylim,
             **kwargs,
         )
@@ -1480,10 +1496,10 @@ def plot_dist(
             dist_type_for_plotly = None
         elif dist_type in ("kde", "qq"):
             dist_type_for_plotly = dist_type
-        elif dist_type in ("hist", "ecdf"):
+        elif dist_type in ("hist", "ecdf", "hist_ascii"):
             raise ValueError(
                 f"plotly library does not support dist_type='{dist_type}'. "
-                f"Use dist_type='kde' or 'qq' with plotly, or use library='seaborn' for all dist_type options."
+                f"Use dist_type='kde' or 'qq' with plotly, or use library='balance' for ASCII output."
             )
 
         return plotly_plot_dist(
@@ -1493,6 +1509,22 @@ def plot_dist(
             weighted,
             dist_type=dist_type_for_plotly,
             ylim=ylim,
+            **kwargs,
+        )
+    elif library == "balance":
+        if dist_type is not None and dist_type != "hist_ascii":
+            logger.warning(
+                f"library='balance' only supports dist_type='hist_ascii'. "
+                f"Ignoring dist_type='{dist_type}' and using 'hist_ascii'."
+            )
+        from balance.stats_and_plots.ascii_plots import ascii_plot_dist
+
+        return ascii_plot_dist(
+            dfs=dfs,
+            names=names,
+            variables=variables,
+            numeric_n_values_threshold=numeric_n_values_threshold,
+            weighted=weighted,
             **kwargs,
         )
 

--- a/tests/test_ascii_plots.py
+++ b/tests/test_ascii_plots.py
@@ -1,0 +1,1036 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import io
+import textwrap
+from typing import List
+from unittest.mock import patch
+
+import balance.testutil
+import numpy as np
+import pandas as pd
+from balance.stats_and_plots.ascii_plots import (
+    _build_legend,
+    _render_horizontal_bars,
+    _weighted_histogram,
+    ascii_comparative_hist,
+    ascii_plot_bar,
+    ascii_plot_dist,
+    ascii_plot_hist,
+)
+from balance.stats_and_plots.weighted_comparisons_plots import (
+    DataFrameWithWeight,
+    plot_dist,
+)
+
+
+class TestWeightedHistogram(balance.testutil.BalanceTestCase):
+    """Tests for _weighted_histogram helper."""
+
+    def test_uniform_weights(self) -> None:
+        """Test with uniform weights produces expected proportions."""
+        values = pd.Series([0.5, 1.5, 2.5, 3.5])
+        bin_edges = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        result = _weighted_histogram(values, None, bin_edges)
+        # Each value falls in a different bin, so each bin should be 0.25
+        np.testing.assert_array_almost_equal(result, [0.25, 0.25, 0.25, 0.25])
+
+    def test_nonuniform_weights(self) -> None:
+        """Test with non-uniform weights changes proportions."""
+        values = pd.Series([0.5, 1.5])
+        weights = pd.Series([3.0, 1.0])
+        bin_edges = np.array([0.0, 1.0, 2.0])
+        result = _weighted_histogram(values, weights, bin_edges)
+        np.testing.assert_array_almost_equal(result, [0.75, 0.25])
+
+    def test_proportions_sum_to_one(self) -> None:
+        """Test that returned proportions sum to 1.0."""
+        values = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+        weights = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+        bin_edges = np.linspace(0.5, 5.5, 6)
+        result = _weighted_histogram(values, weights, bin_edges)
+        self.assertAlmostEqual(float(result.sum()), 1.0)
+
+    def test_empty_values(self) -> None:
+        """Test with no values returns zeros."""
+        values = pd.Series([], dtype=float)
+        bin_edges = np.array([0.0, 1.0, 2.0])
+        result = _weighted_histogram(values, None, bin_edges)
+        np.testing.assert_array_equal(result, [0.0, 0.0])
+
+    def test_negative_weights_raises(self) -> None:
+        """Test that negative weights raise ValueError."""
+        values = pd.Series([0.5, 1.5])
+        weights = pd.Series([1.0, -1.0])
+        bin_edges = np.array([0.0, 1.0, 2.0])
+        with self.assertRaises(ValueError):
+            _weighted_histogram(values, weights, bin_edges)
+
+    def test_non_numeric_weights_raises(self) -> None:
+        """Test that non-numeric weights raise TypeError."""
+        values = pd.Series([0.5, 1.5])
+        weights = pd.Series(["a", "b"])
+        bin_edges = np.array([0.0, 1.0, 2.0])
+        with self.assertRaises(TypeError):
+            _weighted_histogram(values, weights, bin_edges)
+
+    def test_none_weights_passes_validation(self) -> None:
+        """Test that None weights are accepted without error."""
+        values = pd.Series([0.5, 1.5])
+        bin_edges = np.array([0.0, 1.0, 2.0])
+        result = _weighted_histogram(values, None, bin_edges)
+        np.testing.assert_array_almost_equal(result, [0.5, 0.5])
+
+
+class TestRenderHorizontalBars(balance.testutil.BalanceTestCase):
+    """Tests for _render_horizontal_bars helper."""
+
+    def test_basic_rendering(self) -> None:
+        """Test basic bar rendering with known proportions."""
+        result = _render_horizontal_bars(
+            label="cat_a",
+            proportions={"sample": 0.5, "population": 0.25},
+            legend_names=["sample", "population"],
+            bar_width=20,
+            max_value=0.5,
+            label_width=10,
+        )
+        lines = result.split("\n")
+        self.assertEqual(len(lines), 2)
+        # First line has the label
+        self.assertIn("cat_a", lines[0])
+        self.assertIn("50.0%", lines[0])
+        # Second line has blank label
+        self.assertIn("25.0%", lines[1])
+
+    def test_zero_proportion(self) -> None:
+        """Test that zero proportion produces empty bar with 0.0%."""
+        result = _render_horizontal_bars(
+            label="x",
+            proportions={"sample": 0.0},
+            legend_names=["sample"],
+            bar_width=20,
+            max_value=1.0,
+            label_width=5,
+        )
+        self.assertIn("0.0%", result)
+
+    def test_bar_width_scaling(self) -> None:
+        """Test that bars scale correctly to bar_width."""
+        result = _render_horizontal_bars(
+            label="x",
+            proportions={"sample": 1.0},
+            legend_names=["sample"],
+            bar_width=20,
+            max_value=1.0,
+            label_width=5,
+        )
+        # The bar should be exactly 20 '█' characters
+        self.assertIn("█" * 20, result)
+
+    def test_multiple_datasets_different_chars(self) -> None:
+        """Test that different datasets get different characters."""
+        result = _render_horizontal_bars(
+            label="x",
+            proportions={"a": 0.5, "b": 0.5},
+            legend_names=["a", "b"],
+            bar_width=10,
+            max_value=0.5,
+            label_width=5,
+        )
+        lines = result.split("\n")
+        self.assertIn("█", lines[0])
+        self.assertIn("▒", lines[1])
+
+
+class TestBuildLegend(balance.testutil.BalanceTestCase):
+    """Tests for _build_legend helper."""
+
+    def test_legend_format(self) -> None:
+        """Test that legend has correct format."""
+        result = _build_legend(["sample", "population"])
+        self.assertIn("Legend:", result)
+        self.assertIn("█ sample", result)
+        self.assertIn("▒ population", result)
+        self.assertIn(
+            "Bar lengths are proportional to weighted frequency within each dataset.",
+            result,
+        )
+
+    def test_three_datasets(self) -> None:
+        """Test legend with three datasets."""
+        result = _build_legend(["sample", "adjusted", "population"])
+        self.assertIn("█ sample", result)
+        self.assertIn("▒ adjusted", result)
+        self.assertIn("▐ population", result)
+        self.assertIn(
+            "Bar lengths are proportional to weighted frequency within each dataset.",
+            result,
+        )
+
+
+class TestAsciiPlotBar(balance.testutil.BalanceTestCase):
+    """Tests for ascii_plot_bar function."""
+
+    def test_basic_categorical_output(self) -> None:
+        """Test that basic categorical data produces expected ASCII bars."""
+        df = pd.DataFrame({"group": ("a", "b", "c", "c")})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series((1, 1, 1, 1))},
+            {"df": df, "weight": pd.Series((1, 1, 1, 1))},
+        ]
+        result = ascii_plot_bar(dfs, names=["self", "target"], column="group")
+        self.assertIn("=== group (categorical) ===", result)
+        self.assertIn("a", result)
+        self.assertIn("b", result)
+        self.assertIn("c", result)
+        self.assertIn("Legend:", result)
+
+    def test_weighted_categorical_output(self) -> None:
+        """Test that weights affect proportions correctly."""
+        df = pd.DataFrame({"group": ("a", "b", "c", "c")})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series((1, 1, 1, 1))},
+            {"df": df, "weight": pd.Series((2, 1, 1, 1))},
+        ]
+        result = ascii_plot_bar(dfs, names=["self", "target"], column="group")
+        # With equal weights: a=25%, b=25%, c=50%
+        self.assertIn("25.0%", result)
+        self.assertIn("50.0%", result)
+        # With weight (2,1,1,1): a=40%, b=20%, c=40%
+        self.assertIn("40.0%", result)
+        self.assertIn("20.0%", result)
+
+    def test_single_dataset(self) -> None:
+        """Test with a single DataFrame (no comparison)."""
+        df = pd.DataFrame({"group": ("a", "b")})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series((1, 1))},
+        ]
+        result = ascii_plot_bar(dfs, names=["self"], column="group")
+        self.assertIn("=== group (categorical) ===", result)
+        self.assertIn("50.0%", result)
+
+    def test_legend_names_transformation(self) -> None:
+        """Test that naming_legend is applied."""
+        df = pd.DataFrame({"group": ("a", "b")})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series((1, 1))},
+            {"df": df, "weight": pd.Series((1, 1))},
+            {"df": df, "weight": pd.Series((1, 1))},
+        ]
+        result = ascii_plot_bar(
+            dfs, names=["self", "unadjusted", "target"], column="group"
+        )
+        # "self" -> "adjusted", "unadjusted" -> "sample", "target" -> "population"
+        self.assertIn("adjusted", result)
+        self.assertIn("sample", result)
+        self.assertIn("population", result)
+
+    def test_unweighted(self) -> None:
+        """Test unweighted mode ignores weights."""
+        df = pd.DataFrame({"group": ("a", "b")})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series((100, 1))},
+        ]
+        result = ascii_plot_bar(dfs, names=["self"], column="group", weighted=False)
+        # Without weighting, each row counts equally: a=50%, b=50%
+        self.assertIn("50.0%", result)
+
+
+class TestAsciiPlotHist(balance.testutil.BalanceTestCase):
+    """Tests for ascii_plot_hist function."""
+
+    def test_basic_numeric_output(self) -> None:
+        """Test that numeric data produces expected bin labels and bars."""
+        df = pd.DataFrame({"v1": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(5))},
+        ]
+        result = ascii_plot_hist(dfs, names=["self"], column="v1", n_bins=5)
+        self.assertIn("=== v1 (numeric) ===", result)
+        self.assertIn("Legend:", result)
+        # Should have 5 bin labels
+        self.assertIn("[", result)
+        self.assertIn(")", result)
+
+    def test_weighted_numeric_output(self) -> None:
+        """Test that weights change histogram proportions."""
+        df = pd.DataFrame({"v1": [0.5, 1.5]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([3.0, 1.0])},
+        ]
+        result = ascii_plot_hist(dfs, names=["self"], column="v1", n_bins=2)
+        # First bin should have ~75%, second ~25%
+        self.assertIn("75.0%", result)
+        self.assertIn("25.0%", result)
+
+    def test_custom_n_bins(self) -> None:
+        """Test that n_bins parameter changes number of bins."""
+        df = pd.DataFrame({"v1": np.linspace(0, 10, 100)})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(100))},
+        ]
+        result_5 = ascii_plot_hist(dfs, names=["self"], column="v1", n_bins=5)
+        result_20 = ascii_plot_hist(dfs, names=["self"], column="v1", n_bins=20)
+        # More bins = more lines of output
+        self.assertGreater(len(result_20.split("\n")), len(result_5.split("\n")))
+
+    def test_handles_single_value(self) -> None:
+        """Test edge case where all values are the same."""
+        df = pd.DataFrame({"v1": [5.0, 5.0, 5.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(3))},
+        ]
+        result = ascii_plot_hist(dfs, names=["self"], column="v1", n_bins=3)
+        self.assertIn("=== v1 (numeric) ===", result)
+
+    def test_two_datasets_comparison(self) -> None:
+        """Test comparing two datasets in a histogram."""
+        df = pd.DataFrame({"v1": [1.0, 2.0, 3.0, 4.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1, 1, 1, 1])},
+            {"df": df, "weight": pd.Series([4, 1, 1, 1])},
+        ]
+        result = ascii_plot_hist(dfs, names=["self", "target"], column="v1", n_bins=4)
+        # Both sample and population should appear in legend
+        self.assertIn("sample", result)
+        self.assertIn("population", result)
+
+    def test_unweighted_hist(self) -> None:
+        """Test ascii_plot_hist with weighted=False (line 316)."""
+        df = pd.DataFrame({"v1": [1.0, 2.0, 3.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([100.0, 100.0, 100.0])},
+        ]
+        result = ascii_plot_hist(
+            dfs, names=["self"], column="v1", n_bins=2, weighted=False
+        )
+        # Without weighting, each value counts equally
+        self.assertIn("=== v1 (numeric) ===", result)
+
+    def test_empty_after_na_drop(self) -> None:
+        """Test ascii_plot_hist with all-NaN data returns empty message (line 323)."""
+        df = pd.DataFrame({"v1": [np.nan, np.nan, np.nan]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": None},
+        ]
+        result = ascii_plot_hist(dfs, names=["self"], column="v1", n_bins=2)
+        self.assertIn("No data available.", result)
+
+
+class TestAsciiPlotDist(balance.testutil.BalanceTestCase):
+    """Tests for ascii_plot_dist dispatcher function."""
+
+    def test_dispatches_categorical_and_numeric(self) -> None:
+        """Test that mixed data produces both barplots and histograms."""
+        df = pd.DataFrame(
+            {
+                "gender": ["male", "female", "female", "male"],
+                "age": [25.0, 35.0, 45.0, 55.0],
+            }
+        )
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1, 1, 1, 1])},
+            {"df": df, "weight": pd.Series([1, 1, 1, 1])},
+        ]
+        result = ascii_plot_dist(
+            dfs, names=["self", "target"], numeric_n_values_threshold=0
+        )
+        self.assertIn("(categorical)", result)
+        self.assertIn("(numeric)", result)
+
+    def test_respects_numeric_n_values_threshold(self) -> None:
+        """Test that low-cardinality numeric columns are treated as categorical."""
+        df = pd.DataFrame({"v1": [1, 2, 3, 1, 2, 3]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(6))},
+        ]
+        # With threshold=10, 3 unique values < 10, so treated as categorical
+        result = ascii_plot_dist(dfs, names=["self"], numeric_n_values_threshold=10)
+        self.assertIn("(categorical)", result)
+
+        # With threshold=0, treated as numeric
+        result = ascii_plot_dist(dfs, names=["self"], numeric_n_values_threshold=0)
+        self.assertIn("(numeric)", result)
+
+    def test_returns_string(self) -> None:
+        """Test that the function returns a string."""
+        df = pd.DataFrame({"v1": [1.0, 2.0, 3.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(3))},
+        ]
+        result = ascii_plot_dist(dfs, names=["self"])
+        self.assertIsInstance(result, str)
+
+    def test_prints_to_stdout(self) -> None:
+        """Test that the function prints output to stdout."""
+        df = pd.DataFrame({"v1": [1.0, 2.0, 3.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(3))},
+        ]
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+            ascii_plot_dist(dfs, names=["self"])
+            output = mock_stdout.getvalue()
+        self.assertIn("v1", output)
+
+    def test_variables_parameter(self) -> None:
+        """Test that the variables parameter filters variables."""
+        df = pd.DataFrame(
+            {
+                "v1": [1.0, 2.0, 3.0],
+                "v2": [4.0, 5.0, 6.0],
+            }
+        )
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(3))},
+        ]
+        result = ascii_plot_dist(dfs, names=["self"], variables=["v1"])
+        self.assertIn("v1", result)
+        self.assertNotIn("v2", result)
+
+    def test_default_names(self) -> None:
+        """Test that default names are generated when names is None."""
+        df = pd.DataFrame({"v1": [1.0, 2.0, 3.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(3))},
+        ]
+        result = ascii_plot_dist(dfs, names=None)
+        self.assertIn("df_0", result)
+
+
+class TestPlotDistBalanceLibrary(balance.testutil.BalanceTestCase):
+    """Tests for plot_dist with library='balance'."""
+
+    def test_plot_dist_balance_returns_string(self) -> None:
+        """Test that plot_dist with library='balance' returns a string."""
+        df = pd.DataFrame({"v1": [1.0, 2.0, 3.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(3))},
+        ]
+        result = plot_dist(
+            dfs, names=["self"], library="balance", numeric_n_values_threshold=0
+        )
+        self.assertIsInstance(result, str)
+        assert isinstance(result, str)
+        self.assertIn("v1", result)
+
+    def test_plot_dist_invalid_library_message(self) -> None:
+        """Test that the error message for invalid library mentions 'balance'."""
+        df = pd.DataFrame({"v1": [1.0, 2.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(2))},
+        ]
+        with self.assertRaises(ValueError) as cm:
+            plot_dist(dfs, names=["self"], library="invalid")  # pyre-ignore[6]
+        self.assertIn("balance", str(cm.exception))
+
+
+class TestAsciiPlotsEndToEnd(balance.testutil.BalanceTestCase):
+    """End-to-end tests comparing full ASCII plot output against expected strings."""
+
+    def _assert_lines_equal(self, actual: str, expected_text: str) -> None:
+        """Compare actual output lines against a dedented expected string."""
+        expected_lines = textwrap.dedent(expected_text).strip().splitlines()
+        actual_lines = [line.rstrip() for line in actual.splitlines()]
+        self.assertEqual(actual_lines, expected_lines)
+
+    def test_e2e_ascii_bar_single_dataset(self) -> None:
+        """Full barplot output for a single categorical variable, one dataset."""
+        df = pd.DataFrame({"color": ["red", "blue", "blue", "green"]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+        ]
+        result = ascii_plot_bar(dfs, names=["self"], column="color", bar_width=20)
+        self._assert_lines_equal(
+            result,
+            """\
+            === color (categorical) ===
+
+            Category | sample
+                     |
+            blue     | ████████████████████ (50.0%)
+            green    | ██████████ (25.0%)
+            red      | ██████████ (25.0%)
+
+            Legend: █ sample
+            Bar lengths are proportional to weighted frequency within each dataset.
+            """,
+        )
+
+    def test_e2e_ascii_bar_two_datasets(self) -> None:
+        """Full barplot output for a single categorical variable, two datasets."""
+        df_a = pd.DataFrame({"color": ["red", "blue", "blue", "green"]})
+        df_b = pd.DataFrame({"color": ["red", "red", "blue", "green"]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df_a, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+            {"df": df_b, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+        ]
+        result = ascii_plot_bar(
+            dfs, names=["self", "target"], column="color", bar_width=20
+        )
+        self._assert_lines_equal(
+            result,
+            """\
+            === color (categorical) ===
+
+            Category | sample  population
+                     |
+            blue     | ████████████████████ (50.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒ (25.0%)
+            green    | ██████████ (25.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒ (25.0%)
+            red      | ██████████ (25.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (50.0%)
+
+            Legend: █ sample  ▒ population
+            Bar lengths are proportional to weighted frequency within each dataset.
+            """,
+        )
+
+    def test_e2e_ascii_hist_single_dataset(self) -> None:
+        """Full histogram output for a single numeric variable, one dataset."""
+        df = pd.DataFrame({"age": [10.0, 20.0, 30.0, 40.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+        ]
+        result = ascii_plot_hist(
+            dfs, names=["self"], column="age", n_bins=2, bar_width=20
+        )
+        self._assert_lines_equal(
+            result,
+            """\
+            === age (numeric) ===
+
+            Bin            | sample
+                           |
+            [10.00, 25.00) | ████████████████████ (50.0%)
+            [25.00, 40.00] | ████████████████████ (50.0%)
+
+            Legend: █ sample
+            Bar lengths are proportional to weighted frequency within each dataset.
+            """,
+        )
+
+    def test_e2e_ascii_hist_two_datasets(self) -> None:
+        """Full histogram output for a single numeric variable, two datasets."""
+        df_a = pd.DataFrame({"age": [10.0, 20.0, 30.0, 40.0]})
+        df_b = pd.DataFrame({"age": [10.0, 10.0, 10.0, 40.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df_a, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+            {"df": df_b, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+        ]
+        result = ascii_plot_hist(
+            dfs, names=["self", "target"], column="age", n_bins=2, bar_width=20
+        )
+        self._assert_lines_equal(
+            result,
+            """\
+            === age (numeric) ===
+
+            Bin            | sample  population
+                           |
+            [10.00, 25.00) | █████████████ (50.0%)
+                           | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (75.0%)
+            [25.00, 40.00] | █████████████ (50.0%)
+                           | ▒▒▒▒▒▒▒ (25.0%)
+
+            Legend: █ sample  ▒ population
+            Bar lengths are proportional to weighted frequency within each dataset.
+            """,
+        )
+
+    def test_e2e_ascii_plot_dist_mixed(self) -> None:
+        """Full output for ascii_plot_dist with one categorical and one numeric."""
+        df_a = pd.DataFrame(
+            {"color": ["red", "blue", "blue", "green"], "age": [10.0, 20.0, 30.0, 40.0]}
+        )
+        df_b = pd.DataFrame(
+            {"color": ["red", "red", "blue", "green"], "age": [10.0, 10.0, 10.0, 40.0]}
+        )
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df_a, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+            {"df": df_b, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+        ]
+        with patch("sys.stdout", new_callable=io.StringIO):
+            result = ascii_plot_dist(
+                dfs,
+                names=["self", "target"],
+                numeric_n_values_threshold=0,
+                n_bins=2,
+                bar_width=20,
+            )
+        self._assert_lines_equal(
+            result,
+            """\
+            === color (categorical) ===
+
+            Category | sample  population
+                     |
+            blue     | ████████████████████ (50.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒ (25.0%)
+            green    | ██████████ (25.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒ (25.0%)
+            red      | ██████████ (25.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (50.0%)
+
+            Legend: █ sample  ▒ population
+            Bar lengths are proportional to weighted frequency within each dataset.
+
+            === age (numeric) ===
+
+            Bin            | sample  population
+                           |
+            [10.00, 25.00) | █████████████ (50.0%)
+                           | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (75.0%)
+            [25.00, 40.00] | █████████████ (50.0%)
+                           | ▒▒▒▒▒▒▒ (25.0%)
+
+            Legend: █ sample  ▒ population
+            Bar lengths are proportional to weighted frequency within each dataset.
+            """,
+        )
+
+    def test_e2e_plot_dist_balance_library(self) -> None:
+        """Full output through the plot_dist(library='balance') public API."""
+        df = pd.DataFrame({"color": ["red", "blue", "blue", "green"]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+        ]
+        with patch("sys.stdout", new_callable=io.StringIO):
+            result = plot_dist(
+                dfs,
+                names=["self"],
+                library="balance",
+                bar_width=20,
+            )
+        assert isinstance(result, str)
+        self._assert_lines_equal(
+            result,
+            """\
+            === color (categorical) ===
+
+            Category | sample
+                     |
+            blue     | ████████████████████ (50.0%)
+            green    | ██████████ (25.0%)
+            red      | ██████████ (25.0%)
+
+            Legend: █ sample
+            Bar lengths are proportional to weighted frequency within each dataset.
+            """,
+        )
+
+
+class TestAsciiComparativeHistEndToEnd(balance.testutil.BalanceTestCase):
+    """End-to-end tests for ascii_comparative_hist function."""
+
+    def _assert_lines_equal(self, actual: str, expected_text: str) -> None:
+        """Compare actual output lines against a dedented expected string."""
+        expected_lines = textwrap.dedent(expected_text).strip().splitlines()
+        actual_lines = [line.rstrip() for line in actual.splitlines()]
+        self.assertEqual(actual_lines, expected_lines)
+
+    def test_e2e_comparative_hist_single_dataset(self) -> None:
+        """One dataset, 2 bins — degrades to a regular histogram with filled bars."""
+        df = pd.DataFrame({"age": [10.0, 20.0, 30.0, 40.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+        ]
+        result = ascii_comparative_hist(
+            dfs, names=["Normal"], column="age", n_bins=2, bar_width=20
+        )
+        self._assert_lines_equal(
+            result,
+            """\
+            Range          | Normal (%)
+            ------------------------------------------
+            [10.00, 25.00) | ████████████████████ 50.0
+            [25.00, 40.00] | ████████████████████ 50.0
+            ------------------------------------------
+            Total          | 100.0
+            """,
+        )
+
+    def test_e2e_comparative_hist_two_datasets(self) -> None:
+        """Two datasets, 2 bins — verifies common, excess, and missing rendering."""
+        df_a = pd.DataFrame({"age": [10.0, 20.0, 30.0, 40.0]})
+        df_b = pd.DataFrame({"age": [10.0, 10.0, 10.0, 40.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df_a, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+            {"df": df_b, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+        ]
+        result = ascii_comparative_hist(
+            dfs, names=["Normal", "Skewed"], column="age", n_bins=2, bar_width=20
+        )
+        self._assert_lines_equal(
+            result,
+            """\
+            Range          | Normal (%)         | Skewed (%)
+            ---------------------------------------------------------------
+            [10.00, 25.00) | █████████████ 50.0 | █████████████▒▒▒▒▒▒▒ 75.0
+            [25.00, 40.00] | █████████████ 50.0 | ███████     ] 25.0
+            ---------------------------------------------------------------
+            Total          | 100.0              | 100.0
+
+            Key: █ = shared with Normal, ▒ = excess,    ] = deficit
+            """,
+        )
+
+    def test_e2e_comparative_hist_three_datasets(self) -> None:
+        """Three datasets, 3 bins — full comparative display."""
+        df_a = pd.DataFrame({"v": [1.0, 2.0, 3.0, 1.0, 2.0, 3.0]})
+        df_b = pd.DataFrame({"v": [1.0, 1.0, 1.0, 2.0, 2.0, 3.0]})
+        df_c = pd.DataFrame({"v": [1.0, 2.0, 3.0, 3.0, 3.0, 3.0]})
+        w_all = pd.Series([1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df_a, "weight": w_all},
+            {"df": df_b, "weight": w_all},
+            {"df": df_c, "weight": w_all},
+        ]
+        result = ascii_comparative_hist(
+            dfs, names=["Baseline", "Left", "Right"], column="v", n_bins=3, bar_width=20
+        )
+        self._assert_lines_equal(
+            result,
+            """\
+            Range        | Baseline (%)    | Left (%)             | Right (%)
+            ---------------------------------------------------------------------------------
+            [1.00, 1.67) | ██████████ 33.3 | ██████████▒▒▒▒▒ 50.0 | █████    ] 16.7
+            [1.67, 2.33) | ██████████ 33.3 | ██████████ 33.3      | █████    ] 16.7
+            [2.33, 3.00] | ██████████ 33.3 | █████    ] 16.7      | ██████████▒▒▒▒▒▒▒▒▒▒ 66.7
+            ---------------------------------------------------------------------------------
+            Total        | 100.0           | 100.0                | 100.0
+
+            Key: █ = shared with Baseline, ▒ = excess,    ] = deficit
+            """,
+        )
+
+    def test_e2e_comparative_hist_empty_data(self) -> None:
+        """Empty data returns 'No data available.' message."""
+        df_empty = pd.DataFrame({"v": pd.Series([], dtype=float)})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df_empty, "weight": pd.Series([], dtype=float)},
+        ]
+        result = ascii_comparative_hist(
+            dfs, names=["Empty"], column="v", n_bins=2, bar_width=20
+        )
+        self.assertEqual(result, "No data available.")
+
+
+class TestAsciiPlotsAdjustmentEndToEnd(balance.testutil.BalanceTestCase):
+    """End-to-end test: adjust a biased sample and verify ASCII plot output."""
+
+    def _assert_lines_equal(self, actual: str, expected_text: str) -> None:
+        """Compare actual output lines against a dedented expected string."""
+        expected_lines = textwrap.dedent(expected_text).strip().splitlines()
+        actual_lines = [line.rstrip() for line in actual.splitlines()]
+        self.assertEqual(actual_lines, expected_lines)
+
+    def test_full_pipeline_adjust_and_ascii_plot(self) -> None:
+        """Create biased sample, adjust to target, and verify ASCII comparison plot."""
+        from balance.sample_class import Sample
+
+        # Biased sample: overrepresents "male" (75%) and "young" (62.5%)
+        sample_df = pd.DataFrame(
+            {
+                "gender": ["male"] * 6 + ["female"] * 2,
+                "age_group": ["young"] * 5 + ["old"] * 3,
+                "id": list(range(1, 9)),
+            }
+        )
+        sample = Sample.from_frame(sample_df, id_column="id")
+
+        # Target population: balanced (50/50 for both)
+        target_df = pd.DataFrame(
+            {
+                "gender": ["male", "male", "female", "female"],
+                "age_group": ["young", "old", "young", "old"],
+                "id": list(range(1, 5)),
+            }
+        )
+        target = Sample.from_frame(target_df, id_column="id")
+
+        # Adjust to correct the bias
+        adjusted = sample.set_target(target).adjust(method="ipw")
+
+        # Generate ASCII plot comparing unadjusted, adjusted, and target
+        with patch("sys.stdout", new_callable=io.StringIO):
+            result = adjusted.covars().plot(library="balance", bar_width=20)
+
+        assert isinstance(result, str)
+
+        # Verify the full output matches expected ASCII plots.
+        #
+        # The plot shows three datasets per variable:
+        #   █ sample     = unadjusted (original biased sample)
+        #   ▒ adjusted   = after IPW bias correction
+        #   ▐ population = target population
+        #
+        # For gender: sample is 75% male / 25% female, population is 50/50.
+        #   IPW adjustment shifts adjusted slightly toward the target.
+        # For age_group: sample is 62.5% young / 37.5% old, population is 50/50.
+        self._assert_lines_equal(
+            result,
+            """\
+            === gender (categorical) ===
+
+            Category | sample  adjusted  population
+                     |
+            female   | ███████ (25.0%)
+                     | ▒▒▒▒▒▒▒ (26.2%)
+                     | ▐▐▐▐▐▐▐▐▐▐▐▐▐ (50.0%)
+            male     | ████████████████████ (75.0%)
+                     | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (73.8%)
+                     | ▐▐▐▐▐▐▐▐▐▐▐▐▐ (50.0%)
+
+            Legend: █ sample  ▒ adjusted  ▐ population
+            Bar lengths are proportional to weighted frequency within each dataset.
+
+            === age_group (categorical) ===
+
+            Category | sample  adjusted  population
+                     |
+            old      | ████████████ (37.5%)
+                     | ▒▒▒▒▒▒▒▒▒▒▒▒ (38.6%)
+                     | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (50.0%)
+            young    | ████████████████████ (62.5%)
+                     | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (61.4%)
+                     | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (50.0%)
+
+            Legend: █ sample  ▒ adjusted  ▐ population
+            Bar lengths are proportional to weighted frequency within each dataset.
+            """,
+        )
+
+
+class TestAsciiPlotDistTypeWarning(balance.testutil.BalanceTestCase):
+    """Tests that dist_type warnings are logged for ASCII plot functions."""
+
+    def test_ascii_plot_bar_warns_on_unsupported_dist_type(self) -> None:
+        """Test ascii_plot_bar logs warning for non-hist_ascii dist_type."""
+        import logging
+
+        df = pd.DataFrame({"g": ["a", "b"]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0])},
+        ]
+        with self.assertLogs("balance.stats_and_plots", level=logging.WARNING) as ctx:
+            ascii_plot_bar(dfs, names=["self"], column="g", dist_type="kde")
+        self.assertTrue(
+            any("only support dist_type='hist_ascii'" in m for m in ctx.output)
+        )
+
+    def test_ascii_plot_hist_warns_on_unsupported_dist_type(self) -> None:
+        """Test ascii_plot_hist logs warning for non-hist_ascii dist_type."""
+        import logging
+
+        df = pd.DataFrame({"v": [1.0, 2.0, 3.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0, 1.0])},
+        ]
+        with self.assertLogs("balance.stats_and_plots", level=logging.WARNING) as ctx:
+            ascii_plot_hist(dfs, names=["self"], column="v", dist_type="kde")
+        self.assertTrue(
+            any("only support dist_type='hist_ascii'" in m for m in ctx.output)
+        )
+
+    def test_ascii_plot_dist_warns_on_unsupported_dist_type(self) -> None:
+        """Test ascii_plot_dist logs warning for non-hist_ascii dist_type."""
+        import logging
+
+        df = pd.DataFrame({"v": ["a", "b"]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0])},
+        ]
+        with self.assertLogs("balance.stats_and_plots", level=logging.WARNING) as ctx:
+            with patch("sys.stdout", new_callable=io.StringIO):
+                ascii_plot_dist(dfs, names=["self"], dist_type="kde")
+        self.assertTrue(
+            any("only support dist_type='hist_ascii'" in m for m in ctx.output)
+        )
+
+    def test_no_warning_when_dist_type_is_hist_ascii(self) -> None:
+        """Test no warning is logged when dist_type='hist_ascii'."""
+        import logging
+
+        df = pd.DataFrame({"v": ["a", "b"]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0])},
+        ]
+        logger = logging.getLogger("balance.stats_and_plots")
+        with patch.object(logger, "warning") as mock_warn:
+            ascii_plot_bar(dfs, names=["self"], column="v", dist_type="hist_ascii")
+        mock_warn.assert_not_called()
+
+
+class TestRenderHorizontalBarsEdgeCases(balance.testutil.BalanceTestCase):
+    """Tests for edge cases in _render_horizontal_bars."""
+
+    def test_zero_max_value(self) -> None:
+        """Test that max_value=0 produces bars of length 0."""
+        result = _render_horizontal_bars(
+            label="cat",
+            proportions={"sample": 0.0},
+            legend_names=["sample"],
+            bar_width=20,
+            max_value=0.0,
+            label_width=3,
+        )
+        # bar_len should be 0, so no fill characters
+        self.assertNotIn("█", result)
+        self.assertIn("0.0%", result)
+
+
+class TestAsciiComparativeHistEdgeCases(balance.testutil.BalanceTestCase):
+    """Tests for edge cases in ascii_comparative_hist."""
+
+    def test_all_zero_weights(self) -> None:
+        """Test with all-NaN data produces 'No data available.'."""
+        df = pd.DataFrame({"v": [np.nan, np.nan]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0])},
+        ]
+        result = ascii_comparative_hist(
+            dfs, names=["Target"], column="v", n_bins=2, bar_width=10
+        )
+        self.assertEqual(result, "No data available.")
+
+    def test_weighted_with_nas(self) -> None:
+        """Test ascii_comparative_hist with weighted data containing NAs."""
+        df = pd.DataFrame({"v": [1.0, 2.0, np.nan, 4.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 2.0, 1.0, 1.0])},
+            {"df": df, "weight": pd.Series([2.0, 1.0, 1.0, 2.0])},
+        ]
+        result = ascii_comparative_hist(
+            dfs, names=["Target", "Sample"], column="v", n_bins=2, bar_width=10
+        )
+        # Should produce output without error, with NAs removed
+        self.assertIn("Target", result)
+        self.assertIn("Sample", result)
+        self.assertIn("Total", result)
+
+    def test_all_zero_weights_two_datasets(self) -> None:
+        """Test ascii_comparative_hist with all-zero weights (max_pct == 0)."""
+        df = pd.DataFrame({"v": [1.0, 2.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([0.0, 0.0])},
+            {"df": df, "weight": pd.Series([0.0, 0.0])},
+        ]
+        result = ascii_comparative_hist(
+            dfs, names=["Target", "Sample"], column="v", n_bins=2, bar_width=10
+        )
+        # All bins should show 0.0, totals should be 0.0
+        self.assertIn("0.0", result)
+        self.assertIn("Total", result)
+        # Data rows should have no bars (only the Key line has █)
+        data_lines = [
+            line
+            for line in result.splitlines()
+            if not line.startswith("Key:") and not line.startswith("---")
+        ]
+        for line in data_lines:
+            if "0.0" in line and "Total" not in line:
+                # Data bin lines should have no fill characters
+                self.assertNotIn("▒", line)
+
+    def test_unweighted(self) -> None:
+        """Test ascii_comparative_hist with weighted=False."""
+        df = pd.DataFrame({"v": [1.0, 2.0, 3.0, 4.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([10.0, 10.0, 10.0, 10.0])},
+        ]
+        result = ascii_comparative_hist(
+            dfs, names=["Base"], column="v", n_bins=2, bar_width=10, weighted=False
+        )
+        # Without weighting, each value counts equally
+        self.assertIn("50.0", result)
+
+    def test_identical_values(self) -> None:
+        """Test ascii_comparative_hist when all values are identical (lines 463-464)."""
+        df = pd.DataFrame({"v": [5.0, 5.0, 5.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0, 1.0])},
+        ]
+        result = ascii_comparative_hist(
+            dfs, names=["Base"], column="v", n_bins=2, bar_width=10
+        )
+        # Should not error; global_min == global_max triggers the ±0.5 adjustment
+        self.assertIn("Base", result)
+        self.assertIn("100.0", result)
+
+    def test_deficit_of_one(self) -> None:
+        """Test ascii_comparative_hist deficit==1 renders ']' (lines 519-520)."""
+        # Craft data so that one bin has a deficit of exactly 1 character
+        # Baseline: 2 values in bin0, 2 in bin1 => 50%/50%
+        # Comparison: 3 values in bin0, 1 in bin1
+        # With bar_width=10: baseline_len=5 for 50%, comparison bin1 => 1/4=25% => bar_len=2.5->round(2 or 3)
+        # We need precise control: bar_width=4
+        # Baseline 50% => baseline_len = round(50/50*4) = 4
+        # Comparison bin1: 25% => bar_len = round(25/50*4) = round(2) = 2
+        # deficit = 4 - 2 = 2, which is >= 2, not == 1
+        # Let's try bar_width=3:
+        # Baseline 50% => round(50/50*3) = 3
+        # Comparison bin1: 25% => round(25/50*3) = round(1.5) = 2
+        # deficit = 3 - 2 = 1 => exactly deficit == 1!
+        df_a = pd.DataFrame({"v": [0.5, 0.5, 1.5, 1.5]})
+        df_b = pd.DataFrame({"v": [0.5, 0.5, 0.5, 1.5]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df_a, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+            {"df": df_b, "weight": pd.Series([1.0, 1.0, 1.0, 1.0])},
+        ]
+        result = ascii_comparative_hist(
+            dfs, names=["Base", "Test"], column="v", n_bins=2, bar_width=3
+        )
+        # deficit==1 should render as "██]" (bar_len chars + "]")
+        self.assertIn("]", result)
+
+    def test_deficit_of_zero(self) -> None:
+        """Test ascii_comparative_hist deficit==0 renders no bracket (lines 521-522)."""
+        # Same proportions in both datasets => deficit is 0 for all bins
+        df = pd.DataFrame({"v": [0.5, 1.5]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0])},
+            {"df": df, "weight": pd.Series([1.0, 1.0])},
+        ]
+        result = ascii_comparative_hist(
+            dfs, names=["Base", "Same"], column="v", n_bins=2, bar_width=10
+        )
+        # No deficit or excess in the "Same" column
+        for line in result.splitlines():
+            if "Same (%)" in line or line.startswith("---") or line.startswith("Key:"):
+                continue
+            # Check the Same column portion (after the second |)
+            parts = line.split("|")
+            if len(parts) >= 3:
+                same_col = parts[2]
+                self.assertNotIn("▒", same_col)
+                # The ] in same_col would only be a deficit bracket, not a bin label
+                self.assertNotIn("]", same_col)
+
+
+class TestAsciiPlotDistAllNanVariable(balance.testutil.BalanceTestCase):
+    """Test ascii_plot_dist skips all-NaN variables (lines 680-681)."""
+
+    def test_skips_all_nan_variable(self) -> None:
+        """Test that a variable with all NaN values is skipped with a warning."""
+        import logging
+
+        df = pd.DataFrame({"good": ["a", "b", "c"], "bad": [np.nan, np.nan, np.nan]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0, 1.0])},
+        ]
+        with self.assertLogs("balance.stats_and_plots", level=logging.WARNING) as ctx:
+            with patch("sys.stdout", new_callable=io.StringIO):
+                result = ascii_plot_dist(dfs, names=["self"])
+        # The good variable should be plotted
+        self.assertIn("good", result)
+        # The warning should mention the bad variable
+        self.assertTrue(any("bad" in m for m in ctx.output))

--- a/tests/test_weighted_comparisons_plots.py
+++ b/tests/test_weighted_comparisons_plots.py
@@ -441,7 +441,7 @@ class Test_weighted_comparisons_plots(balance.testutil.BalanceTestCase):
         self.assertEqual(type(dict_of_figures["v1"]), go.Figure)
 
         # Test error handling for invalid library parameter
-        with self.assertRaisesRegex(ValueError, "library must be either*"):
+        with self.assertRaisesRegex(ValueError, "library must be"):
             plot_dist(
                 test_datasets,
                 names=["self", "unadjusted", "target"],
@@ -1948,3 +1948,87 @@ class TestPlotDistPlotlyUnsupportedDistType(balance.testutil.BalanceTestCase):
                 dist_type="ecdf",
             )
         self.assertIn("plotly library does not support", str(context.exception))
+
+    def test_plot_dist_plotly_raises_on_hist_ascii_dist_type(self) -> None:
+        """Test plot_dist with plotly library raises on hist_ascii dist_type."""
+        df = pd.DataFrame({"v1": [1.0, 2.0, 3.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": None},
+            {"df": df.copy(), "weight": None},
+        ]
+        with self.assertRaises(ValueError) as context:
+            weighted_comparisons_plots.plot_dist(
+                dfs,
+                names=["self", "target"],
+                library="plotly",
+                dist_type="hist_ascii",
+            )
+        self.assertIn("plotly library does not support", str(context.exception))
+        self.assertIn("hist_ascii", str(context.exception))
+
+
+class TestPlotDistBalanceUnsupportedDistType(balance.testutil.BalanceTestCase):
+    """Test that plot_dist with balance library warns on unsupported dist_type."""
+
+    def test_plot_dist_balance_warns_on_non_hist_ascii_dist_type(self) -> None:
+        """Test plot_dist with balance library logs warning for non-hist_ascii dist_type."""
+        import io
+        import logging
+        from unittest.mock import patch
+
+        df = pd.DataFrame({"v1": ["a", "a", "b"]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series([1.0, 1.0, 1.0])},
+        ]
+        with self.assertLogs(
+            "balance.stats_and_plots", level=logging.WARNING
+        ) as log_ctx:
+            with patch("sys.stdout", new_callable=io.StringIO):
+                weighted_comparisons_plots.plot_dist(
+                    dfs,
+                    names=["self"],
+                    library="balance",
+                    dist_type="kde",
+                )
+        self.assertTrue(
+            any("only supports dist_type='hist_ascii'" in msg for msg in log_ctx.output)
+        )
+
+
+class TestPlotDistSeabornDistType(balance.testutil.BalanceTestCase):
+    """Test plot_dist with seaborn library and various dist_type values."""
+
+    def test_plot_dist_seaborn_default_dist_type(self) -> None:
+        """Test plot_dist with seaborn and dist_type=None uses kde default."""
+        df = pd.DataFrame({"v1": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(5))},
+            {"df": df.copy(), "weight": pd.Series(np.ones(5))},
+        ]
+        # dist_type=None should work without error for seaborn
+        result = weighted_comparisons_plots.plot_dist(
+            dfs,
+            names=["self", "target"],
+            library="seaborn",
+            dist_type=None,
+        )
+        # seaborn returns None by default (no return_axes)
+        self.assertIsNone(result)
+        plt.close("all")
+
+    def test_plot_dist_seaborn_raises_on_hist_ascii(self) -> None:
+        """Test plot_dist with seaborn raises on hist_ascii dist_type."""
+        df = pd.DataFrame({"v1": [1.0, 2.0, 3.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df, "weight": pd.Series(np.ones(3))},
+            {"df": df.copy(), "weight": pd.Series(np.ones(3))},
+        ]
+        with self.assertRaises(ValueError) as context:
+            weighted_comparisons_plots.plot_dist(
+                dfs,
+                names=["self", "target"],
+                library="seaborn",
+                dist_type="hist_ascii",
+            )
+        self.assertIn("seaborn library does not support", str(context.exception))
+        self.assertIn("hist_ascii", str(context.exception))

--- a/tutorials/balance_quickstart.ipynb
+++ b/tutorials/balance_quickstart.ipynb
@@ -428,9 +428,9 @@
     "  (See: https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence)\n",
     "- **EMD (Earth Mover's Distance)** measures the minimum \"cost\" to transform one distribution into another.\n",
     "  (See: https://en.wikipedia.org/wiki/Earth_mover%27s_distance)\n",
-    "- **CVMD (Cram\u00e9r\u2013von Mises distance)** measures the integrated squared difference between the empirical CDFs.\n",
+    "- **CVMD (Cramér–von Mises distance)** measures the integrated squared difference between the empirical CDFs.\n",
     "  (See: https://en.wikipedia.org/wiki/Cram%C3%A9r%E2%80%93von_Mises_criterion)\n",
-    "- **KS (Kolmogorov\u2013Smirnov distance)** measures the maximum absolute difference between the empirical CDFs.\n",
+    "- **KS (Kolmogorov–Smirnov distance)** measures the maximum absolute difference between the empirical CDFs.\n",
     "  (See: https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test)\n",
     "\n",
     "Note: Distribution diagnostics operate on the raw covariates (with NA indicators), rather than the model matrix, so categorical variables stay intact.\n",
@@ -680,6 +680,140 @@
     "# This shows how we could use seaborn to plot a kernel density estimation\n",
     "adjusted.covars().plot(library = \"seaborn\", dist_type = \"kde\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## ASCII Comparative Histogram\n",
+    "\n",
+    "When working in a terminal, notebook with limited rendering, or logging context, you can use `ascii_comparative_hist` to get a quick text-based comparison of numeric distributions across datasets.\n",
+    "\n",
+    "The first dataset serves as the **baseline**. For each bin in subsequent datasets:\n",
+    "- `█` (solid) shows the proportion shared with the baseline\n",
+    "- `▒` (shaded) shows excess beyond the baseline\n",
+    "- `   ]` (right bracket) shows deficit relative to the baseline"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from balance.stats_and_plots.ascii_plots import ascii_comparative_hist\n",
+    "\n",
+    "# Compare the income distribution: target (baseline) vs unadjusted sample\n",
+    "dfs = [\n",
+    "    {\"df\": target_df, \"weight\": None},\n",
+    "    {\"df\": sample_df, \"weight\": None},\n",
+    "]\n",
+    "print(ascii_comparative_hist(dfs, names=[\"Target\", \"Sample\"], column=\"income\", n_bins=5, bar_width=20))"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## ASCII Grouped Histogram\n",
+    "\n",
+    "`ascii_plot_hist` provides a simpler side-by-side view: each dataset gets its own bar (with a distinct fill character) so you can compare how mass is distributed across bins. Bar lengths are proportional to weighted frequency within each dataset."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from balance.stats_and_plots.ascii_plots import ascii_plot_hist\n",
+    "\n",
+    "# Compare the income distribution: target vs unadjusted sample\n",
+    "dfs = [\n",
+    "    {\"df\": target_df, \"weight\": None},\n",
+    "    {\"df\": sample_df, \"weight\": None},\n",
+    "]\n",
+    "print(ascii_plot_hist(dfs, names=[\"Target\", \"Sample\"], column=\"income\", n_bins=5, bar_width=30))"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## ASCII Plot: Adjusted vs Unadjusted vs Target\n",
+    "\n",
+    "You can also use `library=\"balance\"` with the standard `.covars().plot()` API on an\n",
+    "adjusted `Sample` to get a three-way ASCII comparison. This shows the full pipeline\n",
+    "output — unadjusted sample, adjusted (IPW-reweighted) sample, and target population —\n",
+    "side by side, which is useful for verifying that adjustment moved the distributions\n",
+    "in the right direction.\n",
+    "\n",
+    "Each variable is plotted as a grouped barplot (categorical) or histogram (numeric).\n",
+    "The three fill characters distinguish the datasets:\n",
+    "- `█` = **sample** (unadjusted)\n",
+    "- `▒` = **adjusted** (after IPW)\n",
+    "- `▐` = **population** (target)"
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# ASCII plot comparing all three: unadjusted sample, adjusted sample, and target population\n",
+    "adjusted.covars().plot(library=\"balance\", bar_width=30)"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Focusing on a numeric variable\n",
+    "\n",
+    "You can pass `variables=[\"income\"]` to plot just one covariate. For numeric variables\n",
+    "the output is a grouped histogram where each bin shows the weighted proportion for\n",
+    "the unadjusted sample, adjusted sample, and target population. This makes it easy to\n",
+    "see whether adjustment shifted the distribution toward the target."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Grouped histogram for income only: sample vs adjusted vs population\n",
+    "adjusted.covars().plot(library=\"balance\", variables=[\"income\"], n_bins=10, bar_width=30)"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "You can also use `ascii_comparative_hist` directly with the adjusted weights to get the\n",
+    "baseline-relative view. Here the target is the baseline, so `▒` shows where the adjusted\n",
+    "sample has **more** mass than the target and `   ]` shows where it has **less**."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Comparative histogram: target (baseline) vs unadjusted vs adjusted for income\n",
+    "# Uses the adjusted weights from the IPW model to show how reweighting corrects bias\n",
+    "dfs = [\n",
+    "    {\"df\": target.covars().df, \"weight\": target.weight_column},\n",
+    "    {\"df\": sample_with_target.covars().df, \"weight\": sample_with_target.weight_column},\n",
+    "    {\"df\": adjusted.covars().df, \"weight\": adjusted.weight_column},\n",
+    "]\n",
+    "print(ascii_comparative_hist(\n",
+    "    dfs, names=[\"Target\", \"Unadjusted\", \"Adjusted\"],\n",
+    "    column=\"income\", n_bins=5, bar_width=20,\n",
+    "))"
+   ],
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Summary:
This change adds ASCII text plotting capabilities to the balance library, enabling text-based visualization of weighted distribution comparisons that is suitable for LLM consumption.

The motivation is to provide a way to visualize balance diagnostics in environments where graphical plotting is not available or practical, such as when working with LLMs that can process text output but not images.

Key additions:
- New `ascii_plots.py` module with functions for ASCII histograms (`ascii_plot_hist`) and barplots (`ascii_plot_bar`)
- `ascii_plot_dist` dispatcher that automatically chooses histogram vs barplot based on variable type
- Integration into the existing `plot_dist` API via `library="balance"` parameter
- Support for weighted distributions with multiple dataset comparisons using distinct characters (#, =, ., +, ~, *) for each dataset

Differential Revision: D93754276


