### PR TITLE
Prepare SampleFrame for inheritance (#385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@
   - Column-role list properties: `covars_columns`, `weight_columns`,
     `outcome_columns`, `predicted_outcome_columns`, `misc_columns` (all return
     copies).
+  - `ignored_columns()`: alias for `df_misc`, provided for API parity with
+    `Sample.ignored_columns()`.
   - Internal `_create()` factory with `_skip_copy` optimization for callers that
     have already deep-copied.
   - Comprehensive validation: null/negative/non-numeric weights, null IDs,

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -577,7 +577,7 @@ class BalanceFrame:
             id_column=self._responders.id_column_name,
             weight_column=self._responders.active_weight_column,
             outcome_columns=self._responders.outcome_columns or None,
-            ignore_columns=self._responders.misc_columns or None,
+            ignore_columns=self._responders.ignore_columns or None,
             standardize_types=False,
         )
         target_sample = Sample.from_frame(
@@ -585,7 +585,7 @@ class BalanceFrame:
             id_column=target.id_column_name,
             weight_column=target.active_weight_column,
             outcome_columns=target.outcome_columns or None,
-            ignore_columns=target.misc_columns or None,
+            ignore_columns=target.ignore_columns or None,
             standardize_types=False,
         )
         result = resp_sample.set_target(target_sample)
@@ -596,7 +596,7 @@ class BalanceFrame:
                 id_column=self._unadjusted.id_column_name,
                 weight_column=self._unadjusted.active_weight_column,
                 outcome_columns=self._unadjusted.outcome_columns or None,
-                ignore_columns=self._unadjusted.misc_columns or None,
+                ignore_columns=self._unadjusted.ignore_columns or None,
                 standardize_types=False,
             )
             result._links["unadjusted"] = unadj_sample
@@ -952,7 +952,7 @@ class BalanceFrame:
             >>> resp = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0],
             ...                   "weight": [1.0, 1.0], "region": ["US", "UK"]}),
-            ...     misc_columns=["region"])
+            ...     ignore_columns=["region"])
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
             >>> bf = BalanceFrame(responders=resp, target=tgt)
@@ -1151,9 +1151,9 @@ class BalanceFrame:
                 sf._column_roles["predicted"] = [
                     c for c in sf._column_roles["predicted"] if c in keep_set
                 ]
-            if sf._column_roles["misc"]:
-                sf._column_roles["misc"] = [
-                    c for c in sf._column_roles["misc"] if c in keep_set
+            if sf._column_roles["ignored"]:
+                sf._column_roles["ignored"] = [
+                    c for c in sf._column_roles["ignored"] if c in keep_set
                 ]
 
         sf._df = df

--- a/balance/cli.py
+++ b/balance/cli.py
@@ -801,7 +801,10 @@ class BalanceCLI:
             )
 
             # Update dtypes
-            if self.args.return_df_with_original_dtypes:
+            if (
+                self.args.return_df_with_original_dtypes
+                and adjusted._df_dtypes is not None
+            ):
                 df_to_return = balance.util._astype_in_df_from_dtypes(
                     adjusted.df, adjusted._df_dtypes
                 )
@@ -826,7 +829,10 @@ class BalanceCLI:
                 error_message = f"{module_name}: {e}"
                 logger.exception("The error message is: " + error_message)
                 # Update dtypes
-                if self.args.return_df_with_original_dtypes:
+                if (
+                    self.args.return_df_with_original_dtypes
+                    and sample._df_dtypes is not None
+                ):
                     df_to_return = balance.util._astype_in_df_from_dtypes(
                         sample.df, sample._df_dtypes
                     )

--- a/balance/sample_frame.py
+++ b/balance/sample_frame.py
@@ -332,7 +332,13 @@ class SampleFrame:
                 + null_weight_rows.to_string(index=False)
             )
 
-        if not np.issubdtype(_df[weight_column].dtype, np.number):
+        try:
+            is_numeric = np.issubdtype(_df[weight_column].dtype, np.number)
+        except TypeError:
+            # Extension dtypes (e.g. pandas StringDtype) can't be interpreted
+            # by np.issubdtype — treat them as non-numeric.
+            is_numeric = False
+        if not is_numeric:
             raise ValueError("Weights must be numeric")
 
         if any(_df[weight_column] < 0):

--- a/balance/sample_frame.py
+++ b/balance/sample_frame.py
@@ -7,7 +7,7 @@
 
 """SampleFrame: an explicit-role DataFrame container for the Balance library.
 
-Stores covariates, weights, outcomes, predicted, and misc columns with
+Stores covariates, weights, outcomes, predicted, and ignored columns with
 explicit role metadata, replacing the inference-by-exclusion pattern used
 in the legacy Sample class.
 """
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 
 if TYPE_CHECKING:
-    from balance.balancedf_class import BalanceDFSource
+    from balance.balancedf_class import BalanceDFSource  # noqa: F401
 
 
 logger: logging.Logger = logging.getLogger(__package__)
@@ -33,7 +33,7 @@ class SampleFrame:
 
     SampleFrame stores data as a single internal pd.DataFrame but with
     explicit metadata tracking which columns belong to which role:
-    covars (X), weights (W), outcomes (Y), predicted_outcomes (Y_hat), misc.
+    covars (X), weights (W), outcomes (Y), predicted_outcomes (Y_hat), ignored.
 
     Must be constructed via SampleFrame.from_frame() or SampleFrame.from_sample().
 
@@ -66,27 +66,17 @@ class SampleFrame:
     _active_weight_column: str | None
     # pyre-fixme[13]: Initialized in _create() which bypasses __init__
     _weight_metadata: dict[str, Any]
+    # pyre-fixme[13]: Initialized in _create() which bypasses __init__
+    _links: dict[str, Any]
+    # pyre-fixme[13]: Initialized in _create() which bypasses __init__
+    _df_dtypes: pd.Series | None
     # SampleFrame is a single-DataFrame container and does NOT manage
-    # multi-sample relationships.  _links is exposed as a read-only property
-    # returning an empty dict to satisfy the BalanceDFSource protocol.
-    # Link management belongs in BalanceDF/BalanceFrame, which can pass
-    # explicit links via the BalanceDF(links=...) parameter.
+    # multi-sample relationships.  _links is initialised to an empty dict
+    # in _create() to satisfy the BalanceDFSource protocol.  BalanceFrame
+    # overrides _links with a defaultdict(list) in its own _create().
 
     def __init__(self) -> None:
-        raise NotImplementedError(
-            "SampleFrame must be constructed via from_frame() or from_sample(). "
-            "Direct construction is not supported."
-        )
-
-    @property
-    def _links(self) -> dict[str, BalanceDFSource]:
-        """Return an empty links dict (satisfies BalanceDFSource protocol).
-
-        SampleFrame is a single-DataFrame container and does not manage
-        multi-sample relationships.  Link management belongs in
-        BalanceDF/BalanceFrame.
-        """
-        return {}
+        pass
 
     def __len__(self) -> int:
         """Return the number of rows in the SampleFrame.
@@ -121,13 +111,16 @@ class SampleFrame:
             >>> sf2._df is sf._df
             False
         """
-        new_instance = object.__new__(SampleFrame)
+        new_instance = object.__new__(type(self))
         memo[id(self)] = new_instance
         new_instance._df = self._df.copy()
         new_instance._id_column_name = self._id_column_name
         new_instance._column_roles = deepcopy(self._column_roles, memo)
         new_instance._active_weight_column = self._active_weight_column
         new_instance._weight_metadata = deepcopy(self._weight_metadata, memo)
+        new_instance._links = deepcopy(getattr(self, "_links", {}), memo)
+        _df_dtypes = getattr(self, "_df_dtypes", None)
+        new_instance._df_dtypes = _df_dtypes.copy() if _df_dtypes is not None else None
         return new_instance
 
     @classmethod
@@ -139,8 +132,9 @@ class SampleFrame:
         weight_columns: list[str],
         outcome_columns: list[str] | None = None,
         predicted_outcome_columns: list[str] | None = None,
-        misc_columns: list[str] | None = None,
+        ignore_columns: list[str] | None = None,
         _skip_copy: bool = False,
+        _df_dtypes: pd.Series | None = None,
     ) -> SampleFrame:
         """Internal factory method. Use from_frame() instead."""
         instance = object.__new__(cls)
@@ -151,11 +145,13 @@ class SampleFrame:
             "weights": list(weight_columns),
             "outcomes": list(outcome_columns or []),
             "predicted": list(predicted_outcome_columns or []),
-            "misc": list(misc_columns or []),
+            "ignored": list(ignore_columns or []),
         }
         instance._active_weight_column = weight_columns[0] if weight_columns else None
         # Defaults; set via set_weight_metadata() etc.
         instance._weight_metadata = {}
+        instance._links = {}
+        instance._df_dtypes = _df_dtypes
         return instance
 
     # --- Construction ---
@@ -169,7 +165,7 @@ class SampleFrame:
         weight_column: str | None = None,
         outcome_columns: list[str] | tuple[str, ...] | str | None = None,
         predicted_outcome_columns: list[str] | tuple[str, ...] | str | None = None,
-        misc_columns: list[str] | tuple[str, ...] | str | None = None,
+        ignore_columns: list[str] | tuple[str, ...] | str | None = None,
         check_id_uniqueness: bool = True,
         standardize_types: bool = True,
         use_deepcopy: bool = True,
@@ -190,7 +186,7 @@ class SampleFrame:
                 (``"id"``, ``"ID"``, etc.).
             covars_columns (list of str, optional): Explicit list of covariate
                 column names. If None, inferred by exclusion (all columns
-                minus id, weight, outcome, predicted, and misc columns).
+                minus id, weight, outcome, predicted, and ignored columns).
             weight_column (str, optional): Name of the column containing
                 sampling weights. If None, guesses ``"weight"``/``"weights"``
                 or creates one filled with 1.0.
@@ -198,8 +194,8 @@ class SampleFrame:
                 treat as outcome variables.
             predicted_outcome_columns (list of str or str, optional): Column
                 names to treat as predicted outcome variables.
-            misc_columns (list of str or str, optional): Column names to treat
-                as miscellaneous (excluded from covariates).
+            ignore_columns (list of str or str, optional): Column names to
+                ignore (excluded from covariates).
             check_id_uniqueness (bool): Whether to verify id uniqueness.
                 Defaults to True.
             standardize_types (bool): Whether to standardize dtypes.
@@ -208,14 +204,13 @@ class SampleFrame:
                 Defaults to True.
             id_column_candidates (list of str, optional): Candidate id column
                 names to try when ``id_column`` is None.
-
         Returns:
             SampleFrame: A validated SampleFrame with standardized dtypes.
 
         Raises:
             ValueError: If the id column contains nulls or duplicates, if the
                 weight column contains nulls or negative values, or if
-                specified outcome/predicted/misc columns are missing from the
+                specified outcome/predicted/ignore columns are missing from the
                 DataFrame.
 
         Examples:
@@ -238,8 +233,8 @@ class SampleFrame:
             outcome_columns = [outcome_columns]
         if isinstance(predicted_outcome_columns, str):
             predicted_outcome_columns = [predicted_outcome_columns]
-        if isinstance(misc_columns, str):
-            misc_columns = [misc_columns]
+        if isinstance(ignore_columns, str):
+            ignore_columns = [ignore_columns]
 
         # Deep copy
         df_dtypes = df.dtypes
@@ -364,14 +359,21 @@ class SampleFrame:
                     f"predicted outcome columns {list(missing_predicted)} not in df columns {_df.columns.values.tolist()}"
                 )
 
-        # --- Misc columns validation ---
-        misc_list: list[str] | None = None
-        if misc_columns is not None:
-            misc_list = list(misc_columns)
-            missing_misc = set(misc_list).difference(_df.columns)
-            if missing_misc:
+        # --- Ignore columns validation ---
+        ignore_list: list[str] | None = None
+        if ignore_columns is not None:
+            ignore_list = list(dict.fromkeys(ignore_columns))  # deduplicate
+            missing_ignore = set(ignore_list).difference(_df.columns)
+            if missing_ignore:
                 raise ValueError(
-                    f"misc columns {list(missing_misc)} not in df columns {_df.columns.values.tolist()}"
+                    f"ignore columns {list(missing_ignore)} not in df columns {_df.columns.values.tolist()}"
+                )
+            # ignore_columns must not overlap with id/weight columns
+            reserved = {id_col_name, weight_column} - {None}
+            overlap_reserved = set(ignore_list).intersection(reserved)
+            if overlap_reserved:
+                raise ValueError(
+                    f"ignore columns cannot include id/weight columns: {overlap_reserved}"
                 )
 
         # --- Covariate columns ---
@@ -384,7 +386,7 @@ class SampleFrame:
                 )
         else:
             # Infer by exclusion
-            ignored = (predicted_list or []) + (misc_list or [])
+            ignored = (predicted_list or []) + (ignore_list or [])
             special = {id_col_name, weight_column}
             special.update(outcome_list or [])
             special.update(ignored or [])
@@ -395,7 +397,7 @@ class SampleFrame:
             "covars": covar_list,
             "outcomes": outcome_list or [],
             "predicted": predicted_list or [],
-            "misc": misc_list or [],
+            "ignored": ignore_list or [],
         }
         roles = list(role_to_columns.keys())
         for i in range(len(roles)):
@@ -415,8 +417,9 @@ class SampleFrame:
             weight_columns=[weight_column],
             outcome_columns=outcome_list,
             predicted_outcome_columns=predicted_list,
-            misc_columns=misc_list,
+            ignore_columns=ignore_list,
             _skip_copy=True,
+            _df_dtypes=df_dtypes,
         )
 
     # --- Column role accessors ---
@@ -507,25 +510,25 @@ class SampleFrame:
         return list(self._column_roles["predicted"])
 
     @property
-    def misc_columns(self) -> list[str]:
-        """Names of the miscellaneous columns.
+    def ignore_columns(self) -> list[str]:
+        """Names of the ignored columns.
 
         Returns a copy so that callers cannot accidentally mutate the
         internal column-role registry.
 
         Returns:
-            list[str]: Misc column names (empty list if none).
+            list[str]: Ignored column names (empty list if none).
 
         Examples:
             >>> import pandas as pd
             >>> from balance.sample_frame import SampleFrame
             >>> df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20],
             ...                    "weight": [1.0, 1.0], "region": ["US", "UK"]})
-            >>> sf = SampleFrame.from_frame(df, misc_columns=["region"])
-            >>> sf.misc_columns
+            >>> sf = SampleFrame.from_frame(df, ignore_columns=["region"])
+            >>> sf.ignore_columns
             ['region']
         """
-        return list(self._column_roles["misc"])
+        return list(self._column_roles["ignored"])
 
     @property
     def active_weight_column(self) -> str | None:
@@ -641,53 +644,49 @@ class SampleFrame:
         return self._df[cols].copy() if cols else None
 
     @property
-    def df_misc(self) -> pd.DataFrame | None:
-        """Misc columns, or None.
+    def df_ignored(self) -> pd.DataFrame | None:
+        """Ignored columns, or None.
 
         Returns a copy so that callers cannot accidentally mutate the
         internal data.
 
         Returns:
-            pd.DataFrame | None: A copy of miscellaneous columns, or
-                None if no misc columns are registered.
+            pd.DataFrame | None: A copy of ignored columns, or
+                None if no ignored columns are registered.
 
         Examples:
             >>> import pandas as pd
             >>> from balance.sample_frame import SampleFrame
             >>> df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20],
             ...                    "weight": [1.0, 1.0], "region": ["US", "UK"]})
-            >>> sf = SampleFrame.from_frame(df, misc_columns=["region"])
-            >>> m = sf.df_misc
+            >>> sf = SampleFrame.from_frame(df, ignore_columns=["region"])
+            >>> m = sf.df_ignored
             >>> m["region"] = ["XX", "XX"]
-            >>> list(sf.df_misc["region"])  # internal data unchanged
+            >>> list(sf.df_ignored["region"])  # internal data unchanged
             ['US', 'UK']
         """
-        cols = self._column_roles["misc"]
+        cols = self._column_roles["ignored"]
         return self._df[cols].copy() if cols else None
 
     def ignored_columns(self) -> pd.DataFrame | None:
-        """Return ignored (misc) columns as a DataFrame, or None.
-
-        This is an alias for :attr:`df_misc`, provided for API parity with
-        :class:`~balance.sample_class.Sample` which uses ``ignored_columns()``
-        to access miscellaneous/ignored columns.
+        """Return ignored columns as a DataFrame, or None.
 
         Returns:
-            pd.DataFrame | None: A copy of miscellaneous columns, or
-                None if no misc columns are registered.
+            pd.DataFrame | None: A copy of ignored columns, or
+                None if no ignored columns are registered.
 
         Examples:
             >>> import pandas as pd
             >>> from balance.sample_frame import SampleFrame
             >>> df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20],
             ...                    "weight": [1.0, 1.0], "region": ["US", "UK"]})
-            >>> sf = SampleFrame.from_frame(df, misc_columns=["region"])
+            >>> sf = SampleFrame.from_frame(df, ignore_columns=["region"])
             >>> sf.ignored_columns()
                    region
             0     US
             1     UK
         """
-        return self.df_misc
+        return self.df_ignored
 
     @property
     def id_column(self) -> pd.Series:
@@ -827,11 +826,15 @@ class SampleFrame:
 
     # --- BalanceDF integration ---
 
-    def covars(self) -> Any:
+    def covars(self, formula: str | list[str] | None = None) -> Any:
         """Return a :class:`~balance.balancedf_class.BalanceDFCovars` for this SampleFrame.
 
         Creates a covariate analysis view backed by this SampleFrame,
         inheriting any linked sources set via ``_links``.
+
+        Args:
+            formula: Optional formula string (or list) for model matrix
+                construction. Passed through to BalanceDFCovars.
 
         Returns:
             BalanceDFCovars: Covariate view backed by this SampleFrame.
@@ -847,7 +850,8 @@ class SampleFrame:
         """
         from balance.balancedf_class import BalanceDFCovars
 
-        return BalanceDFCovars(self)
+        # pyre-ignore[6]: SampleFrame satisfies BalanceDFSource at runtime
+        return BalanceDFCovars(self, formula=formula)
 
     def weights(self) -> Any:
         """Return a :class:`~balance.balancedf_class.BalanceDFWeights` for this SampleFrame.
@@ -869,6 +873,7 @@ class SampleFrame:
         """
         from balance.balancedf_class import BalanceDFWeights
 
+        # pyre-ignore[6]: SampleFrame satisfies BalanceDFSource at runtime
         return BalanceDFWeights(self)
 
     def outcomes(self) -> Any | None:
@@ -895,6 +900,7 @@ class SampleFrame:
         # Deferred import to avoid circular dependency with balancedf_class
         from balance.balancedf_class import BalanceDFOutcomes
 
+        # pyre-ignore[6]: SampleFrame satisfies BalanceDFSource at runtime
         return BalanceDFOutcomes(self)
 
     @property
@@ -988,6 +994,42 @@ class SampleFrame:
             )
         self._active_weight_column = column_name
 
+    def rename_weight_column(self, old_name: str, new_name: str) -> None:
+        """Rename a weight column in-place.
+
+        Renames the column in the DataFrame, updates the column roles list,
+        active weight pointer, and weight metadata.
+
+        Args:
+            old_name: Current name of the weight column.
+            new_name: New name for the weight column.
+
+        Raises:
+            ValueError: If *old_name* is not a registered weight column,
+                or if *new_name* already exists in the DataFrame.
+        """
+        if old_name not in self._column_roles["weights"]:
+            raise ValueError(
+                f"'{old_name}' is not a weight column. "
+                f"Weight columns: {self._column_roles['weights']}"
+            )
+        if new_name in self._df.columns:
+            raise ValueError(
+                f"'{new_name}' already exists in the DataFrame. "
+                "Choose a different name."
+            )
+        # Rename in DataFrame
+        self._df = self._df.rename(columns={old_name: new_name})
+        # Update column roles
+        idx = self._column_roles["weights"].index(old_name)
+        self._column_roles["weights"][idx] = new_name
+        # Update active weight pointer
+        if self._active_weight_column == old_name:
+            self._active_weight_column = new_name
+        # Migrate metadata
+        if old_name in self._weight_metadata:
+            self._weight_metadata[new_name] = self._weight_metadata.pop(old_name)
+
     def add_weight_column(
         self,
         name: str,
@@ -1034,10 +1076,16 @@ class SampleFrame:
                 f"Choose a different name."
             )
         if len(values) != len(self._df):
-            raise ValueError(
-                f"'values' length ({len(values)}) doesn't match "
-                f"DataFrame length ({len(self._df)})"
-            )
+            if isinstance(values, pd.Series) and len(values) < len(self._df):
+                # Align by index, padding missing rows with NaN.
+                # This supports adjustment functions that drop rows internally
+                # (e.g., na_action="drop") and return fewer weights.
+                values = values.reindex(self._df.index)
+            else:
+                raise ValueError(
+                    f"'values' length ({len(values)}) doesn't match "
+                    f"DataFrame length ({len(self._df)})"
+                )
         self._df[name] = values.to_numpy()
         self._column_roles["weights"].append(name)
         if metadata is not None:
@@ -1048,8 +1096,8 @@ class SampleFrame:
         """Convert a :class:`~balance.sample_class.Sample` to a SampleFrame.
 
         Preserves the Sample's tabular data and column role assignments:
-        id column, weight column, outcome columns, and ignored columns
-        (mapped to ``misc``).  Covariate columns are inferred by exclusion,
+        id column, weight column, outcome columns, and ignored columns.
+        Covariate columns are inferred by exclusion,
         matching the Sample's own logic.
 
         The internal DataFrame is deep-copied so that the resulting
@@ -1100,8 +1148,18 @@ class SampleFrame:
                 f"'sample' must be a Sample instance, got {type(sample).__name__}"
             )
 
-        id_col_name: str = sample.id_column.name
-        weight_col_name: str = sample.weight_column.name
+        _id_col = sample.id_column
+        _weight_col = sample.weight_column
+        if _id_col is None:
+            raise ValueError(
+                "Sample must have an id_column before converting to SampleFrame."
+            )
+        if _weight_col is None:
+            raise ValueError(
+                "Sample must have a weight_column before converting to SampleFrame."
+            )
+        id_col_name: str = str(_id_col.name)
+        weight_col_name: str = str(_weight_col.name)
 
         outcome_cols: list[str] | None = None
         if sample._outcome_columns is not None:
@@ -1119,7 +1177,7 @@ class SampleFrame:
             covars_columns=sample._covar_columns_names(),
             weight_columns=[weight_col_name],
             outcome_columns=outcome_cols,
-            misc_columns=ignored_cols if ignored_cols else None,
+            ignore_columns=ignored_cols if ignored_cols else None,
         )
 
     def __repr__(self) -> str:

--- a/balance/stats_and_plots/impact_of_weights_on_outcome.py
+++ b/balance/stats_and_plots/impact_of_weights_on_outcome.py
@@ -12,6 +12,7 @@ from typing import Iterable, TYPE_CHECKING
 import numpy as np
 import pandas as pd
 from balance.stats_and_plots.weights_stats import _check_weights_are_valid
+from balance.util import _assert_type
 from balance.utils.input_validation import _coerce_to_numeric_and_validate
 from scipy import stats
 
@@ -236,13 +237,15 @@ def _align_samples_by_id(
         ValueError: If IDs have duplicates, no common IDs exist, outcome values
             differ, or no valid weights exist.
     """
-    ids0 = adjusted0.id_column.to_numpy()
-    ids1 = adjusted1.id_column.to_numpy()
+    id_col0 = _assert_type(adjusted0.id_column)
+    id_col1 = _assert_type(adjusted1.id_column)
+    ids0 = id_col0.to_numpy()
+    ids1 = id_col1.to_numpy()
     if pd.Index(ids0).has_duplicates or pd.Index(ids1).has_duplicates:
         raise ValueError("Samples must have unique ids to compare outcomes.")
 
-    y0_indexed = y0.set_index(adjusted0.id_column)
-    y1_indexed = y1.set_index(adjusted1.id_column)
+    y0_indexed = y0.set_index(id_col0)
+    y1_indexed = y1.set_index(id_col1)
 
     common_ids = y0_indexed.index.intersection(y1_indexed.index)
     if common_ids.empty:
@@ -255,12 +258,12 @@ def _align_samples_by_id(
             "Outcome values differ between adjusted Samples for common ids."
         )
 
-    weights0 = adjusted0.weight_column.to_numpy()
+    weights0 = _assert_type(adjusted0.weight_column).to_numpy()
     weights0_series = pd.Series(weights0, index=ids0)
     weights0_aligned = weights0_series.reindex(common_ids).to_numpy()
 
     weights1_series = pd.Series(
-        adjusted1.weight_column.to_numpy(),
+        _assert_type(adjusted1.weight_column).to_numpy(),
         index=ids1,
     ).reindex(common_ids)
 

--- a/balance/stats_and_plots/weighted_comparisons_plots.py
+++ b/balance/stats_and_plots/weighted_comparisons_plots.py
@@ -671,6 +671,10 @@ def seaborn_plot_dist(
     variables = choose_variables(*(d["df"] for d in dfs), variables=variables)
     logger.debug(f"plotting variables {variables}")
 
+    if len(variables) == 0:
+        logger.warning("No variables to plot — returning empty axes list.")
+        return [] if return_axes else None
+
     #  Set up subplots
     f, axes = plt.subplots(len(variables), 1, figsize=(7, 7 * len(variables)))
     axes_list: List[plt.Axes]

--- a/balance/utils/input_validation.py
+++ b/balance/utils/input_validation.py
@@ -245,7 +245,7 @@ def _check_weighting_methods_input(
 # This is so to avoid various cyclic imports (since various files call sample_class, and then sample_class also calls these files)
 # TODO: (p2) move away from this method once we restructure Sample and BalanceDF objects...
 def _isinstance_sample(obj: Any) -> bool:
-    """Check if an object is an instance of Sample.
+    """Check if an object is an instance of Sample, BalanceFrame, or SampleFrame.
 
     The import is done inside the function to avoid circular import issues at
     module load time. Since this module is part of the balance package, the
@@ -255,11 +255,10 @@ def _isinstance_sample(obj: Any) -> bool:
         obj: The object to check.
 
     Returns:
-        bool: True if obj is a Sample instance, False otherwise.
+        bool: True if obj has a ``covars()`` method (Sample, BalanceFrame,
+            or SampleFrame), False otherwise.
     """
-    from balance import sample_class
-
-    return isinstance(obj, sample_class.Sample)
+    return hasattr(obj, "covars") and callable(getattr(obj, "covars", None))
 
 
 def guess_id_column(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ target-version = ["py39", "py310", "py311", "py312", "py313"]
 first_party_detection = false
 
 [tool.pytest.ini_options]
+markers = [
+    "requires_sklearn_1_4: test requires scikit-learn >= 1.4 (deselected otherwise)",
+]
 filterwarnings = [
     # Ignore third-party deprecation warnings from matplotlib's internal dependencies
     "ignore:'oneOf' deprecated:DeprecationWarning:matplotlib._fontconfig_pattern",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,58 @@
 
 """Test configuration shared across pytest runs"""
 
+from __future__ import annotations
+
 import matplotlib
 
 # Force a non-interactive backend so tests do not require a Tk installation.
 matplotlib.use("Agg", force=True)
 
 import plotly.io as pio  # noqa: E402
+import pytest  # noqa: E402
 
 # Force plotly to use a non-interactive renderer so tests don't open a browser.
 pio.renderers.default = "json"
+
+
+# ---------------------------------------------------------------------------
+# Deselect (rather than skip) tests that require scikit-learn >= 1.4.
+#
+# Using ``@unittest.skipIf`` for version-gated tests emits noisy "SKIPPED"
+# warnings in CI output.  By deselecting at collection time the tests simply
+# disappear from the run — no warnings, no noise.
+# ---------------------------------------------------------------------------
+
+
+def _has_sklearn_1_4() -> bool:
+    """Return True if scikit-learn >= 1.4 is available."""
+    try:
+        import sklearn
+
+        return tuple(int(x) for x in sklearn.__version__.split(".")[:2]) >= (1, 4)
+    except Exception:
+        return False
+
+
+_SKLEARN_1_4_AVAILABLE: bool = _has_sklearn_1_4()
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Deselect tests marked ``requires_sklearn_1_4`` when sklearn < 1.4."""
+    if _SKLEARN_1_4_AVAILABLE:
+        return  # nothing to deselect
+
+    keep: list[pytest.Item] = []
+    deselected: list[pytest.Item] = []
+    for item in items:
+        if item.get_closest_marker("requires_sklearn_1_4"):
+            deselected.append(item)
+        else:
+            keep.append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = keep

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -987,7 +987,7 @@ class TestBalanceFrameParityHelpers(BalanceTestCase):
                 "weight": [1.0, 1.0, 1.0],
             }
         )
-        self.resp_sf = SampleFrame.from_frame(self.resp_df, misc_columns=["region"])
+        self.resp_sf = SampleFrame.from_frame(self.resp_df, ignore_columns=["region"])
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
         self.bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
 

--- a/tests/test_balancedf.py
+++ b/tests/test_balancedf.py
@@ -5,7 +5,13 @@
 
 # pyre-strict
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    annotations,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import tempfile
 from copy import deepcopy
@@ -3390,7 +3396,9 @@ class TestBalanceDFSourceProtocol(BalanceTestCase):
 
     def test_protocol_is_runtime_checkable(self) -> None:
         """Verify that BalanceDFSource is runtime_checkable."""
-        self.assertTrue(hasattr(BalanceDFSource, "__protocol_attrs__"))
+        # _is_runtime_protocol is set by @runtime_checkable on all Python
+        # versions (3.8+).  __protocol_attrs__ only exists from 3.12+.
+        self.assertTrue(getattr(BalanceDFSource, "_is_runtime_protocol", False))
 
     def test_non_conforming_object_fails_isinstance(self) -> None:
         """Verify that an arbitrary object does NOT satisfy the protocol."""

--- a/tests/test_e2e_from_tutorials.py
+++ b/tests/test_e2e_from_tutorials.py
@@ -1,0 +1,891 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""End-to-end tests that reproduce the balance_quickstart tutorial.
+
+Each test mirrors a section of the tutorial notebook and compares output
+against known-good expected values captured from a healthy codebase run.
+
+IPW adjustments use a fixed lambda (``num_lambdas=1``) to skip the
+cross-validation grid search and keep runtime under a few seconds.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import sys
+import unittest
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from balance import load_data, Sample
+
+
+# ---------------------------------------------------------------------------
+# Fixed lambda from the tutorial run — avoids the slow CV search.
+# ---------------------------------------------------------------------------
+
+_FIXED_LAMBDA: float = 0.041158338186664825
+_IPW_FAST_KWARGS: dict[str, Any] = {
+    "num_lambdas": 1,
+    "lambda_min": _FIXED_LAMBDA,
+    "lambda_max": _FIXED_LAMBDA,
+}
+
+
+class E2ETutorialQuickstartTest(unittest.TestCase):
+    """Reproduce balance_quickstart.ipynb and verify outputs."""
+
+    # shared across all tests — created once
+    target_df: pd.DataFrame
+    sample_df: pd.DataFrame
+    sample: Sample
+    target: Sample
+    sample_with_target: Sample
+    adjusted: Sample
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        target_df, sample_df = load_data()
+        assert target_df is not None and sample_df is not None
+        cls.target_df = target_df
+        cls.sample_df = sample_df
+        cls.sample = Sample.from_frame(cls.sample_df, outcome_columns=["happiness"])
+        cls.target = Sample.from_frame(cls.target_df, outcome_columns=["happiness"])
+        cls.sample_with_target = cls.sample.set_target(cls.target)
+        cls.adjusted = cls.sample_with_target.adjust(**_IPW_FAST_KWARGS)
+
+    # -----------------------------------------------------------------------
+    # 1. Load data
+    # -----------------------------------------------------------------------
+    def test_load_data_shapes(self) -> None:
+        self.assertEqual(self.sample_df.shape, (1000, 5))
+        self.assertEqual(self.target_df.shape, (10000, 5))
+
+    def test_target_df_head(self) -> None:
+        expected = {
+            "id": {0: "100000", 1: "100001", 2: "100002", 3: "100003", 4: "100004"},
+            "gender": {0: "Male", 1: "Male", 2: "Male", 3: np.nan, 4: np.nan},
+            "age_group": {0: "45+", 1: "45+", 2: "35-44", 3: "45+", 4: "25-34"},
+            "income": {0: 10.18, 1: 6.04, 2: 5.23, 3: 5.75, 4: 4.84},
+            "happiness": {0: 61.71, 1: 79.12, 2: 44.21, 3: 83.99, 4: 49.34},
+        }
+        result = self.target_df.head().round(2).to_dict()
+
+        # Compare non-NaN values; NaN == NaN is False, so handle gender separately
+        for col in ["id", "age_group", "income", "happiness"]:
+            self.assertEqual(result[col], expected[col], f"Mismatch in column {col}")
+
+        gender = result["gender"]
+        self.assertEqual(gender[0], "Male")
+        self.assertEqual(gender[1], "Male")
+        self.assertEqual(gender[2], "Male")
+        self.assertTrue(pd.isna(gender[3]))
+        self.assertTrue(pd.isna(gender[4]))
+
+    def test_sample_df_head(self) -> None:
+        head = self.sample_df.head().round(2)
+        self.assertEqual(head["id"].tolist(), ["0", "1", "2", "3", "4"])
+
+        # Compare non-NaN values; NaN == NaN is False, so handle gender separately
+        gender = head["gender"].tolist()
+        self.assertEqual(gender[0], "Male")
+        self.assertEqual(gender[1], "Female")
+        self.assertEqual(gender[2], "Male")
+        self.assertTrue(pd.isna(gender[3]))
+        self.assertTrue(pd.isna(gender[4]))
+
+        self.assertEqual(
+            head["age_group"].tolist(),
+            ["25-34", "18-24", "18-24", "18-24", "18-24"],
+        )
+        self.assertEqual(head["income"].tolist(), [6.43, 9.94, 2.67, 10.55, 2.69])
+        self.assertEqual(
+            head["happiness"].tolist(), [26.04, 66.89, 37.09, 49.39, 72.30]
+        )
+
+    # -----------------------------------------------------------------------
+    # 2. Sample object creation
+    # -----------------------------------------------------------------------
+    def test_sample_df_shape_and_columns(self) -> None:
+        """sample.df has 1000 rows x 6 columns (id, gender, age_group, income, happiness, weight)."""
+        self.assertEqual(self.sample.df.shape, (1000, 6))
+        self.assertCountEqual(
+            self.sample.df.columns.tolist(),
+            ["id", "gender", "age_group", "income", "happiness", "weight"],
+        )
+
+    def test_sample_repr(self) -> None:
+        r = repr(self.sample)
+        self.assertIn("balance Sample object", r)
+        self.assertIn("1000 observations x 3 variables", r)
+        self.assertIn("gender,age_group,income", r)
+        self.assertIn("outcome_columns: happiness", r)
+
+    def test_target_repr(self) -> None:
+        r = repr(self.target)
+        self.assertIn("balance Sample object", r)
+        self.assertIn("10000 observations x 3 variables", r)
+
+    def test_sample_with_target_repr(self) -> None:
+        r = repr(self.sample_with_target)
+        self.assertIn("balance Sample object with target set", r)
+        self.assertIn("3 common variables", r)
+
+    # -----------------------------------------------------------------------
+    # 3. Pre-adjustment diagnostics: covars().mean()
+    # -----------------------------------------------------------------------
+    def test_covars_mean_before_adjustment(self) -> None:
+        mean_df = self.sample_with_target.covars().mean().T
+        _expected_str = """  # noqa: F841
+source                     self     target
+_is_na_gender[T.True]  0.088000   0.089800
+age_group[T.25-34]     0.300000   0.297400
+age_group[T.35-44]     0.156000   0.299200
+age_group[T.45+]       0.053000   0.206300
+gender[Female]         0.268000   0.455100
+gender[Male]           0.644000   0.455100
+gender[_NA]            0.088000   0.089800
+income                 6.297302  12.737608
+"""
+        # Verify key values with rounding
+        self.assertAlmostEqual(mean_df.loc["income", "self"], 6.297302, places=2)
+        self.assertAlmostEqual(mean_df.loc["income", "target"], 12.737608, places=2)
+        self.assertAlmostEqual(mean_df.loc["gender[Female]", "self"], 0.268, places=3)
+        self.assertAlmostEqual(
+            mean_df.loc["gender[Female]", "target"], 0.4551, places=3
+        )
+        self.assertAlmostEqual(mean_df.loc["age_group[T.45+]", "self"], 0.053, places=3)
+        self.assertAlmostEqual(
+            mean_df.loc["age_group[T.45+]", "target"], 0.2063, places=3
+        )
+        self.assertAlmostEqual(
+            mean_df.loc["_is_na_gender[T.True]", "self"], 0.088, places=3
+        )
+
+    # -----------------------------------------------------------------------
+    # 4. Pre-adjustment diagnostics: covars().asmd()
+    # -----------------------------------------------------------------------
+    def test_covars_asmd_before_adjustment(self) -> None:
+        asmd_df = self.sample_with_target.covars().asmd().T
+        _expected_str = """  # noqa: F841
+source                  self
+age_group[T.25-34]  0.005688
+age_group[T.35-44]  0.312711
+age_group[T.45+]    0.378828
+gender[Female]      0.375699
+gender[Male]        0.379314
+gender[_NA]         0.006296
+income              0.494217
+mean(asmd)          0.326799
+"""
+        self.assertAlmostEqual(asmd_df.loc["mean(asmd)", "self"], 0.326799, places=3)
+        self.assertAlmostEqual(asmd_df.loc["income", "self"], 0.494217, places=3)
+        self.assertAlmostEqual(
+            asmd_df.loc["gender[Female]", "self"], 0.375699, places=3
+        )
+
+    def test_covars_asmd_aggregated_before_adjustment(self) -> None:
+        asmd_agg = self.sample_with_target.covars().asmd(aggregate_by_main_covar=True).T
+        _expected_str = """  # noqa: F841
+source          self
+age_group   0.232409
+gender      0.253769
+income      0.494217
+mean(asmd)  0.326799
+"""
+        self.assertAlmostEqual(asmd_agg.loc["age_group", "self"], 0.232409, places=3)
+        self.assertAlmostEqual(asmd_agg.loc["gender", "self"], 0.253769, places=3)
+        self.assertAlmostEqual(asmd_agg.loc["income", "self"], 0.494217, places=3)
+        self.assertAlmostEqual(asmd_agg.loc["mean(asmd)", "self"], 0.326799, places=3)
+
+    # -----------------------------------------------------------------------
+    # 5. Distribution diagnostics (KLD, EMD, CVMD, KS)
+    # -----------------------------------------------------------------------
+    def test_covars_kld_before_adjustment(self) -> None:
+        kld = self.sample_with_target.covars().kld().T
+        _expected_str = """  # noqa: F841
+source         self
+gender     0.079889
+age_group  0.277138
+income     0.114895
+mean(kld)  0.157307
+"""
+        self.assertAlmostEqual(kld.loc["mean(kld)", "self"], 0.157307, places=3)
+        self.assertAlmostEqual(kld.loc["gender", "self"], 0.079889, places=3)
+        self.assertAlmostEqual(kld.loc["age_group", "self"], 0.277138, places=3)
+        self.assertAlmostEqual(kld.loc["income", "self"], 0.114895, places=3)
+
+    def test_covars_emd_before_adjustment(self) -> None:
+        emd = self.sample_with_target.covars().emd().T
+        _expected_str = """  # noqa: F841
+source         self
+gender     0.188900
+age_group  0.743700
+income     6.440306
+mean(emd)  2.457635
+"""
+        self.assertAlmostEqual(emd.loc["mean(emd)", "self"], 2.457635, places=2)
+        self.assertAlmostEqual(emd.loc["income", "self"], 6.440306, places=2)
+
+    def test_covars_cvmd_before_adjustment(self) -> None:
+        cvmd = self.sample_with_target.covars().cvmd().T
+        _expected_str = """  # noqa: F841
+source          self
+gender      0.012658
+age_group   0.061326
+income      0.029834
+mean(cvmd)  0.034606
+"""
+        self.assertAlmostEqual(cvmd.loc["mean(cvmd)", "self"], 0.034606, places=3)
+
+    def test_covars_ks_before_adjustment(self) -> None:
+        ks = self.sample_with_target.covars().ks().T
+        _expected_str = """  # noqa: F841
+source         self
+gender     0.187100
+age_group  0.296500
+income     0.246400
+mean(ks)   0.243333
+"""
+        self.assertAlmostEqual(ks.loc["mean(ks)", "self"], 0.243333, places=3)
+
+    # -----------------------------------------------------------------------
+    # 6. Pre-adjustment plots (no-crash)
+    # -----------------------------------------------------------------------
+    def test_covars_plot_plotly_no_crash(self) -> None:
+        """covars().plot() should not crash (plotly, default)."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+        # Default library is plotly; this should not raise
+        self.sample_with_target.covars().plot()
+
+    def test_covars_plot_seaborn_kde_no_crash(self) -> None:
+        """covars().plot(library='seaborn', dist_type='kde') should not crash."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+        self.sample_with_target.covars().plot(library="seaborn", dist_type="kde")
+
+    # -----------------------------------------------------------------------
+    # 7. Adjustment
+    # -----------------------------------------------------------------------
+    def test_adjusted_repr(self) -> None:
+        r = str(self.adjusted)
+        _expected_str = """  # noqa: F841
+        Adjusted balance Sample object with target set using ipw
+        1000 observations x 3 variables: gender,age_group,income
+        id_column: id, weight_column: weight,
+        outcome_columns: happiness
+"""
+        self.assertIn("Adjusted balance Sample object", r)
+        self.assertIn("ipw", r)
+        self.assertIn("1000 observations x 3 variables", r)
+        self.assertIn("outcome_columns: happiness", r)
+
+    def test_adjusted_is_adjusted(self) -> None:
+        self.assertTrue(self.adjusted.is_adjusted())
+        self.assertFalse(self.sample_with_target.is_adjusted())
+
+    # -----------------------------------------------------------------------
+    # 8. Post-adjustment diagnostics: summary
+    # -----------------------------------------------------------------------
+    def test_adjusted_summary_key_metrics(self) -> None:
+        summary = self.adjusted.summary()
+        _expected_str = """  # noqa: F841
+Adjustment details:
+    method: ipw
+    weight trimming mean ratio: 20
+Covariate diagnostics:
+    Covar ASMD reduction: 63.4%
+    Covar ASMD (7 variables): 0.327 -> 0.120
+    Covar mean KLD reduction: 92.3%
+    Covar mean KLD (3 variables): 0.157 -> 0.012
+Weight diagnostics:
+    design effect (Deff): 1.880
+    effective sample size proportion (ESSP): 0.532
+    effective sample size (ESS): 531.9
+Outcome weighted means:
+            happiness
+source
+self           53.295
+target         56.278
+unadjusted     48.559
+Model performance: Model proportion deviance explained: 0.173
+"""
+        self.assertIn("method: ipw", summary)
+        self.assertIn("weight trimming mean ratio: 20", summary)
+
+        # ASMD reduction
+        asmd_match = re.search(
+            r"Covar ASMD \(7 variables\): ([\d.]+) -> ([\d.]+)", summary
+        )
+        self.assertIsNotNone(asmd_match)
+        assert asmd_match is not None
+        self.assertAlmostEqual(float(asmd_match.group(1)), 0.327, places=2)
+        self.assertAlmostEqual(float(asmd_match.group(2)), 0.120, places=1)
+
+        # Design effect
+        deff_match = re.search(r"design effect \(Deff\): ([\d.]+)", summary)
+        self.assertIsNotNone(deff_match)
+        assert deff_match is not None
+        self.assertAlmostEqual(float(deff_match.group(1)), 1.880, places=1)
+
+        # ESS
+        ess_match = re.search(r"effective sample size \(ESS\): ([\d.]+)", summary)
+        self.assertIsNotNone(ess_match)
+        assert ess_match is not None
+        self.assertAlmostEqual(float(ess_match.group(1)), 531.9, places=0)
+
+        # Outcome means
+        self.assertIn("happiness", summary)
+        self.assertIn("unadjusted", summary)
+
+    # -----------------------------------------------------------------------
+    # 9. Post-adjustment diagnostics: covars().mean()
+    # -----------------------------------------------------------------------
+    def test_adjusted_covars_mean(self) -> None:
+        mean_df = self.adjusted.covars().mean().T
+        _expected_str = """  # noqa: F841
+source                      self     target  unadjusted
+_is_na_gender[T.True]   0.086776   0.089800    0.088000
+age_group[T.25-34]      0.307355   0.297400    0.300000
+age_group[T.35-44]      0.273609   0.299200    0.156000
+age_group[T.45+]        0.137581   0.206300    0.053000
+gender[Female]          0.406337   0.455100    0.268000
+gender[Male]            0.506887   0.455100    0.644000
+gender[_NA]             0.086776   0.089800    0.088000
+income                 10.060068  12.737608    6.297302
+"""
+        # Check that "unadjusted" column now appears
+        self.assertIn("unadjusted", mean_df.columns)
+        self.assertIn("self", mean_df.columns)
+        self.assertIn("target", mean_df.columns)
+
+        # Verify key values
+        self.assertAlmostEqual(mean_df.loc["income", "self"], 10.060, places=1)
+        self.assertAlmostEqual(mean_df.loc["income", "target"], 12.738, places=1)
+        self.assertAlmostEqual(mean_df.loc["income", "unadjusted"], 6.297, places=1)
+        self.assertAlmostEqual(mean_df.loc["gender[Female]", "self"], 0.406, places=2)
+        self.assertAlmostEqual(
+            mean_df.loc["age_group[T.35-44]", "self"], 0.274, places=2
+        )
+        self.assertAlmostEqual(
+            mean_df.loc["age_group[T.35-44]", "unadjusted"], 0.156, places=3
+        )
+
+    # -----------------------------------------------------------------------
+    # 10. Post-adjustment diagnostics: covars().asmd()
+    # -----------------------------------------------------------------------
+    def test_adjusted_covars_asmd(self) -> None:
+        asmd_df = self.adjusted.covars().asmd().T
+        _expected_str = """  # noqa: F841
+source                  self  unadjusted  unadjusted - self
+age_group[T.25-34]  0.021777    0.005688          -0.016090
+age_group[T.35-44]  0.055884    0.312711           0.256827
+age_group[T.45+]    0.169816    0.378828           0.209013
+gender[Female]      0.097916    0.375699           0.277783
+gender[Male]        0.103989    0.379314           0.275324
+gender[_NA]         0.010578    0.006296          -0.004282
+income              0.205469    0.494217           0.288748
+mean(asmd)          0.119597    0.326799           0.207202
+"""
+        # mean(asmd) should decrease from unadjusted to adjusted
+        mean_adjusted = asmd_df.loc["mean(asmd)", "self"]
+        mean_unadjusted = asmd_df.loc["mean(asmd)", "unadjusted"]
+        self.assertAlmostEqual(mean_adjusted, 0.1196, places=2)
+        self.assertAlmostEqual(mean_unadjusted, 0.3268, places=2)
+        self.assertGreater(mean_unadjusted, mean_adjusted)
+
+        # income ASMD should shrink
+        self.assertAlmostEqual(asmd_df.loc["income", "self"], 0.2055, places=2)
+        self.assertAlmostEqual(asmd_df.loc["income", "unadjusted"], 0.4942, places=2)
+
+    # -----------------------------------------------------------------------
+    # 11. Post-adjustment diagnostics: covars().kld()
+    # -----------------------------------------------------------------------
+    def test_adjusted_covars_kld(self) -> None:
+        kld = self.adjusted.covars().kld().T
+        _expected_str = """  # noqa: F841
+source         self  unadjusted  unadjusted - self
+gender     0.005603    0.079889           0.074286
+age_group  0.030191    0.277138           0.246947
+income     0.000768    0.114895           0.114127
+mean(kld)  0.012187    0.157307           0.145120
+"""
+        self.assertAlmostEqual(kld.loc["mean(kld)", "self"], 0.0122, places=2)
+        self.assertAlmostEqual(kld.loc["mean(kld)", "unadjusted"], 0.1573, places=2)
+        self.assertGreater(
+            kld.loc["mean(kld)", "unadjusted"], kld.loc["mean(kld)", "self"]
+        )
+
+    # -----------------------------------------------------------------------
+    # 12. Post-adjustment plots (no-crash)
+    # -----------------------------------------------------------------------
+    def test_adjusted_covars_plot_plotly_no_crash(self) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        self.adjusted.covars().plot()
+
+    def test_adjusted_covars_plot_seaborn_kde_no_crash(self) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        self.adjusted.covars().plot(library="seaborn", dist_type="kde")
+
+    def test_adjusted_covars_plot_ascii(self) -> None:
+        """ASCII plot should produce readable text output."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+
+        buf = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = buf
+        try:
+            self.adjusted.covars().plot(library="balance", bar_width=30)
+        finally:
+            sys.stdout = old_stdout
+
+        output = buf.getvalue()
+
+        _expected_str = """  # noqa: F841
+=== gender (categorical) ===
+
+Category | population  adjusted  sample
+         |
+Female   | █████████████████████ (50.0%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (44.5%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐ (29.4%)
+
+Male     | █████████████████████ (50.0%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (55.5%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (70.6%)
+
+Legend: █ population  ▒ adjusted  ▐ sample
+Bar lengths are proportional to weighted frequency within each dataset.
+
+=== age_group (categorical) ===
+
+Category | population  adjusted  sample
+         |
+18-24    | ████████████ (19.7%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (28.1%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (49.1%)
+
+25-34    | ██████████████████ (29.7%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (30.7%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (30.0%)
+
+35-44    | ██████████████████ (29.9%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (27.4%)
+         | ▐▐▐▐▐▐▐▐▐▐ (15.6%)
+
+45+      | █████████████ (20.6%)
+         | ▒▒▒▒▒▒▒▒ (13.8%)
+         | ▐▐▐ (5.3%)
+
+Legend: █ population  ▒ adjusted  ▐ sample
+Bar lengths are proportional to weighted frequency within each dataset.
+"""
+        # Verify key structural elements of ASCII plot
+        self.assertIn("=== gender (categorical) ===", output)
+        self.assertIn("=== age_group (categorical) ===", output)
+        self.assertIn("=== income (numeric, comparative) ===", output)
+        self.assertIn("Female", output)
+        self.assertIn("Male", output)
+        self.assertIn("18-24", output)
+        self.assertIn("25-34", output)
+        self.assertIn("35-44", output)
+        self.assertIn("45+", output)
+        self.assertIn("population", output)
+        self.assertIn("adjusted", output)
+        self.assertIn("sample", output)
+
+        # Verify percentages appear (with some tolerance for rounding)
+        self.assertIn("50.0%", output)  # gender population split
+        self.assertIn("49.1%", output)  # 18-24 sample proportion
+
+    # -----------------------------------------------------------------------
+    # 13. Weights diagnostics
+    # -----------------------------------------------------------------------
+    def test_weights_plot_no_crash(self) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        self.adjusted.weights().plot()
+
+    def test_weights_summary(self) -> None:
+        ws = self.adjusted.weights().summary().round(2)
+        _expected_str = """  # noqa: F841
+                                var       val
+0                     design_effect      1.88
+1       effective_sample_proportion      0.53
+2             effective_sample_size    531.92
+3                               sum  10000.00
+4                    describe_count   1000.00
+5                     describe_mean      1.00
+6                      describe_std      0.94
+7                      describe_min      0.30
+8                      describe_25%      0.45
+9                      describe_50%      0.65
+10                     describe_75%      1.17
+11                     describe_max     11.36
+12                    prop(w < 0.1)      0.00
+13                    prop(w < 0.2)      0.00
+14                  prop(w < 0.333)      0.11
+15                    prop(w < 0.5)      0.32
+16                      prop(w < 1)      0.67
+17                     prop(w >= 1)      0.33
+18                     prop(w >= 2)      0.10
+19                     prop(w >= 3)      0.03
+20                     prop(w >= 5)      0.01
+21                    prop(w >= 10)      0.00
+22               nonparametric_skew      0.37
+23  weighted_median_breakdown_point      0.21
+"""
+        # Build a lookup dict from var -> val
+        lookup = dict(zip(ws["var"].tolist(), ws["val"].tolist()))
+        self.assertAlmostEqual(lookup["design_effect"], 1.88, places=1)
+        self.assertAlmostEqual(lookup["effective_sample_proportion"], 0.53, places=1)
+        self.assertAlmostEqual(lookup["effective_sample_size"], 531.92, places=0)
+        self.assertAlmostEqual(lookup["sum"], 10000.0, places=0)
+        self.assertAlmostEqual(lookup["describe_count"], 1000.0, places=0)
+        self.assertAlmostEqual(lookup["describe_mean"], 1.0, places=1)
+        self.assertAlmostEqual(lookup["describe_min"], 0.30, places=1)
+        self.assertAlmostEqual(lookup["describe_max"], 11.36, places=0)
+        self.assertAlmostEqual(lookup["nonparametric_skew"], 0.37, places=1)
+
+    # -----------------------------------------------------------------------
+    # 14. Outcomes
+    # -----------------------------------------------------------------------
+    def test_outcomes_summary(self) -> None:
+        summary = self.adjusted.outcomes().summary()
+        _expected_str = """  # noqa: F841
+1 outcomes: ['happiness']
+Mean outcomes (with 95% confidence intervals):
+source       self  target  unadjusted           self_ci         target_ci     unadjusted_ci
+happiness  53.295  56.278      48.559  (52.096, 54.495)  (55.961, 56.595)  (47.669, 49.449)
+"""
+        self.assertIn("1 outcomes: ['happiness']", summary)
+        self.assertIn("happiness", summary)
+        self.assertIn("Mean outcomes", summary)
+
+        # Extract numeric values from the mean outcomes line
+        # happiness  53.295  56.278      48.559
+        happiness_match = re.search(
+            r"happiness\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)", summary
+        )
+        self.assertIsNotNone(happiness_match)
+        assert happiness_match is not None
+        adjusted_mean = float(happiness_match.group(1))
+        target_mean = float(happiness_match.group(2))
+        unadjusted_mean = float(happiness_match.group(3))
+
+        self.assertAlmostEqual(adjusted_mean, 53.295, places=0)
+        self.assertAlmostEqual(target_mean, 56.278, places=0)
+        self.assertAlmostEqual(unadjusted_mean, 48.559, places=0)
+
+        # Adjusted should be closer to target than unadjusted
+        self.assertLess(
+            abs(adjusted_mean - target_mean),
+            abs(unadjusted_mean - target_mean),
+        )
+
+    def test_outcomes_plot_no_crash(self) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        self.adjusted.outcomes().plot()
+
+    # -----------------------------------------------------------------------
+    # 15. Comparing adjustment methods: HGB
+    # -----------------------------------------------------------------------
+    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    def test_adjust_hgb_native_categorical(self) -> None:
+        from sklearn.ensemble import HistGradientBoostingClassifier
+
+        hgb = HistGradientBoostingClassifier(
+            random_state=0, categorical_features="from_dtype"
+        )
+        adjusted_hgb = self.sample_with_target.adjust(model=hgb, use_model_matrix=False)
+        summary = adjusted_hgb.summary()
+        _expected_str = """  # noqa: F841
+Adjustment details:
+    method: ipw
+    weight trimming mean ratio: 20
+Covariate diagnostics:
+    Covar ASMD reduction: 67.7%
+    Covar ASMD (7 variables): 0.327 -> 0.106
+    Covar mean KLD reduction: 95.7%
+    Covar mean KLD (3 variables): 0.157 -> 0.007
+Weight diagnostics:
+    design effect (Deff): 2.539
+    effective sample size proportion (ESSP): 0.394
+    effective sample size (ESS): 393.8
+Outcome weighted means:
+            happiness
+source
+self           54.326
+target         56.278
+unadjusted     48.559
+Model performance: Model proportion deviance explained: 0.204
+"""
+        self.assertIn("method: ipw", summary)
+
+        deff_match = re.search(r"design effect \(Deff\): ([\d.]+)", summary)
+        self.assertIsNotNone(deff_match)
+        assert deff_match is not None
+        self.assertAlmostEqual(float(deff_match.group(1)), 2.539, places=1)
+
+        ess_match = re.search(r"effective sample size \(ESS\): ([\d.]+)", summary)
+        self.assertIsNotNone(ess_match)
+        assert ess_match is not None
+        self.assertAlmostEqual(float(ess_match.group(1)), 393.8, places=0)
+
+    def test_adjust_hgb_with_model_matrix(self) -> None:
+        from sklearn.ensemble import HistGradientBoostingClassifier
+
+        hgb_mm = HistGradientBoostingClassifier(random_state=0)
+        adjusted_hgb_mm = self.sample_with_target.adjust(
+            model=hgb_mm, use_model_matrix=True
+        )
+        summary = adjusted_hgb_mm.summary()
+        _expected_str = """  # noqa: F841
+Adjustment details:
+    method: ipw
+    weight trimming mean ratio: 20
+Covariate diagnostics:
+    Covar ASMD reduction: 68.8%
+    Covar ASMD (7 variables): 0.327 -> 0.102
+    Covar mean KLD reduction: 95.7%
+    Covar mean KLD (3 variables): 0.157 -> 0.007
+Weight diagnostics:
+    design effect (Deff): 2.699
+    effective sample size proportion (ESSP): 0.370
+    effective sample size (ESS): 370.5
+Outcome weighted means:
+            happiness
+source
+self           54.460
+target         56.278
+unadjusted     48.559
+Model performance: Model proportion deviance explained: 0.206
+"""
+        self.assertIn("method: ipw", summary)
+
+        deff_match = re.search(r"design effect \(Deff\): ([\d.]+)", summary)
+        self.assertIsNotNone(deff_match)
+        assert deff_match is not None
+        self.assertAlmostEqual(float(deff_match.group(1)), 2.699, places=1)
+
+        ess_match = re.search(r"effective sample size \(ESS\): ([\d.]+)", summary)
+        self.assertIsNotNone(ess_match)
+        assert ess_match is not None
+        self.assertAlmostEqual(float(ess_match.group(1)), 370.5, places=0)
+
+
+class E2ETutorialRakeTest(unittest.TestCase):
+    """Reproduce key sections of balance_quickstart_rake.ipynb."""
+
+    sample_with_target: Sample
+    adjusted_rake: Sample
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        target_df, sample_df = load_data()
+        assert target_df is not None and sample_df is not None
+        # Tutorial uses only gender + age_group (categorical covariates)
+        sample = Sample.from_frame(
+            sample_df[["id", "gender", "age_group", "happiness"]],
+            outcome_columns=["happiness"],
+        )
+        target = Sample.from_frame(
+            target_df[["id", "gender", "age_group", "happiness"]],
+            outcome_columns=["happiness"],
+        )
+        cls.sample_with_target = sample.set_target(target)
+        cls.adjusted_rake = cls.sample_with_target.adjust(method="rake")
+
+    def test_rake_summary(self) -> None:
+        summary = self.adjusted_rake.summary()
+        _expected_str = """  # noqa: F841
+Adjustment details:
+    method: rake
+Covariate diagnostics:
+    Covar ASMD reduction: 100.0%
+    Covar ASMD (6 variables): 0.243 -> 0.000
+    Covar mean KLD reduction: 100.0%
+    Covar mean KLD (2 variables): 0.179 -> 0.000
+Weight diagnostics:
+    design effect (Deff): 2.103
+    effective sample size proportion (ESSP): 0.476
+    effective sample size (ESS): 475.6
+Outcome weighted means:
+            happiness
+source
+self           55.484
+target         56.278
+unadjusted     48.559
+"""
+        self.assertIn("method: rake", summary)
+        self.assertIn("Covar ASMD reduction: 100.0%", summary)
+
+        deff_match = re.search(r"design effect \(Deff\): ([\d.]+)", summary)
+        self.assertIsNotNone(deff_match)
+        assert deff_match is not None
+        self.assertAlmostEqual(float(deff_match.group(1)), 2.103, places=1)
+
+        ess_match = re.search(r"effective sample size \(ESS\): ([\d.]+)", summary)
+        self.assertIsNotNone(ess_match)
+        assert ess_match is not None
+        self.assertAlmostEqual(float(ess_match.group(1)), 475.6, places=0)
+
+    def test_rake_asmd_near_zero(self) -> None:
+        """Rake should achieve near-perfect balance on categorical covariates."""
+        asmd_df = self.adjusted_rake.covars().asmd().T
+        _expected_str = """  # noqa: F841
+source                      self  unadjusted  unadjusted - self
+age_group[T.25-34]  9.805611e-06    0.005688           0.005678
+age_group[T.35-44]  1.769428e-05    0.312711           0.312694
+age_group[T.45+]    3.015863e-05    0.378828           0.378798
+gender[Female]      1.114671e-16    0.375699           0.375699
+gender[Male]        3.344013e-16    0.379314           0.379314
+gender[_NA]         4.853912e-17    0.006296           0.006296
+mean(asmd)          9.609754e-06    0.243089           0.243080
+"""
+        mean_asmd = asmd_df.loc["mean(asmd)", "self"]
+        # Rake achieves near-zero ASMD on categorical marginals
+        self.assertLess(mean_asmd, 0.001)
+        # Unadjusted should be much higher
+        self.assertAlmostEqual(
+            asmd_df.loc["mean(asmd)", "unadjusted"], 0.243089, places=3
+        )
+
+    def test_rake_covars_mean(self) -> None:
+        """Rake covars().mean() should match target exactly."""
+        mean_df = self.adjusted_rake.covars().mean().T
+        _expected_str = """  # noqa: F841
+source                     self  target  unadjusted
+_is_na_gender[T.True]  0.089800  0.0898       0.088
+age_group[T.25-34]     0.297404  0.2974       0.300
+age_group[T.35-44]     0.299208  0.2992       0.156
+age_group[T.45+]       0.206288  0.2063       0.053
+gender[Female]         0.455100  0.4551       0.268
+gender[Male]           0.455100  0.4551       0.644
+gender[_NA]            0.089800  0.0898       0.088
+"""
+        # Gender proportions should match target exactly after raking
+        self.assertAlmostEqual(
+            mean_df.loc["gender[Female]", "self"],
+            mean_df.loc["gender[Female]", "target"],
+            places=4,
+        )
+        self.assertAlmostEqual(
+            mean_df.loc["gender[Male]", "self"],
+            mean_df.loc["gender[Male]", "target"],
+            places=4,
+        )
+        # Age group proportions should also match target closely
+        self.assertAlmostEqual(
+            mean_df.loc["age_group[T.45+]", "self"],
+            mean_df.loc["age_group[T.45+]", "target"],
+            places=3,
+        )
+
+
+class E2ETutorialPoststratifyTest(unittest.TestCase):
+    """Reproduce key sections of balance_quickstart_poststratify.ipynb."""
+
+    def test_poststratify_single_variable(self) -> None:
+        """Post-stratify on gender matches target counts exactly."""
+        from balance.weighting_methods.poststratify import poststratify
+
+        target_df, sample_df = load_data()
+        assert target_df is not None and sample_df is not None
+
+        sample_gender = sample_df.dropna(subset=["gender"])
+        target_gender = target_df.dropna(subset=["gender"])
+
+        result = poststratify(
+            sample_df=sample_gender[["gender"]],
+            sample_weights=pd.Series(1, index=sample_gender.index),
+            target_df=target_gender[["gender"]],
+            target_weights=pd.Series(1, index=target_gender.index),
+        )
+
+        weighted = sample_gender.assign(weight=result["weight"])
+        weighted_counts = weighted.groupby("gender")["weight"].sum()
+        target_counts = target_gender.groupby("gender").size()
+
+        _expected_str = """  # noqa: F841
+        weighted_sample  target_population
+gender
+Female           4551.0               4551
+Male             4551.0               4551
+"""
+        # Weighted sample counts should exactly match target population counts
+        self.assertAlmostEqual(weighted_counts["Female"], 4551.0, places=0)
+        self.assertAlmostEqual(weighted_counts["Male"], 4551.0, places=0)
+        self.assertAlmostEqual(
+            weighted_counts["Female"], float(target_counts["Female"]), places=0
+        )
+        self.assertAlmostEqual(
+            weighted_counts["Male"], float(target_counts["Male"]), places=0
+        )
+
+    def test_poststratify_joint_distribution(self) -> None:
+        """Post-stratify on gender x age_group matches joint target counts."""
+        from balance.weighting_methods.poststratify import poststratify
+
+        target_df, sample_df = load_data()
+        assert target_df is not None and sample_df is not None
+
+        covariates = ["gender", "age_group"]
+        sample_cells = sample_df.dropna(subset=covariates)
+        target_cells = target_df.dropna(subset=covariates)
+
+        result = poststratify(
+            sample_df=sample_cells[covariates],
+            sample_weights=pd.Series(1, index=sample_cells.index),
+            target_df=target_cells[covariates],
+            target_weights=pd.Series(1, index=target_cells.index),
+        )
+
+        weighted = sample_cells.assign(weight=result["weight"])
+        weighted_counts = weighted.groupby(covariates)["weight"].sum()
+        target_counts = target_cells.groupby(covariates).size()
+
+        _expected_str = """  # noqa: F841
+                  weighted_sample  target_population
+gender age_group
+Female 18-24                876.0                876
+       25-34               1360.0               1360
+       35-44               1370.0               1370
+       45+                  945.0                945
+Male   18-24                905.0                905
+       25-34               1355.0               1355
+       35-44               1347.0               1347
+       45+                  944.0                944
+"""
+        # Each cell's weighted count should match target exactly
+        for cell, count in target_counts.items():
+            self.assertAlmostEqual(
+                weighted_counts[cell],
+                float(count),
+                places=0,
+                msg=f"Cell {cell} mismatch",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ipw.py
+++ b/tests/test_ipw.py
@@ -13,15 +13,12 @@ from __future__ import (
     unicode_literals,
 )
 
-import unittest
-
 import balance.testutil
 import numpy as np
 import pandas as pd
-import sklearn
+import pytest
 from balance.sample_class import Sample
 from balance.weighting_methods import ipw as balance_ipw
-from packaging.version import Version
 from scipy.sparse import csr_matrix
 from sklearn.ensemble import HistGradientBoostingClassifier, RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
@@ -29,8 +26,6 @@ from sklearn.metrics import log_loss
 from sklearn.naive_bayes import GaussianNB
 from sklearn.svm import LinearSVC
 from sklearn.tree import DecisionTreeClassifier
-
-_SKLEARN_LT_1_4: bool = Version(sklearn.__version__) < Version("1.4")
 
 
 class TestIPW(
@@ -339,10 +334,7 @@ class TestIPW(
                 use_model_matrix=False,
             )
 
-    @unittest.skipIf(
-        _SKLEARN_LT_1_4,
-        "categorical_features='from_dtype' requires scikit-learn >= 1.4",
-    )
+    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
     def test_ipw_use_model_matrix_false_preserves_categoricals(self) -> None:
         """Raw-covariate IPW preserves categorical dtype for native sklearn categorical support."""
 
@@ -404,10 +396,8 @@ class TestIPW(
         )
         self.assertEqual(len(result_no_indicator["weight"]), len(sample))
 
-    @unittest.skipIf(
-        _SKLEARN_LT_1_4,
-        "categorical_features='from_dtype' requires scikit-learn >= 1.4",
-    )
+    # pyre-ignore[56]: Pyre cannot infer type of custom pytest mark
+    @pytest.mark.requires_sklearn_1_4
     def test_ipw_use_model_matrix_false_raises_on_old_sklearn(self) -> None:
         """ValueError is raised when sklearn < 1.4 and categorical columns are present."""
         from unittest.mock import patch
@@ -445,10 +435,8 @@ class TestIPW(
             self.assertIn("scikit-learn >= 1.4", str(ctx.exception))
             self.assertIn("1.3.2", str(ctx.exception))
 
-    @unittest.skipIf(
-        _SKLEARN_LT_1_4,
-        "categorical_features='from_dtype' requires scikit-learn >= 1.4",
-    )
+    # pyre-ignore[56]: Pyre cannot infer type of custom pytest mark
+    @pytest.mark.requires_sklearn_1_4
     def test_ipw_use_model_matrix_false_no_error_on_new_sklearn(self) -> None:
         """No version error when sklearn >= 1.4 and categorical columns are present."""
         from unittest.mock import patch

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -2708,8 +2708,8 @@ class TestSampleConversion(balance.testutil.BalanceTestCase):
         )
         sf = sample_with_ignored.to_sample_frame()
         self.assertIsInstance(sf, SampleFrame)
-        self.assertIsNotNone(sf.misc_columns)
-        self.assertIn("b", sf.misc_columns)
+        self.assertIsNotNone(sf.ignore_columns)
+        self.assertIn("b", sf.ignore_columns)
 
     def test_to_balance_frame_unadjusted(self) -> None:
         """to_balance_frame converts a Sample with target to a BalanceFrame."""

--- a/tests/test_sample_frame.py
+++ b/tests/test_sample_frame.py
@@ -21,9 +21,11 @@ from balance.testutil import BalanceTestCase
 
 
 class TestSampleFrame(BalanceTestCase):
-    def test_direct_init_raises(self) -> None:
-        with self.assertRaises(NotImplementedError):
-            SampleFrame()
+    def test_direct_init_noop(self) -> None:
+        # __init__ is a no-op; object is uninitialised (for deepcopy support)
+        sf = SampleFrame.__new__(SampleFrame)
+        sf.__init__()
+        # No attributes set — just verifying it doesn't raise
 
     def test_create_basic(self) -> None:
         df = pd.DataFrame(
@@ -79,14 +81,14 @@ class TestSampleFrame(BalanceTestCase):
         self.assertIsNotNone(sf.df_outcomes)
         self.assertListEqual(list(sf.df_outcomes.columns), ["y"])
 
-    def test_df_misc_none(self) -> None:
+    def test_df_ignored_none(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
             df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
         )
-        self.assertIsNone(sf.df_misc)
+        self.assertIsNone(sf.df_ignored)
 
-    def test_df_misc_present(self) -> None:
+    def test_df_ignored_present(self) -> None:
         df = pd.DataFrame(
             {"id": [1, 2], "x": [10, 20], "w": [1.0, 1.0], "region": ["US", "UK"]}
         )
@@ -95,10 +97,10 @@ class TestSampleFrame(BalanceTestCase):
             id_column="id",
             covars_columns=["x"],
             weight_columns=["w"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
-        self.assertIsNotNone(sf.df_misc)
-        self.assertListEqual(list(sf.df_misc.columns), ["region"])
+        self.assertIsNotNone(sf.df_ignored)
+        self.assertListEqual(list(sf.df_ignored.columns), ["region"])
 
     def test_ignored_columns_none(self) -> None:
         df = pd.DataFrame({"id": [1, 2], "x": [10, 20], "w": [1.0, 1.0]})
@@ -116,14 +118,14 @@ class TestSampleFrame(BalanceTestCase):
             id_column="id",
             covars_columns=["x"],
             weight_columns=["w"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
         result = sf.ignored_columns()
         self.assertIsNotNone(result)
         self.assertListEqual(list(result.columns), ["region"])
         self.assertListEqual(list(result["region"]), ["US", "UK"])
 
-    def test_ignored_columns_matches_df_misc(self) -> None:
+    def test_ignored_columns_matches_df_ignored(self) -> None:
         df = pd.DataFrame(
             {"id": [1, 2], "x": [10, 20], "w": [1.0, 1.0], "region": ["US", "UK"]}
         )
@@ -132,9 +134,9 @@ class TestSampleFrame(BalanceTestCase):
             id_column="id",
             covars_columns=["x"],
             weight_columns=["w"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
-        pd.testing.assert_frame_equal(sf.ignored_columns(), sf.df_misc)
+        pd.testing.assert_frame_equal(sf.ignored_columns(), sf.df_ignored)
 
     def test_id_column(self) -> None:
         df = pd.DataFrame({"id": [1, 2, 3], "x": [10, 20, 30], "w": [1.0, 1.0, 1.0]})
@@ -202,7 +204,7 @@ class TestSampleFrameMutableViewSafety(BalanceTestCase):
             df,
             outcome_columns=["y"],
             predicted_outcome_columns=["p_y"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
 
     def test_df_covars_returns_copy(self) -> None:
@@ -224,11 +226,11 @@ class TestSampleFrameMutableViewSafety(BalanceTestCase):
         outcomes["y"] = [999.0, 999.0, 999.0]
         self.assertEqual(list(sf._df["y"]), [5.0, 6.0, 7.0])
 
-    def test_df_misc_returns_copy(self) -> None:
+    def test_df_ignored_returns_copy(self) -> None:
         sf = self._make_sf()
-        misc = sf.df_misc
-        self.assertIsNotNone(misc)
-        misc["region"] = ["XX", "XX", "XX"]
+        ignored = sf.df_ignored
+        self.assertIsNotNone(ignored)
+        ignored["region"] = ["XX", "XX", "XX"]
         self.assertEqual(list(sf._df["region"]), ["US", "UK", "CA"])
 
     def test_id_column_returns_copy(self) -> None:
@@ -333,36 +335,36 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
         result.append("injected")
         self.assertEqual(sf.predicted_outcome_columns, ["p_y"])
 
-    def test_misc_columns(self) -> None:
+    def test_ignore_columns(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0], "region": ["US"]})
         sf = SampleFrame._create(
             df=df,
             id_column="id",
             covars_columns=["x"],
             weight_columns=["w"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
-        self.assertEqual(sf.misc_columns, ["region"])
+        self.assertEqual(sf.ignore_columns, ["region"])
 
-    def test_misc_columns_empty(self) -> None:
+    def test_ignore_columns_empty(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
             df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
         )
-        self.assertEqual(sf.misc_columns, [])
+        self.assertEqual(sf.ignore_columns, [])
 
-    def test_misc_columns_returns_copy(self) -> None:
+    def test_ignore_columns_returns_copy(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0], "region": ["US"]})
         sf = SampleFrame._create(
             df=df,
             id_column="id",
             covars_columns=["x"],
             weight_columns=["w"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
-        result = sf.misc_columns
+        result = sf.ignore_columns
         result.append("injected")
-        self.assertEqual(sf.misc_columns, ["region"])
+        self.assertEqual(sf.ignore_columns, ["region"])
 
     def test_active_weight_column(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
@@ -509,7 +511,7 @@ class TestSampleFrameFromFrame(BalanceTestCase):
         sf = SampleFrame.from_frame(df, covars_columns=["a", "b"])
         self.assertListEqual(list(sf.df_covars.columns), ["a", "b"])
 
-    def test_from_frame_misc_columns(self) -> None:
+    def test_from_frame_ignore_columns(self) -> None:
         df = pd.DataFrame(
             {
                 "id": ["1", "2"],
@@ -518,9 +520,9 @@ class TestSampleFrameFromFrame(BalanceTestCase):
                 "weight": [1.0, 2.0],
             }
         )
-        sf = SampleFrame.from_frame(df, misc_columns=["region"])
-        self.assertIsNotNone(sf.df_misc)
-        self.assertListEqual(list(sf.df_misc.columns), ["region"])
+        sf = SampleFrame.from_frame(df, ignore_columns=["region"])
+        self.assertIsNotNone(sf.df_ignored)
+        self.assertListEqual(list(sf.df_ignored.columns), ["region"])
         # region should NOT be in covars
         self.assertNotIn("region", list(sf.df_covars.columns))
 
@@ -534,10 +536,10 @@ class TestSampleFrameFromFrame(BalanceTestCase):
         with self.assertRaises(ValueError):
             SampleFrame.from_frame(df, predicted_outcome_columns=["nonexistent"])
 
-    def test_from_frame_missing_misc_column_raises(self) -> None:
+    def test_from_frame_missing_ignore_column_raises(self) -> None:
         df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0]})
         with self.assertRaises(ValueError):
-            SampleFrame.from_frame(df, misc_columns=["nonexistent"])
+            SampleFrame.from_frame(df, ignore_columns=["nonexistent"])
 
     def test_from_frame_no_id_column_raises(self) -> None:
         df = pd.DataFrame({"x": [10, 20], "weight": [1.0, 1.0]})
@@ -603,13 +605,15 @@ class TestSampleFrameFromFrame(BalanceTestCase):
         sf = SampleFrame.from_frame(df)
         self.assertAlmostEqual(sf.df_weights.iloc[0, 0], 0.0, places=5)
 
-    def test_from_frame_overlapping_outcome_and_misc_raises(self) -> None:
-        """A column in both outcome_columns and misc_columns raises ValueError."""
+    def test_from_frame_overlapping_outcome_and_ignored_raises(self) -> None:
+        """A column in both outcome_columns and ignore_columns raises ValueError."""
         df = pd.DataFrame(
             {"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0], "y": [5, 6]}
         )
-        with self.assertRaisesRegex(ValueError, "appear in both 'outcomes' and 'misc'"):
-            SampleFrame.from_frame(df, outcome_columns=["y"], misc_columns=["y"])
+        with self.assertRaisesRegex(
+            ValueError, "appear in both 'outcomes' and 'ignored'"
+        ):
+            SampleFrame.from_frame(df, outcome_columns=["y"], ignore_columns=["y"])
 
     def test_from_frame_overlapping_covar_and_outcome_raises(self) -> None:
         """A column in both explicit covars_columns and outcome_columns raises ValueError."""
@@ -792,10 +796,17 @@ class TestSampleFrameWeightMetadata(BalanceTestCase):
             sf.add_weight_column("x", pd.Series([1.0, 1.0, 1.0]))
         self.assertIn("already exists in the DataFrame", str(ctx.exception))
 
-    def test_add_weight_column_length_mismatch_raises(self) -> None:
+    def test_add_weight_column_shorter_series_pads_with_nan(self) -> None:
+        sf = self._make_sf()
+        # Shorter Series is padded with NaN (supports na_action="drop")
+        sf.add_weight_column("w_short", pd.Series([1.0, 1.0]))
+        self.assertEqual(len(sf._df["w_short"]), 3)
+        self.assertTrue(pd.isna(sf._df["w_short"].iloc[2]))
+
+    def test_add_weight_column_longer_series_raises(self) -> None:
         sf = self._make_sf()
         with self.assertRaises(ValueError) as ctx:
-            sf.add_weight_column("w_bad", pd.Series([1.0, 1.0]))
+            sf.add_weight_column("w_bad", pd.Series([1.0] * 5))
         self.assertIn("length", str(ctx.exception))
 
     def test_multiple_weight_columns_workflow(self) -> None:
@@ -1031,7 +1042,7 @@ class TestSampleFrameFromSample(BalanceTestCase):
         )
         sample = Sample.from_frame(df, ignore_columns=["extra"])
         sf = SampleFrame.from_sample(sample)
-        self.assertEqual(sf._column_roles["misc"], ["extra"])
+        self.assertEqual(sf._column_roles["ignored"], ["extra"])
         self.assertEqual(sf._column_roles["covars"], ["x"])
 
     def test_from_sample_preserves_data(self) -> None:


### PR DESCRIPTION
Summary:


## Stack Overview (Diffs 14.1–14.4 of 15)

This 4-diff stack refactors `Sample` from a monolithic 1,454-line class into a
228-line inheritance wrapper:

```
class Sample(BalanceFrame, SampleFrame)
# MRO: Sample → BalanceFrame → SampleFrame → object
```

- **SampleFrame** (`sample_frame.py`) — DataFrame container with column-role metadata
- **BalanceFrame** (`balance_frame.py`) — adjustment orchestrator (responder + target)
- **Sample** (`sample_class.py`) — backward-compatible facade; **no public API changes**

| Diff | What | Key files | ~Lines |
|------|------|-----------|--------|
| **14.1 (this)** | Prep SampleFrame for inheritance | sample_frame.py, input_validation.py, cli.py | 350 |
| 14.2 | Expand BalanceFrame (absorbs Sample logic) | balance_frame.py | 1,150 |
| 14.3 | Rewrite Sample as inheritance wrapper | sample_class.py (−1,350 lines) | 1,700 |
| 14.4 | Docs + scripts | CLAUDE.md, CHANGELOG.md, tutorial | 250 |

## What This Diff Does

Prepares `SampleFrame` and supporting files so that `Sample` can inherit from
`SampleFrame` (in Diff 14.3). The changes make SampleFrame inheritance-friendly
without changing its public API.

### SampleFrame changes (`sample_frame.py`)

| Change | Why |
|--------|-----|
| Column role key `"misc"` → `"ignored"` | Aligns with `Sample.ignored_columns()` naming |
| `misc_columns` param → `ignore_columns` | Same rename in constructor |
| `__init__`: `raise NotImplementedError` → `pass` | Required for multiple inheritance (`__new__` pattern) |
| `__deepcopy__`: `SampleFrame(...)` → `type(self)(...)` | Returns correct subclass type when `Sample.__deepcopy__` calls super |
| `_links`: read-only property → mutable instance attribute | BalanceFrame needs to set `_links` on the SampleFrame backing |
| Added `_df_dtypes` attribute | Preserves original dtypes through SampleFrame construction |
| Added `ignored_columns()` method | API parity with `Sample.ignored_columns()` |

### Supporting file changes

| File | Change | Why |
|------|--------|-----|
| `input_validation.py` | `_isinstance_sample`: `isinstance(obj, Sample)` → duck typing via `hasattr` | Avoids circular import when Sample inherits from SampleFrame |
| `impact_of_weights_on_outcome.py` | Uses `_assert_type(adjusted0.id_column)` | `id_column` is now a property that may return `None` |
| `cli.py` | Added `and adjusted._df_dtypes is not None` guard | `_df_dtypes` may be `None` in the inheritance path |
| `test_sample_frame.py` | Updated for `misc` → `ignored` rename | Tests match new column role naming |

Reviewed By: sahil350

Differential Revision: D99095515
