### PR TITLE
Typing modernization + PascalCase method renames (#395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@
   - `BalanceFrame._check_outcomes_exists` → `_require_outcomes` — consistent with above.
   - Error messages now use `type(self).__name__` instead of hardcoded "Sample".
 
+- **Typing modernization and style cleanup**
+  - `Dict` → `dict`, `Tuple` → `tuple` in annotations (`balancedf_class.py`).
+  - `List[str]` → `list[str]` in annotations (`sample_class.py`).
+  - `cast(pd.DataFrame, ...)` → `_assert_type(...)` (`sample_frame.py`).
+  - `_check_if_not_BalanceDF` → `_check_if_not_balancedf` — snake_case convention.
+  - `_BalanceDF_child_from_linked_samples` → `_balancedf_child_from_linked_samples`.
+
 - **Refactored `Sample` to delegate to `SampleFrame` and `BalanceFrame` internally**
   - `Sample` is now a thin facade: `set_target()` creates a backing `BalanceFrame`,
     and `adjust()`, `summary()`, `diagnostics()`, `model()`, `is_adjusted`, and
@@ -122,7 +129,7 @@
     sources.
   - Added `covars()`, `weights()`, `outcomes()` methods to `SampleFrame` so that
     linked SampleFrames can produce BalanceDF views (required by the links
-    machinery in `_BalanceDF_child_from_linked_samples`).
+    machinery in `_balancedf_child_from_linked_samples`).
   - `summary()`: consolidated human-readable summary of covariate ASMD/KLD,
     weight design effect/ESS/ESSP, and outcome means. Delegates to shared
     `_build_summary()` in `summary_utils.py`.
@@ -176,7 +183,7 @@
 - **`BalanceDF.__init__()`: added optional `links` parameter for explicit link injection**
   - Allows BalanceDF to work with sources that do not carry mutable `_links`
     (e.g. the upcoming SampleFrame class).
-  - When `links` is provided, `_BalanceDF_child_from_linked_samples()` uses the
+  - When `links` is provided, `_balancedf_child_from_linked_samples()` uses the
     explicit dict; otherwise falls back to `sample._links` (backward compatible).
 
 ## Code Quality & Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
     columns) and `SampleFrame.from_csv()`.
   - DataFrame-access properties use `df_*` prefix convention: `df_covars`,
     `df_weights`, `df_outcomes`, `df_ignored`. All return copies for mutation safety.
-  - Column-role list properties: `covars_columns`, `weight_columns`,
+  - Column-role list properties: `covar_columns`, `weight_columns`,
     `outcome_columns`, `predicted_outcome_columns`, `ignore_columns` (all return
     copies). `misc_columns` is accepted as a deprecated alias.
   - `ignored_columns()`: alias for `df_ignored`, provided for API parity with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@
   - `BalanceFrame.model` is a plain `@property` — all `model()` call sites updated
     to `model`.
 
+- **Guard method renames for consistency**
+  - `BalanceFrame._check_if_adjusted` → `_require_adjusted` — imperative verb pattern.
+  - `BalanceFrame._no_target_error` → `_require_target` — consistent with above.
+  - `BalanceFrame._check_outcomes_exists` → `_require_outcomes` — consistent with above.
+  - Error messages now use `type(self).__name__` instead of hardcoded "Sample".
+
 - **Refactored `Sample` to delegate to `SampleFrame` and `BalanceFrame` internally**
   - `Sample` is now a thin facade: `set_target()` creates a backing `BalanceFrame`,
     and `adjust()`, `summary()`, `diagnostics()`, `model()`, `is_adjusted`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@
   - `BalanceFrame.id_column` and `weight_series` now delegate to `_sf_sample`
     instead of caching redundant copies, removing stale-state risk.
 
+- **`has_target` and `model` are now properties**
+  - `BalanceFrame.has_target` is a `_CallableBool` property — both `bf.has_target`
+    and `bf.has_target()` work (the latter for backward compatibility).
+  - `BalanceFrame.model` is a plain `@property` — all `model()` call sites updated
+    to `model`.
+
 - **Refactored `Sample` to delegate to `SampleFrame` and `BalanceFrame` internally**
   - `Sample` is now a thin facade: `set_target()` creates a backing `BalanceFrame`,
     and `adjust()`, `summary()`, `diagnostics()`, `model()`, `is_adjusted`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,10 +47,8 @@
   - DataFrame-access properties use `df_*` prefix convention: `df_covars`,
     `df_weights`, `df_outcomes`, `df_ignored`. All return copies for mutation safety.
   - Column-role list properties: `covar_columns`, `weight_columns`,
-    `outcome_columns`, `predicted_outcome_columns`, `ignore_columns` (all return
+    `outcome_columns`, `predicted_outcome_columns`, `ignored_columns` (all return
     copies). `misc_columns` is accepted as a deprecated alias.
-  - `ignored_columns()`: alias for `df_ignored`, provided for API parity with
-    `Sample.ignored_columns()`.
   - Internal `_create()` factory with `_skip_copy` optimization for callers that
     have already deep-copied.
   - Comprehensive validation: null/negative/non-numeric weights, null IDs,
@@ -80,8 +78,6 @@
     no target is set.
   - Properties: `responders`, `target`, `unadjusted`, `is_adjusted`.
   - `model()`: returns the adjustment model dictionary.
-  - `ignored_columns()`: returns ignored (misc) columns from the responder
-    SampleFrame (alias for `responders.ignored_columns()`).
   - `id_column` property: returns the ID column of the responder SampleFrame.
   - Records weight provenance metadata on the adjusted weight column.
   - Default transformations applied when neither SampleFrame has custom transforms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,15 +61,15 @@
 
 - **Added `SampleFrame` — a DataFrame container with explicit column-role metadata**
   - New class in `sample_frame.py` that holds a single DataFrame and tracks which
-    columns are covariates, weights, outcomes, predicted outcomes, and misc.
+    columns are covariates, weights, outcomes, predicted outcomes, and ignored.
   - Factory methods: `SampleFrame.from_frame()` (with auto-detection of id/weight
     columns) and `SampleFrame.from_csv()`.
   - DataFrame-access properties use `df_*` prefix convention: `df_covars`,
-    `df_weights`, `df_outcomes`, `df_misc`. All return copies for mutation safety.
+    `df_weights`, `df_outcomes`, `df_ignored`. All return copies for mutation safety.
   - Column-role list properties: `covars_columns`, `weight_columns`,
-    `outcome_columns`, `predicted_outcome_columns`, `misc_columns` (all return
-    copies).
-  - `ignored_columns()`: alias for `df_misc`, provided for API parity with
+    `outcome_columns`, `predicted_outcome_columns`, `ignore_columns` (all return
+    copies). `misc_columns` is accepted as a deprecated alias.
+  - `ignored_columns()`: alias for `df_ignored`, provided for API parity with
     `Sample.ignored_columns()`.
   - Internal `_create()` factory with `_skip_copy` optimization for callers that
     have already deep-copied.
@@ -120,13 +120,23 @@
 - **Added `BalanceFrame` — immutable adjustment orchestrator for survey weighting**
   - New class in `balance_frame.py` that pairs a responder `SampleFrame` with a
     target `SampleFrame` for survey/observational data reweighting.
-  - `__new__`-based constructor: `BalanceFrame(responders=..., target=...)` with
+  - `__new__`-based constructor: `BalanceFrame(sf_with_outcomes=..., sf_target=...)` with
     covariate overlap validation.
+  - `__new__`-based constructor now supports target-less construction:
+    `BalanceFrame(sf_with_outcomes=sf)` creates a BalanceFrame without a target.
+  - `set_target(target, in_place=True)`: set or replace the target population.
+    When `in_place=True` (default), modifies and returns self; when `False`,
+    returns a new BalanceFrame. Resets adjustment state when target changes.
+  - `has_target()`: check if a target population is set.
   - `adjust(method="ipw")`: returns a NEW BalanceFrame (immutable pattern) with
     adjusted weights. Supports string methods (`"ipw"`, `"cbps"`, `"rake"`,
-    `"poststratify"`, `"null"`) and custom callables.
+    `"poststratify"`, `"null"`) and custom callables. Raises `ValueError` if
+    no target is set.
   - Properties: `responders`, `target`, `unadjusted`, `is_adjusted`.
   - `model()`: returns the adjustment model dictionary.
+  - `ignored_columns()`: returns ignored (misc) columns from the responder
+    SampleFrame (alias for `responders.ignored_columns()`).
+  - `id_column` property: returns the ID column of the responder SampleFrame.
   - Records weight provenance metadata on the adjusted weight column.
   - Default transformations applied when neither SampleFrame has custom transforms.
   - Calls weighting functions directly with DataFrames (no Sample dependency).
@@ -171,6 +181,14 @@
   - `BalanceFrame.to_sample()`: converts a BalanceFrame back to a Sample
     (reconstructs responder, target, and optionally unadjusted links).
   - All conversion methods use lazy imports to avoid circular dependencies.
+
+## Infrastructure
+
+- **`BalanceDF.__init__()`: added optional `links` parameter for explicit link injection**
+  - Allows BalanceDF to work with sources that do not carry mutable `_links`
+    (e.g. the upcoming SampleFrame class).
+  - When `links` is provided, `_BalanceDF_child_from_linked_samples()` uses the
+    explicit dict; otherwise falls back to `sample._links` (backward compatible).
 
 ## Code Quality & Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,36 +37,6 @@
     `Sample.adjust()` to `BalanceFrame.adjust()` so both APIs share the same logic.
   - No public API changes — all existing `Sample` methods continue to work identically.
 
-# 0.18.0 (2026-03-24)
-
-## New Features
-
-- **Implemented `r_indicator()` with validated sample-variance formula**
-  - Added a public `r_indicator(sample_p, target_p)` implementation in
-    `weighted_comparisons_stats` using the documented Eq. 2.2.2 formulation
-    over concatenated propensity vectors and explicit input-size validation.
-  - Added validation for non-finite and out-of-range propensity values,
-    and expanded unit coverage for formula correctness and edge cases.
-  - Added `BalanceDFWeights.r_indicator()` as a convenience wrapper, so
-    `sample.weights().r_indicator()` computes the r-indicator directly.
-
-## Deprecations
-
-- **`Sample.design_effect()` is deprecated** — use `sample.weights().design_effect()` instead.
-  The method already exists on `BalanceDFWeights`; the `Sample` method now emits a
-  `DeprecationWarning` and delegates. Will be removed in balance 0.19.0.
-- **`Sample.design_effect_prop()` is deprecated** — use `sample.weights().design_effect_prop()` instead.
-  New method added to `BalanceDFWeights`. Will be removed in balance 0.19.0.
-- **`Sample.plot_weight_density()` is deprecated** — use `sample.weights().plot()` instead.
-  Will be removed in balance 0.19.0.
-- **`Sample.covar_means()` is deprecated** — use `sample.covars().mean()` instead
-  (with `.rename(index={'self': 'adjusted'}).reindex([...]).T` for the same format).
-  Will be removed in balance 0.19.0.
-- **`Sample.outcome_sd_prop()` is deprecated** — use `sample.outcomes().outcome_sd_prop()` instead.
-  New method added to `BalanceDFOutcomes`. Will be removed in balance 0.19.0.
-- **`Sample.outcome_variance_ratio()` is deprecated** — use `sample.outcomes().outcome_variance_ratio()` instead.
-  New method added to `BalanceDFOutcomes`. Will be removed in balance 0.19.0.
-
 ## New Features
 
 - **Added `SampleFrame` — a DataFrame container with explicit column-role metadata**
@@ -92,40 +62,6 @@
   - `set_active_weight()`: switch the active weight column returned by `df_weights`.
   - `add_weight_column()`: append a new weight column with length validation,
     duplicate-name guard (including non-weight columns), and optional metadata.
-
-## Tests
-
-- Added comprehensive tests in `test_sample_frame.py` (8 test classes, ~60 tests):
-  - `TestSampleFrame` — basic creation, DataFrame properties, repr
-  - `TestSampleFrameMutableViewSafety` — mutation isolation for all properties
-  - `TestSampleFrameColumnRoleProperties` — column-role list properties with
-    copy-safety
-  - `TestSampleFrameFromFrame` — auto-detection, validation, equivalence with
-    `Sample.from_frame()`
-  - `TestSampleFrameFromCsv` — CSV roundtrip and kwargs forwarding
-  - `TestSampleFrameDunderMethods` — `__len__`, `__deepcopy__`
-  - `TestSampleFrameEdgeCases` — zero rows, empty weights, skip_copy isolation
-  - `TestSampleFrameWeightMetadata` — weight metadata roundtrip, active weight
-    default, empty dict storage, invalid column, set_active_weight,
-    add_weight_column (with metadata, duplicate guard, non-weight column guard,
-    length mismatch), multi-weight workflow (14 tests)
-  - `TestSampleFrameIntegration` — full lifecycle integration test exercising
-    auto-detection, pd.NA handling, multiple weight columns with add/switch
-    workflow, and numerical equivalence with `Sample.from_frame()` (1 test)
-
-- **`SampleFrame` now implements the `BalanceDFSource` protocol**
-  - Added `weight_column` property: returns the active weight as a `pd.Series`.
-  - Added `_covar_columns()` method: returns covariate DataFrame (delegates to
-    `df_covars`).
-  - Added `_outcome_columns` property: returns outcome DataFrame or None (delegates
-    to `df_outcomes`).
-  - Added `set_weights()` method: replaces active weight values (accepts Series,
-    float, or None).
-  - Added `_links` attribute: default empty dict, used by `BalanceDF` for linked
-    samples (e.g. target/unadjusted).
-  - `id_column` property already existed — no changes needed.
-  - `SampleFrame` can now be passed directly to `BalanceDF`, `BalanceDFCovars`,
-    `BalanceDFWeights`, and `BalanceDFOutcomes` constructors without any adapter.
 
 - **Added `BalanceFrame` — immutable adjustment orchestrator for survey weighting**
   - New class in `balance_frame.py` that pairs a responder `SampleFrame` with a
@@ -252,7 +188,7 @@
 
 ## LLM/GenAI
 
-- **Added `CLAUDE.md` project context files** for Claude Code users, covering architecture,
+- **Updated `CLAUDE.md` project context files** for Claude Code users, covering architecture,
   build/test instructions (Meta and open-source), code conventions, and pre-submit checklist.
 - **Updated `.github/copilot-instructions.md`** review checklist to reduce duplication with
   `CLAUDE.md` and add missing conventions (MIT license header, `from __future__ import annotations`,
@@ -340,11 +276,6 @@
     target_data, adjusted, adjusted_weight_column, with_outcomes,
     roundtrip_sample_bf_sample, roundtrip_adjusted, roundtrip_load_data
 
-- Added `TestSampleConversion` class in `test_sample.py` (6 tests):
-  - to_sample_frame_basic, to_sample_frame_with_outcomes,
-    to_sample_frame_with_ignored, to_balance_frame_unadjusted,
-    to_balance_frame_adjusted, to_balance_frame_no_target_raises
-
 - Added `TestSampleInternalSampleFrame` class in `test_sample.py` (19 tests):
   - `test_sample_has_sample_frame` — Sample has a SampleFrame backing
   - `test_df_property_returns_sample_frame_df` — `_df` delegates to SampleFrame
@@ -371,6 +302,11 @@
 - Added `test_Sample_is_adjusted_property_and_callable` in `test_sample.py`:
   verifies `is_adjusted` works both as property and method call
 
+- Added `TestSampleConversion` class in `test_sample.py` (6 tests):
+  - to_sample_frame_basic, to_sample_frame_with_outcomes,
+    to_sample_frame_with_ignored, to_balance_frame_unadjusted,
+    to_balance_frame_adjusted, to_balance_frame_no_target_raises
+
 - Added `TestBalanceDFSourceProtocol` class in `test_balancedf.py` (8 tests):
   - `test_sample_satisfies_protocol` — verifies `Sample` passes `isinstance` check
   - `test_protocol_is_runtime_checkable` — verifies protocol is runtime-checkable
@@ -391,6 +327,43 @@
     `_build_diagnostics()` matches `Sample.diagnostics()` for null adjustment.
   - `test_build_diagnostics_with_ipw_matches_sample_diagnostics` — same check
     for IPW adjustment.
+
+# 0.18.0 (2026-03-24)
+
+## New Features
+
+- **Implemented `r_indicator()` with validated sample-variance formula**
+  - Added a public `r_indicator(sample_p, target_p)` implementation in
+    `weighted_comparisons_stats` using the documented Eq. 2.2.2 formulation
+    over concatenated propensity vectors and explicit input-size validation.
+  - Added validation for non-finite and out-of-range propensity values,
+    and expanded unit coverage for formula correctness and edge cases.
+  - Added `BalanceDFWeights.r_indicator()` as a convenience wrapper, so
+    `sample.weights().r_indicator()` computes the r-indicator directly.
+
+## Deprecations
+
+- **`Sample.design_effect()` is deprecated** — use `sample.weights().design_effect()` instead.
+  The method already exists on `BalanceDFWeights`; the `Sample` method now emits a
+  `DeprecationWarning` and delegates. Will be removed in balance 0.19.0.
+- **`Sample.design_effect_prop()` is deprecated** — use `sample.weights().design_effect_prop()` instead.
+  New method added to `BalanceDFWeights`. Will be removed in balance 0.19.0.
+- **`Sample.plot_weight_density()` is deprecated** — use `sample.weights().plot()` instead.
+  Will be removed in balance 0.19.0.
+- **`Sample.covar_means()` is deprecated** — use `sample.covars().mean()` instead
+  (with `.rename(index={'self': 'adjusted'}).reindex([...]).T` for the same format).
+  Will be removed in balance 0.19.0.
+- **`Sample.outcome_sd_prop()` is deprecated** — use `sample.outcomes().outcome_sd_prop()` instead.
+  New method added to `BalanceDFOutcomes`. Will be removed in balance 0.19.0.
+- **`Sample.outcome_variance_ratio()` is deprecated** — use `sample.outcomes().outcome_variance_ratio()` instead.
+  New method added to `BalanceDFOutcomes`. Will be removed in balance 0.19.0.
+
+## LLM/GenAI
+
+- **Added `CLAUDE.md` project context files** for Claude Code users, covering architecture,
+  build/test instructions (Meta and open-source), code conventions, and pre-submit checklist.
+- **Added `.github/copilot-instructions.md`** review checklist.
+
 ## Bug Fixes
 
 - **`prepare_marginal_dist_for_raking` / `_realize_dicts_of_proportions`: fixed memory explosion from LCM expansion**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@
   - Formula settings are now propagated to linked covariate views (`target`,
     `unadjusted`) so comparative diagnostics run on consistent design matrices.
 
+## Internal Changes
+
+- **Refactored `Sample` to delegate to `SampleFrame` and `BalanceFrame` internally**
+  - `Sample` is now a thin facade: `set_target()` creates a backing `BalanceFrame`,
+    and `adjust()`, `summary()`, `diagnostics()`, `model()`, `is_adjusted`, and
+    `keep_only_some_rows_columns()` delegate to it.
+  - High-cardinality feature detection and large-target warnings moved from
+    `Sample.adjust()` to `BalanceFrame.adjust()` so both APIs share the same logic.
+  - No public API changes — all existing `Sample` methods continue to work identically.
+
 # 0.18.0 (2026-03-24)
 
 ## New Features
@@ -169,9 +179,24 @@
   - `to_csv()`: write combined DataFrame to CSV via `to_csv_with_defaults()`.
   - `to_download()`: create IPython `FileLink` for interactive download.
 
+- **Sample internally backed by SampleFrame**
+  - `Sample._df`, `_outcome_columns`, and `_ignored_column_names` are now `@property`
+    descriptors that delegate to a backing `_sample_frame: SampleFrame` instance.
+  - `from_frame()` refactored: all DataFrame mutations during construction use a local
+    `working_df` variable; at the end, `SampleFrame._create()` is called with explicit
+    column roles. The public API is fully backward-compatible.
+  - `adjust()` now records weight provenance metadata on the backing SampleFrame via
+    `set_weight_metadata()`, enabling downstream code to inspect how weights were produced.
+  - `keep_only_some_rows_columns()`: column filtering now always preserves outcome
+    columns in the keep set (per-link filtering uses each linked object's own outcomes).
+
+- **`Sample.is_adjusted` is now a `@property` returning `_CallableBool`** — works both
+  as `sample.is_adjusted` (property, consistent with BalanceFrame) and
+  `sample.is_adjusted()` (legacy method call, backward compatible).
+
 - **Added bidirectional conversion between Sample, SampleFrame, and BalanceFrame**
   - `SampleFrame.from_sample(sample)`: converts a Sample to a SampleFrame with
-    proper column-role mapping (id, weight, outcomes, ignored → misc).
+    proper column-role mapping (id, weight, outcomes, ignored).
   - `Sample.to_sample_frame()`: convenience method delegating to
     `SampleFrame.from_sample()`.
   - `BalanceFrame.from_sample(sample)`: converts a Sample (with target) to a
@@ -319,6 +344,32 @@
   - to_sample_frame_basic, to_sample_frame_with_outcomes,
     to_sample_frame_with_ignored, to_balance_frame_unadjusted,
     to_balance_frame_adjusted, to_balance_frame_no_target_raises
+
+- Added `TestSampleInternalSampleFrame` class in `test_sample.py` (19 tests):
+  - `test_sample_has_sample_frame` — Sample has a SampleFrame backing
+  - `test_df_property_returns_sample_frame_df` — `_df` delegates to SampleFrame
+  - `test_df_setter_updates_sample_frame` — setting `_df` updates SampleFrame
+  - `test_outcome_columns_property/none/setter` — outcome columns delegate
+  - `test_ignored_column_names_property/empty/setter` — ignored columns delegate
+  - `test_covar_columns_inferred_correctly` — covars inferred by exclusion
+  - `test_from_frame_builds_sample_frame_with_correct_roles` — all roles correct
+  - `test_set_target_preserves_sample_frame` — set_target keeps SampleFrame
+  - `test_unadjusted_has_no_weight_metadata` — no metadata before adjust
+  - `test_adjust_records_weight_metadata` — adjust() records method + adjusted
+  - `test_adjust_ipw_records_weight_metadata` — IPW method recorded
+  - `test_adjust_callable_records_weight_metadata` — callable __name__ recorded
+  - `test_set_weights_syncs_sample_frame` — set_weights updates SampleFrame
+  - `test_keep_only_some_rows_columns_preserves_outcomes` — outcomes kept in column filter
+  - `test_deepcopy_preserves_sample_frame` — deepcopy creates independent SampleFrame
+
+- Added `TestCallableBool` class in `test_sample.py` (11 tests):
+  - `test_bool_true/false`, `test_call_true/false`, `test_repr`,
+    `test_eq_with_bool`, `test_eq_with_callable_bool`,
+    `test_eq_not_implemented_for_other_types`, `test_hash`,
+    `test_mul`, `test_rmul`
+
+- Added `test_Sample_is_adjusted_property_and_callable` in `test_sample.py`:
+  verifies `is_adjusted` works both as property and method call
 
 - Added `TestBalanceDFSourceProtocol` class in `test_balancedf.py` (8 tests):
   - `test_sample_satisfies_protocol` — verifies `Sample` passes `isinstance` check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@
 
 ## Internal Changes
 
+- **Naming consistency: weight-related property renames**
+  - `SampleFrame.active_weight_column` (str) → `weight_column` — simpler name for
+    the active weight column name.
+  - `SampleFrame.weight_column` (Series) → `weight_series` — clarifies this returns
+    weight values, not a column name.
+  - `SampleFrame.weight_columns` (list) → `weight_columns_all` — avoids confusion
+    with the singular `weight_column`.
+  - `SampleFrame._active_weight_column` → `_weight_column_name` — clearer: stores
+    a column name string.
+  - `BalanceFrame.weight_column` (Series) → `weight_series` — matches SampleFrame.
+  - `BalanceDFSource.weight_column` → `weight_series` — protocol accessor renamed.
+  - All internal references updated across balance, graviton, and test files.
+
 - **Refactored `Sample` to delegate to `SampleFrame` and `BalanceFrame` internally**
   - `Sample` is now a thin facade: `set_target()` creates a backing `BalanceFrame`,
     and `adjust()`, `summary()`, `diagnostics()`, `model()`, `is_adjusted`, and
@@ -152,7 +165,7 @@
 - **Defined `BalanceDFSource` protocol and decoupled `BalanceDF` from `Sample`**
   - Added `BalanceDFSource` — a `typing.Protocol` (runtime-checkable) that captures
     the 6 attributes/methods `BalanceDF` accesses on its backing object:
-    `weight_column`, `id_column`, `_links`, `_covar_columns()`,
+    `weight_series`, `id_column`, `_links`, `_covar_columns()`,
     `_outcome_columns`, and `set_weights()`.
   - Updated `BalanceDF.__init__`, `BalanceDFCovars.__init__`,
     `BalanceDFWeights.__init__`, and `BalanceDFOutcomes.__init__` to accept
@@ -212,7 +225,7 @@
   (21 tests):
   - `test_isinstance_balancedf_source` — verifies `isinstance(sf, BalanceDFSource)`
   - `test_weight_column_returns_series`, `test_weight_column_returns_copy`,
-    `test_weight_column_no_active_raises` — weight_column property
+    `test_weight_series_no_active_raises` — weight_series property
   - `test_id_column_returns_series` — id_column property
   - `test_links_default_empty`, `test_links_preserved_in_deepcopy` — _links attribute
   - `test_covar_columns_method`, `test_covar_columns_method_returns_copy` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,13 @@
   - `BalanceDFSource.weight_column` → `weight_series` — protocol accessor renamed.
   - All internal references updated across balance, graviton, and test files.
 
+- **Naming consistency: BalanceFrame internal attributes**
+  - `BalanceFrame._sf_with_outcomes` → `_sf_sample` — shorter, clearer.
+  - `BalanceFrame._sf_with_outcomes_pre_adjust` → `_sf_sample_pre_adjust`.
+  - `BalanceFrame(sf_with_outcomes=...)` constructor param → `sample=`.
+  - `BalanceFrame.id_column` and `weight_series` now delegate to `_sf_sample`
+    instead of caching redundant copies, removing stale-state risk.
+
 - **Refactored `Sample` to delegate to `SampleFrame` and `BalanceFrame` internally**
   - `Sample` is now a thin facade: `set_target()` creates a backing `BalanceFrame`,
     and `adjust()`, `summary()`, `diagnostics()`, `model()`, `is_adjusted`, and
@@ -77,10 +84,10 @@
 - **Added `BalanceFrame` — immutable adjustment orchestrator for survey weighting**
   - New class in `balance_frame.py` that pairs a responder `SampleFrame` with a
     target `SampleFrame` for survey/observational data reweighting.
-  - `__new__`-based constructor: `BalanceFrame(sf_with_outcomes=..., sf_target=...)` with
+  - `__new__`-based constructor: `BalanceFrame(sample=..., sf_target=...)` with
     covariate overlap validation.
   - `__new__`-based constructor now supports target-less construction:
-    `BalanceFrame(sf_with_outcomes=sf)` creates a BalanceFrame without a target.
+    `BalanceFrame(sample=sf)` creates a BalanceFrame without a target.
   - `set_target(target, in_place=True)`: set or replace the target population.
     When `in_place=True` (default), modifies and returns self; when `False`,
     returns a new BalanceFrame. Resets adjustment state when target changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@
   - Column-role list properties: `covars_columns`, `weight_columns`,
     `outcome_columns`, `predicted_outcome_columns`, `misc_columns` (all return
     copies).
+  - `ignored_columns()`: alias for `df_misc`, provided for API parity with
+    `Sample.ignored_columns()`.
   - Internal `_create()` factory with `_skip_copy` optimization for callers that
     have already deep-copied.
   - Comprehensive validation: null/negative/non-numeric weights, null IDs,

--- a/balance/__init__.py
+++ b/balance/__init__.py
@@ -78,8 +78,5 @@ logger.info(f"Using {__package__} version {__version__}")
 print(WELCOME_MESSAGE)
 
 
-SHOW_DEPRECATION_WARNINGS: bool = True
-
-
 def set_warnings(level: str = "WARNING") -> None:
     logger.setLevel(getattr(logging, level))

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -13,27 +13,85 @@ immutable adjust() method that returns a new, weight-augmented BalanceFrame.
 
 from __future__ import annotations
 
+import collections
 import copy
 import logging
+from copy import deepcopy
 from typing import Any, Callable, cast, Literal, TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
+from balance import util as balance_util
 from balance.adjustment import _find_adjustment_method
 from balance.csv_utils import to_csv_with_defaults
 from balance.sample_frame import SampleFrame
 from balance.stats_and_plots import weights_stats
 from balance.summary_utils import _build_diagnostics, _build_summary
 from balance.typing import FilePathOrBuffer
+from balance.util import (
+    _assert_type,
+    _detect_high_cardinality_features,
+    HighCardinalityFeature,
+)
 from balance.utils.file_utils import _to_download
 
 if TYPE_CHECKING:
-    from balance.balancedf_class import BalanceDFSource
+    from typing import Self
+
+    from balance.balancedf_class import BalanceDFSource  # noqa: F401
 
 # The set of string method names accepted by _find_adjustment_method.
 _AdjustmentMethodStr = Literal["cbps", "ipw", "null", "poststratify", "rake"]
 
 logger: logging.Logger = logging.getLogger(__package__)
+
+
+class _CallableBool:
+    """A bool-like value that is also callable, for backward-compatible property migration.
+
+    This allows ``is_adjusted`` to work both as a property (``sample.is_adjusted``)
+    and as a method call (``sample.is_adjusted()``) for backward compatibility.
+
+    Args:
+        value: The boolean value to wrap.
+
+    Examples:
+        >>> cb = _CallableBool(True)
+        >>> bool(cb)
+        True
+        >>> cb()
+        True
+    """
+
+    __slots__ = ("_value",)
+
+    def __init__(self, value: bool) -> None:
+        self._value: bool = value
+
+    def __bool__(self) -> bool:
+        return self._value
+
+    def __call__(self) -> bool:
+        return self._value
+
+    def __repr__(self) -> str:
+        return repr(self._value)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, bool):
+            return self._value == other
+        if isinstance(other, _CallableBool):
+            return self._value == other._value
+        return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash(self._value)
+
+    def __mul__(self, other: object) -> object:
+        return self._value * other  # pyre-ignore[58]
+
+    def __rmul__(self, other: object) -> object:
+        return other * self._value  # pyre-ignore[58]
 
 
 class BalanceFrame:
@@ -49,7 +107,7 @@ class BalanceFrame:
     it safe to keep a reference to the pre-adjustment state.
 
     Must be constructed via the public constructor
-    ``BalanceFrame(responders=..., target=...)`` which delegates to the
+    ``BalanceFrame(sf_with_outcomes=..., sf_target=...)`` which delegates to the
     internal :meth:`_create` factory.
 
     Attributes:
@@ -65,7 +123,7 @@ class BalanceFrame:
         ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
         >>> tgt = SampleFrame.from_frame(
         ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-        >>> bf = BalanceFrame(responders=resp, target=tgt)
+        >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
         >>> bf.is_adjusted
         False
         >>> adjusted = bf.adjust(method="ipw")
@@ -75,14 +133,83 @@ class BalanceFrame:
         False
     """
 
-    # pyre-fixme[13]: Attributes are initialized in _create()
-    _responders: SampleFrame
-    # pyre-fixme[13]: Attributes are initialized in _create()
-    _target: SampleFrame | None
-    # pyre-fixme[13]: Attributes are initialized in _create()
-    _unadjusted: SampleFrame | None
-    # pyre-fixme[13]: Attributes are initialized in _create()
+    # pyre-fixme[13]: Attributes are initialized in _create() / from_frame()
+    _sf_with_outcomes_pre_adjust: SampleFrame
+    # pyre-fixme[13]: Attributes are initialized in _create() / from_frame()
+    _sf_with_outcomes: SampleFrame
+    # pyre-fixme[13]: Attributes are initialized in _create() / from_frame()
+    _sf_target: SampleFrame | None
+    # pyre-fixme[13]: Attributes are initialized in _create() / from_frame()
     _adjustment_model: dict[str, Any] | None
+    # pyre-fixme[4]: Attributes are initialized in from_frame() / _create()
+    _links = None
+    _id_column: pd.Series | None = None
+    _weight_column: pd.Series | None = None
+
+    @property
+    def _df_dtypes(self) -> pd.Series | None:
+        """Original dtypes, delegated to ``_sf_with_outcomes._df_dtypes``."""
+        return self._sf_with_outcomes._df_dtypes
+
+    @_df_dtypes.setter
+    def _df_dtypes(self, value: pd.Series | None) -> None:
+        self._sf_with_outcomes._df_dtypes = value
+
+    @property
+    def id_column(self) -> pd.Series | None:  # pyre-ignore[3]
+        """The id column Series."""
+        return self._id_column
+
+    @id_column.setter
+    def id_column(self, value: pd.Series | None) -> None:  # pyre-ignore[2,3]
+        self._id_column = value
+
+    @property
+    def weight_column(self) -> pd.Series | None:  # pyre-ignore[3]
+        """The weight column Series."""
+        return self._weight_column
+
+    @weight_column.setter
+    def weight_column(self, value: pd.Series | None) -> None:  # pyre-ignore[2,3]
+        self._weight_column = value
+
+    # --- Property descriptors backed by _sf_with_outcomes ---
+
+    @property
+    def _df(self) -> pd.DataFrame:  # pyre-ignore[3]
+        """The internal DataFrame, delegated to ``_sf_with_outcomes._df``."""
+        return self._sf_with_outcomes._df
+
+    @_df.setter
+    def _df(self, value: pd.DataFrame | None) -> None:  # pyre-ignore[2,3]
+        if value is not None:
+            self._sf_with_outcomes._df = value
+
+    @property
+    def _outcome_columns(self) -> pd.DataFrame | None:
+        """Outcome columns as a DataFrame, delegated to ``_sf_with_outcomes``."""
+        outcome_cols = self._sf_with_outcomes._column_roles.get("outcomes", [])
+        if not outcome_cols:
+            return None
+        return self._sf_with_outcomes._df[outcome_cols]
+
+    @_outcome_columns.setter
+    def _outcome_columns(self, value: pd.DataFrame | None) -> None:
+        if value is None:
+            self._sf_with_outcomes._column_roles["outcomes"] = []
+        else:
+            self._sf_with_outcomes._column_roles["outcomes"] = value.columns.tolist()
+
+    @property
+    def _ignored_column_names(self) -> list[str]:  # pyre-ignore[3]
+        """Ignored column names, delegated to ``_sf_with_outcomes.ignore_columns``."""
+        return self._sf_with_outcomes._column_roles.get("ignored", [])
+
+    @_ignored_column_names.setter
+    def _ignored_column_names(
+        self, value: list[str] | None
+    ) -> None:  # pyre-ignore[2,3]
+        self._sf_with_outcomes._column_roles["ignored"] = list(value) if value else []
 
     # -----------------------------------------------------------------------
     # Design note: Why __new__ + no-op __init__?
@@ -94,7 +221,7 @@ class BalanceFrame:
     #
     # The solution used here:
     #   - __new__ handles BOTH construction paths:
-    #       1. Public constructor: BalanceFrame(responders=sf1, target=sf2)
+    #       1. Public constructor: BalanceFrame(sf_with_outcomes=sf1, sf_target=sf2)
     #          → validates args and delegates to _create().
     #       2. deepcopy path: BalanceFrame() (no args)
     #          → returns a bare object via object.__new__(cls); deepcopy
@@ -103,42 +230,42 @@ class BalanceFrame:
     # -----------------------------------------------------------------------
     def __new__(
         cls,
-        responders: SampleFrame | None = None,
-        target: SampleFrame | None = None,
+        sf_with_outcomes: SampleFrame | None = None,
+        sf_target: SampleFrame | None = None,
     ) -> BalanceFrame:
         """Create a BalanceFrame from responder and target SampleFrames.
 
         This uses ``__new__`` so that the natural constructor syntax
-        ``BalanceFrame(responders=..., target=...)`` works while still
+        ``BalanceFrame(sf_with_outcomes=..., sf_target=...)`` works while still
         routing through the validated :meth:`_create` factory.
 
         Args:
-            responders: The responder / sample data.
-            target: The target / population data.
+            sf_with_outcomes: The responder / sample data.
+            sf_target: The target / population data.
 
         Returns:
             A new BalanceFrame pairing the two samples.
 
         Raises:
-            TypeError: If *responders* or *target* is not a SampleFrame.
-            ValueError: If *responders* and *target* share no covariate
+            TypeError: If *sf_with_outcomes* or *sf_target* is not a SampleFrame.
+            ValueError: If *sf_with_outcomes* and *sf_target* share no covariate
                 columns.
         """
-        if responders is None:
+        if sf_with_outcomes is None:
             # Allow object.__new__(cls) for copy.deepcopy() support.
-            if target is None:
+            if sf_target is None:
                 return object.__new__(cls)
             raise TypeError(
-                "BalanceFrame requires at least a 'responders' argument. "
-                "Usage: BalanceFrame(responders=sf1) or "
-                "BalanceFrame(responders=sf1, target=sf2)"
+                "BalanceFrame requires at least a 'sf_with_outcomes' argument. "
+                "Usage: BalanceFrame(sf_with_outcomes=sf1) or "
+                "BalanceFrame(sf_with_outcomes=sf1, sf_target=sf2)"
             )
-        return cls._create(responders=responders, target=target)
+        return cls._create(sf_with_outcomes=sf_with_outcomes, sf_target=sf_target)
 
     def __init__(
         self,
-        responders: SampleFrame | None = None,
-        target: SampleFrame | None = None,
+        sf_with_outcomes: SampleFrame | None = None,
+        sf_target: SampleFrame | None = None,
     ) -> None:
         # All initialisation happens in _create(); __init__ is intentionally
         # empty so that __new__ + _create() handles everything.
@@ -147,44 +274,52 @@ class BalanceFrame:
     @classmethod
     def _create(
         cls,
-        responders: SampleFrame,
-        target: SampleFrame | None = None,
-    ) -> BalanceFrame:
+        sf_with_outcomes: SampleFrame,
+        sf_target: SampleFrame | None = None,
+    ) -> Self:
         """Internal factory method.
 
         Validates covariate overlap and builds the BalanceFrame instance.
-        Prefer the public constructor ``BalanceFrame(responders=..., target=...)``.
+        Prefer the public constructor ``BalanceFrame(sf_with_outcomes=..., sf_target=...)``.
 
         Args:
-            responders: The responder sample.
-            target: The target population. If None, creates a target-less
+            sf_with_outcomes: The responder sample.
+            sf_target: The target population. If None, creates a target-less
                 BalanceFrame that can be completed later via :meth:`set_target`.
 
         Returns:
             A validated BalanceFrame.
 
         Raises:
-            TypeError: If *responders* or *target* is not a SampleFrame.
+            TypeError: If *sf_with_outcomes* or *sf_target* is not a SampleFrame.
             ValueError: If they share no covariate columns.
         """
-        if not isinstance(responders, SampleFrame):
+        if not isinstance(sf_with_outcomes, SampleFrame):
             raise TypeError(
-                f"'responders' must be a SampleFrame, got {type(responders).__name__}"
+                f"'sf_with_outcomes' must be a SampleFrame, got {type(sf_with_outcomes).__name__}"
             )
-        if target is not None and not isinstance(target, SampleFrame):
+        if sf_target is not None and not isinstance(sf_target, SampleFrame):
             raise TypeError(
-                f"'target' must be a SampleFrame, got {type(target).__name__}"
+                f"'sf_target' must be a SampleFrame, got {type(sf_target).__name__}"
             )
 
         instance = object.__new__(cls)
-        instance._responders = responders
-        instance._target = target
-        instance._unadjusted = None
+        instance._sf_with_outcomes_pre_adjust = sf_with_outcomes
+        instance._sf_with_outcomes = sf_with_outcomes  # same object initially
+        instance._sf_target = sf_target
         instance._adjustment_model = None
+        instance.id_column = sf_with_outcomes.id_column
+        try:
+            instance.weight_column = sf_with_outcomes.weight_column
+        except ValueError:
+            instance.weight_column = None
+        instance._links = collections.defaultdict(list)
+        if sf_target is not None:
+            instance._links["target"] = sf_target
 
         # Validate covariate overlap using public properties
-        if target is not None:
-            cls._validate_covariate_overlap(responders, target)
+        if sf_target is not None:
+            cls._validate_covariate_overlap(sf_with_outcomes, sf_target)
 
         return instance
 
@@ -217,14 +352,40 @@ class BalanceFrame:
     # --- Properties ---
 
     @property
+    def df_responders(self) -> pd.DataFrame:
+        """The responder data as a DataFrame."""
+        return self._sf_with_outcomes.df
+
+    @property
+    def df_target(self) -> pd.DataFrame | None:
+        """The target data as a DataFrame, or None if not yet set."""
+        if self._sf_target is None:
+            return None
+        return self._sf_target.df
+
+    @property
+    def df_responders_unadjusted(self) -> pd.DataFrame:
+        """The original (pre-adjustment) responder data as a DataFrame."""
+        return self._sf_with_outcomes_pre_adjust.df
+
+    # --- Backward-compat aliases (to be removed in a future diff) ---
+
+    @property
     def responders(self) -> SampleFrame:
-        """The responder SampleFrame."""
-        return self._responders
+        """Alias for ``_sf_with_outcomes`` (backward compat, will be removed)."""
+        return self._sf_with_outcomes
 
     @property
     def target(self) -> SampleFrame | None:
-        """The target SampleFrame, or None if not yet set."""
-        return self._target
+        """Alias for ``_sf_target`` (backward compat, will be removed)."""
+        return self._sf_target
+
+    @property
+    def unadjusted(self) -> SampleFrame | None:
+        """Alias for ``_sf_with_outcomes_pre_adjust`` if adjusted, else None (backward compat)."""
+        if self.is_adjusted:
+            return self._sf_with_outcomes_pre_adjust
+        return None
 
     def has_target(self) -> bool:
         """Check if this BalanceFrame has a target population set.
@@ -238,7 +399,7 @@ class BalanceFrame:
             >>> from balance.balance_frame import BalanceFrame
             >>> resp = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp)
             >>> bf.has_target()
             False
             >>> tgt = SampleFrame.from_frame(
@@ -247,23 +408,34 @@ class BalanceFrame:
             >>> bf.has_target()
             True
         """
-        return self._target is not None
+        return self._sf_target is not None or (
+            self._links is not None and "target" in self._links
+        )
 
-    def set_target(self, target: SampleFrame, in_place: bool = True) -> BalanceFrame:
+    def set_target(
+        self, target: BalanceFrame | SampleFrame, in_place: bool | None = None
+    ) -> Self:
         """Set or replace the target population.
 
+        When *target* is a BalanceFrame (or subclass such as Sample), a deep
+        copy of ``self`` is returned with the target set (immutable pattern).
+        When *target* is a raw SampleFrame, the behaviour depends on
+        *in_place*: True mutates self, False returns a new BalanceFrame.
+
         Args:
-            target: The new target SampleFrame.
-            in_place: If True (default), modifies this BalanceFrame in place and
-                returns self. If False, returns a new BalanceFrame with the new
-                target.
+            target: The target population — a BalanceFrame/Sample or a
+                SampleFrame.
+            in_place: If True, mutates self (only valid for SampleFrame
+                targets). If False, returns a new copy. Defaults to None
+                which auto-selects: copy for BalanceFrame targets, in-place
+                for SampleFrame targets.
 
         Returns:
             BalanceFrame with the new target set.
 
         Raises:
-            TypeError: If *target* is not a SampleFrame.
-            ValueError: If responders and target share no covariate columns.
+            TypeError / ValueError: If *target* is not a BalanceFrame or
+                SampleFrame, or if they share no covariate columns.
 
         Examples:
             >>> import pandas as pd
@@ -273,37 +445,58 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp)
             >>> bf.set_target(tgt)
             >>> bf.has_target()
             True
         """
-        if not isinstance(target, SampleFrame):
-            raise TypeError(
-                f"'target' must be a SampleFrame, got {type(target).__name__}"
-            )
-        BalanceFrame._validate_covariate_overlap(self._responders, target)
+        if isinstance(target, BalanceFrame):
+            # BalanceFrame / Sample path: return a deep copy (immutable)
+            new_copy = deepcopy(self)
+            new_copy._links["target"] = target
+            # Validation may fail if sample and target share no covariates
+            # (e.g., outcome-only targets). In that case, skip validation —
+            # adjust() will report the error when called.
+            try:
+                BalanceFrame._validate_covariate_overlap(
+                    new_copy._sf_with_outcomes, target._sf_with_outcomes
+                )
+            except (ValueError, TypeError):
+                pass
+            new_copy._sf_target = target._sf_with_outcomes
+            return new_copy
 
-        if in_place:
-            self._target = target
-            # Reset adjustment state — old adjustment is no longer valid
-            self._unadjusted = None
-            self._adjustment_model = None
-            return self
-        else:
-            return BalanceFrame._create(
-                responders=copy.deepcopy(self._responders), target=target
-            )
+        if isinstance(target, SampleFrame):
+            # SampleFrame path: default in_place=True for backward compat
+            if in_place is None:
+                in_place = True
+            BalanceFrame._validate_covariate_overlap(self._sf_with_outcomes, target)
+
+            if in_place:
+                self._sf_target = target
+                self._links["target"] = target
+                # Reset adjustment state — old adjustment is no longer valid.
+                self._sf_with_outcomes = self._sf_with_outcomes_pre_adjust
+                self._adjustment_model = None
+                return self
+            else:
+                return type(self)._create(
+                    sf_with_outcomes=copy.deepcopy(self._sf_with_outcomes_pre_adjust),
+                    sf_target=target,
+                )
+
+        raise TypeError("A target, a Sample object, must be specified")
 
     @property
-    def unadjusted(self) -> SampleFrame | None:
-        """The pre-adjustment responder SampleFrame, or None if not adjusted."""
-        return self._unadjusted
+    def is_adjusted(self) -> _CallableBool:
+        """Whether this BalanceFrame has been adjusted.
 
-    @property
-    def is_adjusted(self) -> bool:
-        """Whether this BalanceFrame has been adjusted."""
-        return self._unadjusted is not None
+        Returns a ``_CallableBool`` so both ``bf.is_adjusted`` (property)
+        and ``bf.is_adjusted()`` (legacy call) work.
+        """
+        return _CallableBool(
+            self._sf_with_outcomes is not self._sf_with_outcomes_pre_adjust
+        )
 
     # --- Adjustment ---
 
@@ -340,15 +533,15 @@ class BalanceFrame:
         Raises:
             ValueError: If no target is set.
         """
-        if self._target is None:
+        if self._sf_target is None:
             raise ValueError("Cannot get covars without a target population.")
-        return self._responders.df_covars, self._target.df_covars
+        return self._sf_with_outcomes.df_covars, self._sf_target.df_covars
 
     def _build_adjusted_frame(
         self,
         result: dict[str, Any],
         method: str | Callable[..., Any],
-    ) -> BalanceFrame:
+    ) -> Self:
         """Construct a new BalanceFrame with adjusted weights.
 
         Args:
@@ -357,43 +550,76 @@ class BalanceFrame:
             method: The original method argument (string or callable).
 
         Returns:
-            A new, adjusted BalanceFrame.
+            A new, adjusted BalanceFrame (or subclass instance if called on
+            a subclass).
         """
-        new_responders = copy.deepcopy(self._responders)
-        method_name = method if isinstance(method, str) else "custom"
+        new_responders = copy.deepcopy(self._sf_with_outcomes)
+        method_name = (
+            method
+            if isinstance(method, str)
+            else getattr(method, "__name__", str(method))
+        )
         new_responders.add_weight_column(
             "weight_adjusted",
             result["weight"],
             metadata={
                 "method": method_name,
+                "adjusted": True,
                 "model": result.get("model", {}),
             },
         )
         new_responders.set_active_weight("weight_adjusted")
 
-        new_bf = BalanceFrame._create(
-            responders=new_responders,
-            target=self._target,
+        # For Sample subclasses: rename "weight_adjusted" → original weight
+        # column name so the public API always sees the original name.
+        # For direct BalanceFrame: keep both columns (weight + weight_adjusted).
+        original_weight_name = _assert_type(self.weight_column).name
+        if type(self) is not BalanceFrame:
+            # Sample (or other subclass) path: rename weight_adjusted → original
+            if (
+                original_weight_name in new_responders._df.columns
+                and original_weight_name != "weight_adjusted"
+            ):
+                new_responders._df = new_responders._df.drop(
+                    columns=[original_weight_name]
+                )
+                if original_weight_name in new_responders._column_roles["weights"]:
+                    new_responders._column_roles["weights"].remove(original_weight_name)
+            new_responders.rename_weight_column("weight_adjusted", original_weight_name)
+
+        # Use type(self) so subclasses (e.g. Sample) get their own type back.
+        new_bf = type(self)._create(
+            sf_with_outcomes=new_responders,
+            sf_target=self._sf_target,
         )
-        new_bf._unadjusted = copy.deepcopy(self._responders)
+        # Point _sf_with_outcomes_pre_adjust to the original (pre-adjustment) data
+        new_bf._sf_with_outcomes_pre_adjust = self._sf_with_outcomes_pre_adjust
+        new_bf.id_column = new_responders.id_column
+        new_bf.weight_column = new_responders.weight_column
+        # Set _links for __str__() and BalanceDF integration
+        new_bf._links["unadjusted"] = self
+        if "target" in self._links:
+            new_bf._links["target"] = self._links["target"]
+
         raw_model = result.get("model")
         # Defensive copy: the weighting function may retain a reference to the
         # dict it returned, so mutating it here could cause surprising side effects.
         new_bf._adjustment_model = (
             dict(raw_model) if isinstance(raw_model, dict) else raw_model
         )
+        # Preserve the raw model's method name (e.g. "null_adjustment") when
+        # present; only set a fallback when the model doesn't include one.
         if isinstance(new_bf._adjustment_model, dict):
-            if isinstance(method, str):
-                new_bf._adjustment_model["method"] = method_name
-            else:
-                new_bf._adjustment_model.setdefault("method", method_name)
+            new_bf._adjustment_model.setdefault("method", method_name)
         return new_bf
 
     def adjust(
         self,
+        target: BalanceFrame | None = None,
         method: str | Callable[..., Any] = "ipw",
+        *args: Any,
         **kwargs: Any,
-    ) -> BalanceFrame:
+    ) -> Self:
         """Adjust responder weights to match the target. Returns a NEW BalanceFrame.
 
         The original BalanceFrame is not modified (immutable pattern).  The
@@ -402,10 +628,14 @@ class BalanceFrame:
         :attr:`unadjusted`.
 
         Args:
+            target: Optional target BalanceFrame/Sample. If provided, calls
+                ``set_target(target)`` first, then adjusts. If None, uses the
+                already-set target.
             method: The weighting method to use.  Built-in options:
                 ``"ipw"``, ``"cbps"``, ``"rake"``, ``"poststratify"``,
                 ``"null"``.  A callable with the same signature as the
                 built-in methods is also accepted.
+            *args: Positional arguments (forwarded on recursive call only).
             **kwargs: Additional keyword arguments forwarded to the adjustment
                 function (e.g. ``max_de``, ``transformations``).
 
@@ -427,31 +657,85 @@ class BalanceFrame:
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [4, 5, 6], "x": [15.0, 25.0, 35.0],
             ...                   "weight": [1.0, 1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> adjusted = bf.adjust(method="ipw")
             >>> adjusted.is_adjusted
             True
         """
-        target = self._target
-        if target is None:
-            raise ValueError(
-                "Cannot adjust a BalanceFrame without a target population. "
-                "Use set_target() to set one first."
-            )
+        if target is not None:
+            # Inline target: set it first, then recurse
+            self_with_target = self.set_target(target)
+            return self_with_target.adjust(*args, method=method, **kwargs)
+
+        self._no_target_error()
+
         if self.is_adjusted:
             raise ValueError(
                 "Cannot adjust an already-adjusted BalanceFrame. "
                 "Use the original (unadjusted) BalanceFrame instead."
             )
 
+        sf_target = self._sf_target
+        assert sf_target is not None  # guaranteed by _no_target_error() above
+
         adjustment_function = self._resolve_adjustment_function(method)
         resp_covars, target_covars = self._get_covars()
 
+        # Detect high-cardinality features in both responder and target covariates
+        num_rows_sample = resp_covars.shape[0]
+        num_rows_target = target_covars.shape[0]
+        if (
+            num_rows_sample > 0
+            and num_rows_target > 100_000
+            and num_rows_target >= 10 * num_rows_sample
+        ):
+            logger.warning(
+                "Large target detected: %s target rows vs %s sample rows. "
+                "When the target is much larger than the sample (here >10x and >100k rows), "
+                "the target's contribution to variance becomes negligible. "
+                "Standard errors will be driven almost entirely by the sample, "
+                "similar to a one-sample inference setting.",
+                num_rows_target,
+                num_rows_sample,
+            )
+
+        sample_high_card = _detect_high_cardinality_features(resp_covars)
+        target_high_card = _detect_high_cardinality_features(target_covars)
+
+        # Merge the results, taking the maximum unique_count for each column
+        high_cardinality_dict: dict[str, HighCardinalityFeature] = {}
+        for feature in sample_high_card + target_high_card:
+            if (
+                feature.column not in high_cardinality_dict
+                or feature.unique_count
+                > high_cardinality_dict[feature.column].unique_count
+            ):
+                high_cardinality_dict[feature.column] = feature
+
+        high_cardinality_features = sorted(
+            high_cardinality_dict.values(),
+            key=lambda f: f.unique_count,
+            reverse=True,
+        )
+
+        if high_cardinality_features:
+            formatted_details = ", ".join(
+                f"{feature.column} (unique={feature.unique_count}; "
+                f"unique_ratio={feature.unique_ratio:.2f}"
+                f"{'; missing values present' if feature.has_missing else ''}"
+                f")"
+                for feature in high_cardinality_features
+            )
+            logger.warning(
+                "High-cardinality features detected that may not provide signal: "
+                + formatted_details
+            )
+
         result = adjustment_function(
             sample_df=resp_covars,
-            sample_weights=self._responders.df_weights.iloc[:, 0],
+            sample_weights=self._sf_with_outcomes.df_weights.iloc[:, 0],
             target_df=target_covars,
-            target_weights=target.df_weights.iloc[:, 0],
+            target_weights=sf_target.df_weights.iloc[:, 0],
             **kwargs,
         )
 
@@ -471,7 +755,7 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> bf.model() is None
             True
         """
@@ -527,10 +811,13 @@ class BalanceFrame:
         responders_sf = SampleFrame.from_sample(sample)
         target_sf = SampleFrame.from_sample(sample._links["target"])
 
-        bf = cls._create(responders=responders_sf, target=target_sf)
+        bf = cls._create(sf_with_outcomes=responders_sf, sf_target=target_sf)
 
         if sample.is_adjusted():
-            bf._unadjusted = SampleFrame.from_sample(sample._links["unadjusted"])
+            # Set unadjusted to a DIFFERENT SampleFrame so is_adjusted returns True
+            bf._sf_with_outcomes_pre_adjust = SampleFrame.from_sample(
+                sample._links["unadjusted"]
+            )
             bf._adjustment_model = sample.model()
 
         return bf
@@ -558,7 +845,7 @@ class BalanceFrame:
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [4, 5, 6], "x": [15.0, 25.0, 35.0],
             ...                   "weight": [1.0, 1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> s = bf.to_sample()
             >>> s.has_target()
             True
@@ -566,18 +853,18 @@ class BalanceFrame:
         # Lazy import: sample_class ↔ balance_frame have a circular dependency.
         from balance.sample_class import Sample
 
-        target = self._target
+        target = self._sf_target
         if target is None:
             raise ValueError(
                 "Cannot convert to Sample: BalanceFrame has no target set."
             )
 
         resp_sample = Sample.from_frame(
-            self._responders._df,
-            id_column=self._responders.id_column_name,
-            weight_column=self._responders.active_weight_column,
-            outcome_columns=self._responders.outcome_columns or None,
-            ignore_columns=self._responders.ignore_columns or None,
+            self._sf_with_outcomes._df,
+            id_column=self._sf_with_outcomes.id_column_name,
+            weight_column=self._sf_with_outcomes.active_weight_column,
+            outcome_columns=self._sf_with_outcomes.outcome_columns or None,
+            ignore_columns=self._sf_with_outcomes.ignore_columns or None,
             standardize_types=False,
         )
         target_sample = Sample.from_frame(
@@ -590,16 +877,21 @@ class BalanceFrame:
         )
         result = resp_sample.set_target(target_sample)
 
-        if self.is_adjusted and self._unadjusted is not None:
-            unadj_sample = Sample.from_frame(
-                self._unadjusted._df,
-                id_column=self._unadjusted.id_column_name,
-                weight_column=self._unadjusted.active_weight_column,
-                outcome_columns=self._unadjusted.outcome_columns or None,
-                ignore_columns=self._unadjusted.ignore_columns or None,
+        if self.is_adjusted and self._sf_with_outcomes_pre_adjust is not None:
+            unadj_sf = SampleFrame.from_frame(
+                self._sf_with_outcomes_pre_adjust._df,
+                id_column=self._sf_with_outcomes_pre_adjust.id_column_name,
+                weight_column=self._sf_with_outcomes_pre_adjust.active_weight_column,
+                outcome_columns=self._sf_with_outcomes_pre_adjust.outcome_columns
+                or None,
+                ignore_columns=self._sf_with_outcomes_pre_adjust.ignore_columns or None,
                 standardize_types=False,
             )
-            result._links["unadjusted"] = unadj_sample
+            # pyre-ignore[16]: Sample gains this attr via BalanceFrame inheritance (diff 14.3)
+            result._sf_with_outcomes_pre_adjust = unadj_sf
+            # pyre-ignore[16]: Sample gains _links via BalanceFrame inheritance (diff 14.3)
+            result._links["unadjusted"] = unadj_sf
+            # pyre-ignore[16]: Sample gains this attr via BalanceFrame inheritance (diff 14.3)
             result._adjustment_model = self._adjustment_model
 
         return result
@@ -618,18 +910,22 @@ class BalanceFrame:
             dict: Mapping of link names to BalanceDFSource instances.
         """
         links: dict[str, BalanceDFSource] = {}
-        if self._target is not None:
-            links["target"] = self._target
-        if self._unadjusted is not None:
-            links["unadjusted"] = self._unadjusted
+        if self._sf_target is not None:
+            links["target"] = self._sf_target
+        if self.is_adjusted:
+            links["unadjusted"] = self._sf_with_outcomes_pre_adjust
         return links
 
-    def covars(self) -> Any:
+    def covars(self, formula: str | list[str] | None = None) -> Any:
         """Return a :class:`~balance.balancedf_class.BalanceDFCovars` for the responders.
 
         The returned object carries linked target (and unadjusted, if
         adjusted) views so that methods like ``.mean()`` and ``.asmd()``
         automatically include comparisons across sources.
+
+        Args:
+            formula: Optional formula string (or list) for model matrix
+                construction. Passed through to BalanceDFCovars.
 
         Returns:
             BalanceDFCovars: Covariate view with linked sources.
@@ -642,13 +938,17 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> bf.covars().df.columns.tolist()
             ['x']
         """
-        from balance.balancedf_class import BalanceDFCovars
+        from balance.balancedf_class import BalanceDFCovars, BalanceDFSource
 
-        return BalanceDFCovars(self._responders, links=self._build_links_dict())
+        return BalanceDFCovars(
+            cast(BalanceDFSource, self),
+            links=self._build_links_dict(),
+            formula=formula,
+        )
 
     def weights(self) -> Any:
         """Return a :class:`~balance.balancedf_class.BalanceDFWeights` for the responders.
@@ -667,13 +967,17 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 2.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> bf.weights().df.columns.tolist()
             ['weight']
         """
-        from balance.balancedf_class import BalanceDFWeights
+        from balance.balancedf_class import BalanceDFSource, BalanceDFWeights
 
-        return BalanceDFWeights(self._responders, links=self._build_links_dict())
+        # Pass self (not _sf_with_outcomes) so that r_indicator and other methods
+        # that access self._sample._links find the BalanceFrame's _links.
+        return BalanceDFWeights(
+            cast(BalanceDFSource, self), links=self._build_links_dict()
+        )
 
     def outcomes(self) -> Any | None:
         """Return a :class:`~balance.balancedf_class.BalanceDFOutcomes`, or None.
@@ -694,22 +998,29 @@ class BalanceFrame:
             ...     outcome_columns=["y"])
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> bf.outcomes().df.columns.tolist()
             ['y']
         """
-        if not self._responders.outcome_columns:
+        if not self._sf_with_outcomes.outcome_columns:
             return None
-        from balance.balancedf_class import BalanceDFOutcomes
+        from balance.balancedf_class import BalanceDFOutcomes, BalanceDFSource
 
-        return BalanceDFOutcomes(self._responders, links=self._build_links_dict())
+        return BalanceDFOutcomes(
+            cast(BalanceDFSource, self), links=self._build_links_dict()
+        )
 
     # --- Summary & diagnostics ---
 
     def _design_effect_diagnostics(
         self,
+        n_rows: int | None = None,
     ) -> tuple[float | None, float | None, float | None]:
         """Compute design effect, ESS, and ESSP from the responder weights.
+
+        Args:
+            n_rows: Optional row count to use for scaling. Defaults to the
+                sample size when not provided.
 
         Returns:
             tuple: ``(design_effect, effective_sample_size,
@@ -724,13 +1035,16 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [0, 1], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [0, 1], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> bf._design_effect_diagnostics()
             (1.0, 2.0, 1.0)
         """
-        n_rows = len(self._responders)
+        if n_rows is None:
+            n_rows = len(self._sf_with_outcomes)
         try:
-            de = weights_stats.design_effect(self._responders.df_weights.iloc[:, 0])
+            de = weights_stats.design_effect(
+                self._sf_with_outcomes.df_weights.iloc[:, 0]
+            )
         except (TypeError, ValueError, ZeroDivisionError) as exc:
             logger.debug("Unable to compute design effect: %s", exc)
             return None, None, None
@@ -748,6 +1062,7 @@ class BalanceFrame:
 
     def _quick_adjustment_details(
         self,
+        n_rows: int | None = None,
         de: float | None = None,
         ess: float | None = None,
         essp: float | None = None,
@@ -773,7 +1088,7 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [0, 1], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [0, 1], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> adjusted = bf.adjust(method="null")
             >>> "method: null" in adjusted._quick_adjustment_details()
             True
@@ -792,7 +1107,7 @@ class BalanceFrame:
                 details.append(f"weight trimming percentile: {trimming_percentile}")
 
         if de is None:
-            de, ess, essp = self._design_effect_diagnostics()
+            de, ess, essp = self._design_effect_diagnostics(n_rows)
         if de is not None:
             details.append(f"design effect (Deff): {de:.3f}")
             if essp is not None:
@@ -810,6 +1125,9 @@ class BalanceFrame:
         :func:`~balance.summary_utils._build_summary` after computing the
         necessary intermediate values.
 
+        When no target is set, returns a minimal summary with weight
+        diagnostics and outcome means only.
+
         Returns:
             str: A human-readable multi-line summary string.
 
@@ -823,11 +1141,31 @@ class BalanceFrame:
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [5, 6, 7, 8], "x": [0, 0, 1, 1],
             ...                   "weight": [1.0, 1.0, 1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> adjusted = bf.adjust(method="null")
             >>> "Covariate diagnostics:" in adjusted.summary()
             True
         """
+        if not self.has_target() and not self.is_adjusted:
+            # No target: minimal summary (weight diagnostics + outcomes only)
+            de, ess, essp = self._design_effect_diagnostics(self._df.shape[0])
+            outcome_means = None
+            if self._outcome_columns is not None:
+                outcome_means = self.outcomes().mean()
+            return _build_summary(
+                is_adjusted=False,
+                has_target=False,
+                covars_asmd=None,
+                covars_kld=None,
+                asmd_improvement_pct=None,
+                quick_adjustment_details=[],
+                design_effect=de,
+                effective_sample_size=ess,
+                effective_sample_proportion=essp,
+                model_dict=self.model(),
+                outcome_means=outcome_means,
+            )
+
         covars_asmd = self.covars().asmd()
         covars_kld = self.covars().kld(aggregate_by_main_covar=True)
 
@@ -849,7 +1187,7 @@ class BalanceFrame:
             outcome_means = outcomes.mean()
 
         return _build_summary(
-            is_adjusted=self.is_adjusted,
+            is_adjusted=bool(self.is_adjusted),
             has_target=True,
             covars_asmd=covars_asmd,
             covars_kld=covars_kld,
@@ -898,18 +1236,15 @@ class BalanceFrame:
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": ["3", "4"], "x": [0, 1],
             ...                   "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> adjusted = bf.adjust(method="null")
             >>> adjusted.diagnostics().columns.tolist()
             ['metric', 'val', 'var']
         """
-        if not self.is_adjusted:
-            raise ValueError(
-                "diagnostics() requires an adjusted BalanceFrame. "
-                "Call bf.adjust() first."
-            )
+        logger.info("Starting computation of diagnostics of the fitting")
+        self._check_if_adjusted()
 
-        outcome_columns = self._responders.df_outcomes
+        outcome_columns = self._sf_with_outcomes.df_outcomes
         outcome_impact = None
         if weights_impact_on_outcome_method is not None and outcome_columns is not None:
             outcome_impact = self.outcomes().weights_impact_on_outcome_ss(
@@ -918,9 +1253,9 @@ class BalanceFrame:
                 round_ndigits=None,
             )
 
-        target = self._target
+        target = self._sf_target
         assert target is not None, "diagnostics() requires a target"
-        return _build_diagnostics(
+        result = _build_diagnostics(
             covars_df=self.covars().df,
             target_covars_df=target.df_covars,
             weights_summary=self.weights().summary(),
@@ -932,6 +1267,8 @@ class BalanceFrame:
             weights_impact_on_outcome_conf_level=weights_impact_on_outcome_conf_level,
             outcome_impact=outcome_impact,
         )
+        logger.info("Done computing diagnostics")
+        return result
 
     # --- Parity helpers ---
 
@@ -955,48 +1292,23 @@ class BalanceFrame:
             ...     ignore_columns=["region"])
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> bf.ignored_columns()
                region
             0     US
             1     UK
         """
-        return self._responders.ignored_columns()
-
-    @property
-    def id_column(self) -> pd.Series:
-        """The ID column of the responder SampleFrame as a Series.
-
-        Delegates to :attr:`SampleFrame.id_column` on the responders.
-        Provided for API parity with :class:`~balance.sample_class.Sample`.
-
-        Returns:
-            pd.Series: A copy of the responder's ID column.
-
-        Examples:
-            >>> import pandas as pd
-            >>> from balance.sample_frame import SampleFrame
-            >>> from balance.balance_frame import BalanceFrame
-            >>> resp = SampleFrame.from_frame(
-            ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
-            >>> tgt = SampleFrame.from_frame(
-            ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
-            >>> bf.id_column.tolist()
-            ['1', '2']
-        """
-        return self._responders.id_column
+        return self._sf_with_outcomes.ignored_columns()
 
     # --- DataFrame / export ---
 
     @property
-    def df(self) -> pd.DataFrame:
+    def df_all(self) -> pd.DataFrame:
         """Combined DataFrame with all samples, distinguished by a ``"source"`` column.
 
         Concatenates the responder, target, and (if adjusted) unadjusted
         DataFrames vertically, adding a ``"source"`` column with values
         ``"self"``, ``"target"``, and ``"unadjusted"`` respectively.
-        Mirrors the ``Sample.df`` property behaviour.
 
         Returns:
             pd.DataFrame: A DataFrame with all rows from responder, target,
@@ -1011,27 +1323,55 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
-            >>> bf.df["source"].unique().tolist()
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf.df_all["source"].unique().tolist()
             ['self', 'target']
         """
         parts: list[pd.DataFrame] = []
 
-        resp_df = self._responders._df.copy()
+        resp_df = self._sf_with_outcomes._df.copy()
         resp_df["source"] = "self"
         parts.append(resp_df)
 
-        if self._target is not None:
-            tgt_df = self._target._df.copy()
+        if self._sf_target is not None:
+            tgt_df = self._sf_target._df.copy()
             tgt_df["source"] = "target"
             parts.append(tgt_df)
 
-        if self._unadjusted is not None:
-            unadj_df = self._unadjusted._df.copy()
+        if self.is_adjusted:
+            unadj_df = self._sf_with_outcomes_pre_adjust._df.copy()
             unadj_df["source"] = "unadjusted"
             parts.append(unadj_df)
 
         return pd.concat(parts, ignore_index=True)
+
+    @property
+    def df(self) -> pd.DataFrame:
+        """Flat user-facing DataFrame from the responders.
+
+        Returns the responder data with columns ordered as:
+        id → covariates → outcomes → weight → ignored.
+
+        Returns:
+            pd.DataFrame: Ordered copy of the responder's data.
+        """
+        covars = self.covars()
+        outcomes = self.outcomes()
+        ignored = self.ignored_columns()
+        return pd.concat(
+            (
+                self.id_column,
+                covars.df if covars is not None else None,
+                outcomes.df if outcomes is not None else None,
+                (
+                    pd.DataFrame(self.weight_column)
+                    if self.weight_column is not None
+                    else None
+                ),
+                ignored if ignored is not None else None,
+            ),
+            axis=1,
+        )
 
     def keep_only_some_rows_columns(
         self,
@@ -1067,9 +1407,9 @@ class BalanceFrame:
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [4, 5, 6], "x": [15.0, 25.0, 35.0],
             ...                   "weight": [1.0, 1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> filtered = bf.keep_only_some_rows_columns(rows_to_keep="x > 15")
-            >>> len(filtered.responders._df)
+            >>> len(filtered._sf_with_outcomes._df)
             2
         """
         if rows_to_keep is None and columns_to_keep is None:
@@ -1077,17 +1417,61 @@ class BalanceFrame:
 
         new_bf = copy.deepcopy(self)
 
-        new_bf._responders = BalanceFrame._filter_sf(
-            new_bf._responders, rows_to_keep, columns_to_keep
-        )
-        if new_bf._target is not None:
-            new_bf._target = BalanceFrame._filter_sf(
-                new_bf._target, rows_to_keep, columns_to_keep
+        if new_bf.has_target():
+            # With target: filter all SampleFrames
+            new_bf._sf_with_outcomes = BalanceFrame._filter_sf(
+                new_bf._sf_with_outcomes, rows_to_keep, columns_to_keep
             )
-        if new_bf._unadjusted is not None:
-            new_bf._unadjusted = BalanceFrame._filter_sf(
-                new_bf._unadjusted, rows_to_keep, columns_to_keep
+            if new_bf._sf_target is not None:
+                new_bf._sf_target = BalanceFrame._filter_sf(
+                    new_bf._sf_target, rows_to_keep, columns_to_keep
+                )
+            if new_bf._sf_with_outcomes_pre_adjust is not None:
+                new_bf._sf_with_outcomes_pre_adjust = BalanceFrame._filter_sf(
+                    new_bf._sf_with_outcomes_pre_adjust, rows_to_keep, columns_to_keep
+                )
+        else:
+            # No target: filter the responder SampleFrame
+            if columns_to_keep is not None:
+                if not (set(columns_to_keep) <= set(new_bf.df.columns)):
+                    logger.warning(
+                        "Note that not all columns_to_keep are in Sample. "
+                        "Only those that exist are removed"
+                    )
+            new_bf._sf_with_outcomes = BalanceFrame._filter_sf(
+                new_bf._sf_with_outcomes, rows_to_keep, columns_to_keep
             )
+            if (
+                new_bf._sf_with_outcomes_pre_adjust is not None
+                and new_bf._sf_with_outcomes_pre_adjust is not new_bf._sf_with_outcomes
+            ):
+                new_bf._sf_with_outcomes_pre_adjust = BalanceFrame._filter_sf(
+                    new_bf._sf_with_outcomes_pre_adjust, rows_to_keep, columns_to_keep
+                )
+
+        # Sync id_column / weight_column from filtered responders
+        new_bf.id_column = new_bf._sf_with_outcomes.id_column
+        try:
+            new_bf.weight_column = new_bf._sf_with_outcomes.weight_column
+        except ValueError:
+            # Weight column was filtered out — leave it unchanged
+            pass
+
+        # Also filter linked BF/Sample objects in _links
+        if new_bf._links:
+            for k, v in list(new_bf._links.items()):
+                if isinstance(v, BalanceFrame):
+                    try:
+                        new_bf._links[k] = v.keep_only_some_rows_columns(
+                            rows_to_keep=rows_to_keep,
+                            columns_to_keep=columns_to_keep,
+                        )
+                    except (TypeError, ValueError, AttributeError, KeyError) as exc:
+                        logger.warning(
+                            "couldn't filter _links['%s'] using provided filters: %s",
+                            k,
+                            exc,
+                        )
 
         return new_bf
 
@@ -1138,6 +1522,9 @@ class BalanceFrame:
                 keep_set.add(sf._active_weight_column)
             for wc in sf.weight_columns:
                 keep_set.add(wc)
+            # Always preserve outcome columns (matching Sample behavior)
+            for oc in sf._column_roles.get("outcomes", []):
+                keep_set.add(oc)
             df = df.loc[:, df.columns.isin(keep_set)]
 
             new_covars = [c for c in sf._column_roles["covars"] if c in keep_set]
@@ -1184,8 +1571,8 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
-            >>> "source" in bf.to_csv()
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> "id" in bf.to_csv()
             True
         """
         return to_csv_with_defaults(self.df, path_or_buf, **kwargs)
@@ -1212,24 +1599,206 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(responders=resp, target=tgt)
+            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
             >>> link = bf.to_download(tempdir=tempfile.gettempdir())
         """
         return _to_download(self.df, tempdir)
 
-    def __repr__(self) -> str:
-        status = "adjusted" if self.is_adjusted else "unadjusted"
-        n_resp = len(self._responders)
-        n_tgt = len(self._target) if self._target is not None else 0
-        tgt_info = (
-            f"{n_tgt} target observations" if self._target is not None else "no target"
+    # --- Methods moved from Sample ---
+
+    def model_matrix(self) -> pd.DataFrame:
+        """Return the model matrix of the responder covariates.
+
+        Constructs a model matrix using :func:`balance.util.model_matrix`,
+        adding NA indicators for null values.
+
+        Returns:
+            pd.DataFrame: The model matrix.
+        """
+        res = _assert_type(
+            balance_util.model_matrix(self, add_na=True)["sample"], pd.DataFrame
         )
-        resp_covars = self._responders.covars_columns
+        return res
+
+    def set_weights(self, weights: pd.Series | float | None) -> None:
+        """Set or replace the responder weights.
+
+        Overwrites the weight column on the underlying DataFrame.
+        When *weights* is a ``pd.Series``, values are aligned by index.
+
+        Args:
+            weights: New weights. A Series (aligned by index), a scalar
+                (broadcast to all rows), or ``None`` (sets all to NaN).
+        """
+        # Break the shared reference so we don't corrupt the pre-adjustment
+        # baseline (both point to the same SampleFrame initially).
+        if self._sf_with_outcomes is self._sf_with_outcomes_pre_adjust:
+            self._sf_with_outcomes_pre_adjust = copy.deepcopy(self._sf_with_outcomes)
+
+        if isinstance(weights, pd.Series):
+            if not all(idx in weights.index for idx in self.df.index):
+                logger.warning(
+                    "Note that not all Sample units will be assigned weights, "
+                    "since weights are missing some of the indices in Sample.df"
+                )
+
+        wc_name = _assert_type(self.weight_column).name
+        if isinstance(weights, pd.Series):
+            if not pd.api.types.is_float_dtype(self._df[wc_name]):
+                self._df[wc_name] = self._df[wc_name].astype("float64")
+            if not pd.api.types.is_float_dtype(weights):
+                weights = weights.astype("float64")
+            self._df.loc[:, wc_name] = weights
+        else:
+            if not pd.api.types.is_float_dtype(self._df[wc_name]):
+                self._df[wc_name] = self._df[wc_name].astype("float64")
+            weights_value = np.nan if weights is None else weights
+            self._df.loc[:, wc_name] = weights_value
+
+        self.weight_column = self._df[wc_name]
+
+    def set_unadjusted(self, second: BalanceFrame) -> Self:
+        """Set the unadjusted link for comparative analysis.
+
+        Returns a deep copy with ``_sf_with_outcomes_pre_adjust`` pointing at
+        *second*'s responder SampleFrame, and ``_links["unadjusted"]``
+        pointing at *second*.
+
+        Args:
+            second: A BalanceFrame (or subclass) whose responder data
+                becomes the unadjusted baseline.
+
+        Returns:
+            A new BalanceFrame with the unadjusted link set.
+
+        Raises:
+            TypeError: If *second* is not a BalanceFrame.
+        """
+        if not isinstance(second, BalanceFrame):
+            raise TypeError(
+                f"set_unadjusted must be called with a BalanceFrame argument, got {type(second).__name__}"
+            )
+        new_bf = deepcopy(self)
+        new_bf._links["unadjusted"] = second
+        new_bf._sf_with_outcomes_pre_adjust = second._sf_with_outcomes
+        return new_bf
+
+    # --- Column accessors (moved from Sample) ---
+
+    def _special_columns_names(self) -> list[str]:
+        """Return names of all special columns (id, weight, outcome, ignored)."""
         return (
-            f"BalanceFrame ({status}): "
-            f"{n_resp} responders, {tgt_info}, "
-            f"{len(resp_covars)} covariates: {','.join(resp_covars)}"
+            [str(i.name) for i in [self.id_column, self.weight_column] if i is not None]
+            + (
+                self._outcome_columns.columns.tolist()
+                if self._outcome_columns is not None
+                else []
+            )
+            + getattr(self, "_ignored_column_names", [])
         )
 
-    def __str__(self) -> str:
-        return self.__repr__()
+    def _special_columns(self) -> pd.DataFrame:
+        """Return a DataFrame of all special columns."""
+        return self._df[self._special_columns_names()]
+
+    def _covar_columns_names(self) -> list[str]:
+        """Return names of all covariate columns."""
+        return [
+            c for c in self._df.columns.values if c not in self._special_columns_names()
+        ]
+
+    def _covar_columns(self) -> pd.DataFrame:
+        """Return a DataFrame of all covariate columns."""
+        return self._sf_with_outcomes._covar_columns()
+
+    # --- Error checks (moved from Sample) ---
+
+    def _check_if_adjusted(self) -> None:
+        """Raise ValueError if not adjusted."""
+        if not self.is_adjusted:
+            raise ValueError(
+                "This is not an adjusted Sample. Use sample.adjust to adjust the sample to target"
+            )
+
+    def _no_target_error(self) -> None:
+        """Raise ValueError if no target is set."""
+        if not self.has_target():
+            raise ValueError(
+                "This Sample does not have a target set. Use sample.set_target to add target"
+            )
+
+    def _check_outcomes_exists(self) -> None:
+        """Raise ValueError if no outcome columns are specified."""
+        if self.outcomes() is None:
+            raise ValueError("This Sample does not have outcome columns specified")
+
+    def __repr__(self) -> str:
+        return (
+            f"({self.__class__.__module__}.{self.__class__.__qualname__})\n"
+            f"{self.__str__()}"
+        )
+
+    def __str__(self, pkg_source: str | None = None) -> str:
+        """Return a readable summary of the sample and any applied adjustment.
+
+        Args:
+            pkg_source: Package namespace used in the header. Defaults to
+                the module's ``__package__``.
+
+        Returns:
+            str: Multi-line description highlighting key structure and
+                adjustment details.
+        """
+        if pkg_source is None:
+            pkg_source = __package__
+
+        is_adjusted = self.is_adjusted() * "Adjusted "
+        n_rows = self._df.shape[0]
+        n_variables = self._covar_columns().shape[1]
+        has_target = self.has_target() * " with target set"
+        adjustment_method = (
+            " using " + _assert_type(self.model())["method"]
+            if self.model() is not None
+            else ""
+        )
+        variables = ",".join(self._covar_columns_names())
+        id_column_name = self.id_column.name if self.id_column is not None else "None"
+        weight_column_name = (
+            self.weight_column.name if self.weight_column is not None else "None"
+        )
+        outcome_column_names = (
+            ",".join(self._outcome_columns.columns.tolist())
+            if self._outcome_columns is not None
+            else "None"
+        )
+
+        desc = f"""
+        {is_adjusted}{pkg_source} Sample object{has_target}{adjustment_method}
+        {n_rows} observations x {n_variables} variables: {variables}
+        id_column: {id_column_name}, weight_column: {weight_column_name},
+        outcome_columns: {outcome_column_names}
+        """
+
+        if self.is_adjusted():
+            adjustment_details = self._quick_adjustment_details(n_rows)
+            if len(adjustment_details) > 0:
+                desc += """
+        adjustment details:
+            {details}
+                """.format(
+                    details="\n            ".join(adjustment_details)
+                )
+
+        if self.has_target():
+            common_variables = balance_util.choose_variables(
+                self, self._links["target"], variables=None
+            )
+            target_str = self._links["target"].__str__().replace("\n", "\n\t")
+            n_common = len(common_variables)
+            common_variables = ",".join(common_variables)
+            desc += f"""
+            target:
+                 {target_str}
+            {n_common} common variables: {common_variables}
+            """
+        return desc

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -391,11 +391,12 @@ class BalanceFrame:
             return self._sf_sample_pre_adjust
         return None
 
-    def has_target(self) -> bool:
-        """Check if this BalanceFrame has a target population set.
+    @property
+    def has_target(self) -> _CallableBool:
+        """Whether this BalanceFrame has a target population set.
 
-        Returns:
-            bool: True if a target population has been set, False otherwise.
+        Returns a dual-use ``_CallableBool``: both ``bf.has_target`` and
+        ``bf.has_target()`` work (the latter for backward compatibility).
 
         Examples:
             >>> import pandas as pd
@@ -404,16 +405,17 @@ class BalanceFrame:
             >>> resp = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> bf = BalanceFrame(sample=resp)
-            >>> bf.has_target()
+            >>> bf.has_target
             False
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
             >>> bf.set_target(tgt)
-            >>> bf.has_target()
+            >>> bf.has_target
             True
         """
-        return self._sf_target is not None or (
-            self._links is not None and "target" in self._links
+        return _CallableBool(
+            self._sf_target is not None
+            or (self._links is not None and "target" in self._links)
         )
 
     def set_target(
@@ -741,11 +743,9 @@ class BalanceFrame:
 
         return self._build_adjusted_frame(result, method)
 
+    @property
     def model(self) -> dict[str, Any] | None:
-        """Return the adjustment model dictionary, or None if not adjusted.
-
-        Returns:
-            The model dict from the weighting method, or None.
+        """The adjustment model dictionary, or None if not adjusted.
 
         Examples:
             >>> import pandas as pd
@@ -756,7 +756,7 @@ class BalanceFrame:
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
             >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
-            >>> bf.model() is None
+            >>> bf.model is None
             True
         """
         return self._adjustment_model
@@ -818,7 +818,7 @@ class BalanceFrame:
             bf._sf_sample_pre_adjust = SampleFrame.from_sample(
                 sample._links["unadjusted"]
             )
-            bf._adjustment_model = sample.model()
+            bf._adjustment_model = sample.model
 
         return bf
 
@@ -1091,7 +1091,7 @@ class BalanceFrame:
             True
         """
         details: list[str] = []
-        model = self.model()
+        model = self.model
         if isinstance(model, dict):
             method = model.get("method")
             if isinstance(method, str):
@@ -1159,7 +1159,7 @@ class BalanceFrame:
                 design_effect=de,
                 effective_sample_size=ess,
                 effective_sample_proportion=essp,
-                model_dict=self.model(),
+                model_dict=self.model,
                 outcome_means=outcome_means,
             )
 
@@ -1193,7 +1193,7 @@ class BalanceFrame:
             design_effect=de,
             effective_sample_size=ess,
             effective_sample_proportion=essp,
-            model_dict=self.model(),
+            model_dict=self.model,
             outcome_means=outcome_means,
         )
 
@@ -1256,7 +1256,7 @@ class BalanceFrame:
             covars_df=self.covars().df,
             target_covars_df=target.df_covars,
             weights_summary=self.weights().summary(),
-            model_dict=self.model(),
+            model_dict=self.model,
             covars_asmd=self.covars().asmd(),
             covars_asmd_main=self.covars().asmd(aggregate_by_main_covar=True),
             outcome_columns=outcome_columns,
@@ -1716,8 +1716,8 @@ class BalanceFrame:
         n_variables = self._covar_columns().shape[1]
         has_target = self.has_target() * " with target set"
         adjustment_method = (
-            " using " + _assert_type(self.model())["method"]
-            if self.model() is not None
+            " using " + _assert_type(self.model)["method"]
+            if self.model is not None
             else ""
         )
         variables = ",".join(self._covar_columns_names())

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -577,7 +577,7 @@ class BalanceFrame:
             id_column=self._responders.id_column_name,
             weight_column=self._responders.active_weight_column,
             outcome_columns=self._responders.outcome_columns or None,
-            ignore_columns=self._responders.misc_columns or None,
+            ignore_columns=self._responders.ignore_columns or None,
             standardize_types=False,
         )
         target_sample = Sample.from_frame(
@@ -585,7 +585,7 @@ class BalanceFrame:
             id_column=target.id_column_name,
             weight_column=target.active_weight_column,
             outcome_columns=target.outcome_columns or None,
-            ignore_columns=target.misc_columns or None,
+            ignore_columns=target.ignore_columns or None,
             standardize_types=False,
         )
         result = resp_sample.set_target(target_sample)
@@ -596,7 +596,7 @@ class BalanceFrame:
                 id_column=self._unadjusted.id_column_name,
                 weight_column=self._unadjusted.active_weight_column,
                 outcome_columns=self._unadjusted.outcome_columns or None,
-                ignore_columns=self._unadjusted.misc_columns or None,
+                ignore_columns=self._unadjusted.ignore_columns or None,
                 standardize_types=False,
             )
             result._links["unadjusted"] = unadj_sample
@@ -952,7 +952,7 @@ class BalanceFrame:
             >>> resp = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0],
             ...                   "weight": [1.0, 1.0], "region": ["US", "UK"]}),
-            ...     misc_columns=["region"])
+            ...     ignore_columns=["region"])
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
             >>> bf = BalanceFrame(responders=resp, target=tgt)
@@ -1151,9 +1151,9 @@ class BalanceFrame:
                 sf._column_roles["predicted"] = [
                     c for c in sf._column_roles["predicted"] if c in keep_set
                 ]
-            if sf._column_roles["misc"]:
-                sf._column_roles["misc"] = [
-                    c for c in sf._column_roles["misc"] if c in keep_set
+            if sf._column_roles["ignored"]:
+                sf._column_roles["ignored"] = [
+                    c for c in sf._column_roles["ignored"] if c in keep_set
                 ]
 
         sf._df = df

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -165,12 +165,12 @@ class BalanceFrame:
         self._id_column = value
 
     @property
-    def weight_column(self) -> pd.Series | None:  # pyre-ignore[3]
+    def weight_series(self) -> pd.Series | None:  # pyre-ignore[3]
         """The weight column Series."""
         return self._weight_column
 
-    @weight_column.setter
-    def weight_column(self, value: pd.Series | None) -> None:  # pyre-ignore[2,3]
+    @weight_series.setter
+    def weight_series(self, value: pd.Series | None) -> None:  # pyre-ignore[2,3]
         self._weight_column = value
 
     # --- Property descriptors backed by _sf_with_outcomes ---
@@ -315,9 +315,9 @@ class BalanceFrame:
         instance._adjustment_model = None
         instance.id_column = sf_with_outcomes.id_column
         try:
-            instance.weight_column = sf_with_outcomes.weight_column
+            instance.weight_series = sf_with_outcomes.weight_series
         except ValueError:
-            instance.weight_column = None
+            instance.weight_series = None
         instance._links = collections.defaultdict(list)
         if sf_target is not None:
             instance._links["target"] = sf_target
@@ -578,7 +578,7 @@ class BalanceFrame:
         # For Sample subclasses: rename "weight_adjusted" → original weight
         # column name so the public API always sees the original name.
         # For direct BalanceFrame: keep both columns (weight + weight_adjusted).
-        original_weight_name = _assert_type(self.weight_column).name
+        original_weight_name = _assert_type(self.weight_series).name
         if type(self) is not BalanceFrame:
             # Sample (or other subclass) path: rename weight_adjusted → original
             if (
@@ -600,7 +600,7 @@ class BalanceFrame:
         # Point _sf_with_outcomes_pre_adjust to the original (pre-adjustment) data
         new_bf._sf_with_outcomes_pre_adjust = self._sf_with_outcomes_pre_adjust
         new_bf.id_column = new_responders.id_column
-        new_bf.weight_column = new_responders.weight_column
+        new_bf.weight_series = new_responders.weight_series
         # Set _links for __str__() and BalanceDF integration
         new_bf._links["unadjusted"] = self
         if "target" in self._links:
@@ -867,7 +867,7 @@ class BalanceFrame:
         resp_sample = Sample.from_frame(
             self._sf_with_outcomes._df,
             id_column=self._sf_with_outcomes.id_column_name,
-            weight_column=self._sf_with_outcomes.active_weight_column,
+            weight_column=self._sf_with_outcomes.weight_column,
             outcome_columns=self._sf_with_outcomes.outcome_columns or None,
             ignored_columns=self._sf_with_outcomes.ignored_columns or None,
             standardize_types=False,
@@ -875,7 +875,7 @@ class BalanceFrame:
         target_sample = Sample.from_frame(
             target._df,
             id_column=target.id_column_name,
-            weight_column=target.active_weight_column,
+            weight_column=target.weight_column,
             outcome_columns=target.outcome_columns or None,
             ignored_columns=target.ignored_columns or None,
             standardize_types=False,
@@ -886,7 +886,7 @@ class BalanceFrame:
             unadj_sf = SampleFrame.from_frame(
                 self._sf_with_outcomes_pre_adjust._df,
                 id_column=self._sf_with_outcomes_pre_adjust.id_column_name,
-                weight_column=self._sf_with_outcomes_pre_adjust.active_weight_column,
+                weight_column=self._sf_with_outcomes_pre_adjust.weight_column,
                 outcome_columns=self._sf_with_outcomes_pre_adjust.outcome_columns
                 or None,
                 ignored_columns=self._sf_with_outcomes_pre_adjust.ignored_columns
@@ -1342,8 +1342,8 @@ class BalanceFrame:
                 covars.df if covars is not None else None,
                 outcomes.df if outcomes is not None else None,
                 (
-                    pd.DataFrame(self.weight_column)
-                    if self.weight_column is not None
+                    pd.DataFrame(self.weight_series)
+                    if self.weight_series is not None
                     else None
                 ),
                 ignored if ignored is not None else None,
@@ -1427,10 +1427,10 @@ class BalanceFrame:
                     new_bf._sf_with_outcomes_pre_adjust, rows_to_keep, columns_to_keep
                 )
 
-        # Sync id_column / weight_column from filtered responders
+        # Sync id_column / weight_series from filtered responders
         new_bf.id_column = new_bf._sf_with_outcomes.id_column
         try:
-            new_bf.weight_column = new_bf._sf_with_outcomes.weight_column
+            new_bf.weight_series = new_bf._sf_with_outcomes.weight_series
         except ValueError:
             # Weight column was filtered out — leave it unchanged
             pass
@@ -1496,9 +1496,9 @@ class BalanceFrame:
         if columns_to_keep is not None:
             keep_set = set(columns_to_keep)
             keep_set.add(sf._id_column_name)
-            if sf._active_weight_column is not None:
-                keep_set.add(sf._active_weight_column)
-            for wc in sf.weight_columns:
+            if sf._weight_column_name is not None:
+                keep_set.add(sf._weight_column_name)
+            for wc in sf.weight_columns_all:
                 keep_set.add(wc)
             # Always preserve outcome columns (matching Sample behavior)
             for oc in sf._column_roles.get("outcomes", []):
@@ -1620,7 +1620,7 @@ class BalanceFrame:
                     "since weights are missing some of the indices in Sample.df"
                 )
 
-        wc_name = _assert_type(self.weight_column).name
+        wc_name = _assert_type(self.weight_series).name
         if isinstance(weights, pd.Series):
             if not pd.api.types.is_float_dtype(self._df[wc_name]):
                 self._df[wc_name] = self._df[wc_name].astype("float64")
@@ -1633,7 +1633,7 @@ class BalanceFrame:
             weights_value = np.nan if weights is None else weights
             self._df.loc[:, wc_name] = weights_value
 
-        self.weight_column = self._df[wc_name]
+        self.weight_series = self._df[wc_name]
 
     def set_unadjusted(self, second: BalanceFrame) -> Self:
         """Set the unadjusted link for comparative analysis.
@@ -1666,7 +1666,7 @@ class BalanceFrame:
     def _special_columns_names(self) -> list[str]:
         """Return names of all special columns (id, weight, outcome, ignored)."""
         return (
-            [str(i.name) for i in [self.id_column, self.weight_column] if i is not None]
+            [str(i.name) for i in [self.id_column, self.weight_series] if i is not None]
             + (
                 self._outcome_columns.columns.tolist()
                 if self._outcome_columns is not None
@@ -1742,7 +1742,7 @@ class BalanceFrame:
         variables = ",".join(self._covar_columns_names())
         id_column_name = self.id_column.name if self.id_column is not None else "None"
         weight_column_name = (
-            self.weight_column.name if self.weight_column is not None else "None"
+            self.weight_series.name if self.weight_series is not None else "None"
         )
         outcome_column_names = (
             ",".join(self._outcome_columns.columns.tolist())

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -202,7 +202,7 @@ class BalanceFrame:
 
     @property
     def _ignored_column_names(self) -> list[str]:  # pyre-ignore[3]
-        """Ignored column names, delegated to ``_sf_with_outcomes.ignore_columns``."""
+        """Ignored column names, delegated to ``_sf_with_outcomes.ignored_columns``."""
         return self._sf_with_outcomes._column_roles.get("ignored", [])
 
     @_ignored_column_names.setter
@@ -210,6 +210,11 @@ class BalanceFrame:
         self, value: list[str] | None
     ) -> None:  # pyre-ignore[2,3]
         self._sf_with_outcomes._column_roles["ignored"] = list(value) if value else []
+
+    @property
+    def df_ignored(self) -> pd.DataFrame | None:
+        """Ignored columns from the responder SampleFrame, or None."""
+        return self._sf_with_outcomes.df_ignored
 
     # -----------------------------------------------------------------------
     # Design note: Why __new__ + no-op __init__?
@@ -864,7 +869,7 @@ class BalanceFrame:
             id_column=self._sf_with_outcomes.id_column_name,
             weight_column=self._sf_with_outcomes.active_weight_column,
             outcome_columns=self._sf_with_outcomes.outcome_columns or None,
-            ignore_columns=self._sf_with_outcomes.ignore_columns or None,
+            ignored_columns=self._sf_with_outcomes.ignored_columns or None,
             standardize_types=False,
         )
         target_sample = Sample.from_frame(
@@ -872,7 +877,7 @@ class BalanceFrame:
             id_column=target.id_column_name,
             weight_column=target.active_weight_column,
             outcome_columns=target.outcome_columns or None,
-            ignore_columns=target.ignore_columns or None,
+            ignored_columns=target.ignored_columns or None,
             standardize_types=False,
         )
         result = resp_sample.set_target(target_sample)
@@ -884,7 +889,8 @@ class BalanceFrame:
                 weight_column=self._sf_with_outcomes_pre_adjust.active_weight_column,
                 outcome_columns=self._sf_with_outcomes_pre_adjust.outcome_columns
                 or None,
-                ignore_columns=self._sf_with_outcomes_pre_adjust.ignore_columns or None,
+                ignored_columns=self._sf_with_outcomes_pre_adjust.ignored_columns
+                or None,
                 standardize_types=False,
             )
             # pyre-ignore[16]: Sample gains this attr via BalanceFrame inheritance (diff 14.3)
@@ -1272,34 +1278,6 @@ class BalanceFrame:
 
     # --- Parity helpers ---
 
-    def ignored_columns(self) -> pd.DataFrame | None:
-        """Return ignored (misc) columns from the responder SampleFrame, or None.
-
-        Delegates to :meth:`SampleFrame.ignored_columns` on the responders.
-        Provided for API parity with :class:`~balance.sample_class.Sample`.
-
-        Returns:
-            pd.DataFrame | None: A copy of the responder's miscellaneous
-                columns, or None if no misc columns are registered.
-
-        Examples:
-            >>> import pandas as pd
-            >>> from balance.sample_frame import SampleFrame
-            >>> from balance.balance_frame import BalanceFrame
-            >>> resp = SampleFrame.from_frame(
-            ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0],
-            ...                   "weight": [1.0, 1.0], "region": ["US", "UK"]}),
-            ...     ignore_columns=["region"])
-            >>> tgt = SampleFrame.from_frame(
-            ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
-            >>> bf.ignored_columns()
-               region
-            0     US
-            1     UK
-        """
-        return self._sf_with_outcomes.ignored_columns()
-
     # --- DataFrame / export ---
 
     @property
@@ -1357,7 +1335,7 @@ class BalanceFrame:
         """
         covars = self.covars()
         outcomes = self.outcomes()
-        ignored = self.ignored_columns()
+        ignored = self._sf_with_outcomes.df_ignored
         return pd.concat(
             (
                 self.id_column,

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -902,7 +902,7 @@ class BalanceFrame:
 
         Creates a dict mapping link names to SampleFrame instances for the
         target and (if adjusted) the unadjusted responders so that
-        ``BalanceDF._BalanceDF_child_from_linked_samples`` can walk the
+        ``BalanceDF._balancedf_child_from_linked_samples`` can walk the
         links just as it does for the old ``Sample`` class.
 
         Returns:

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -669,7 +669,7 @@ class BalanceFrame:
             self_with_target = self.set_target(target)
             return self_with_target.adjust(*args, method=method, **kwargs)
 
-        self._no_target_error()
+        self._require_target()
 
         if self.is_adjusted:
             raise ValueError(
@@ -678,7 +678,7 @@ class BalanceFrame:
             )
 
         sf_target = self._sf_target
-        assert sf_target is not None  # guaranteed by _no_target_error() above
+        assert sf_target is not None  # guaranteed by _require_target() above
 
         adjustment_function = self._resolve_adjustment_function(method)
         resp_covars, target_covars = self._get_covars()
@@ -1239,7 +1239,7 @@ class BalanceFrame:
             ['metric', 'val', 'var']
         """
         logger.info("Starting computation of diagnostics of the fitting")
-        self._check_if_adjusted()
+        self._require_adjusted()
 
         outcome_columns = self._sf_sample.df_outcomes
         outcome_impact = None
@@ -1672,24 +1672,28 @@ class BalanceFrame:
 
     # --- Error checks (moved from Sample) ---
 
-    def _check_if_adjusted(self) -> None:
+    def _require_adjusted(self) -> None:
         """Raise ValueError if not adjusted."""
         if not self.is_adjusted:
             raise ValueError(
-                "This is not an adjusted Sample. Use sample.adjust to adjust the sample to target"
+                f"This {type(self).__name__} is not adjusted. "
+                "Use .adjust() to adjust to target."
             )
 
-    def _no_target_error(self) -> None:
+    def _require_target(self) -> None:
         """Raise ValueError if no target is set."""
         if not self.has_target():
             raise ValueError(
-                "This Sample does not have a target set. Use sample.set_target to add target"
+                f"This {type(self).__name__} does not have a target set. "
+                "Use .set_target() to add a target."
             )
 
-    def _check_outcomes_exists(self) -> None:
+    def _require_outcomes(self) -> None:
         """Raise ValueError if no outcome columns are specified."""
         if self.outcomes() is None:
-            raise ValueError("This Sample does not have outcome columns specified")
+            raise ValueError(
+                f"This {type(self).__name__} does not have outcome columns specified."
+            )
 
     def __repr__(self) -> str:
         return (

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -332,8 +332,8 @@ class BalanceFrame:
         Raises:
             ValueError: If they share no covariate columns.
         """
-        resp_covars = set(responders.covars_columns)
-        target_covars = set(target.covars_columns)
+        resp_covars = set(responders.covar_columns)
+        target_covars = set(target.covar_columns)
         overlap = resp_covars & target_covars
         if len(overlap) == 0:
             raise ValueError(

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -107,7 +107,7 @@ class BalanceFrame:
     it safe to keep a reference to the pre-adjustment state.
 
     Must be constructed via the public constructor
-    ``BalanceFrame(sf_with_outcomes=..., sf_target=...)`` which delegates to the
+    ``BalanceFrame(sample=..., sf_target=...)`` which delegates to the
     internal :meth:`_create` factory.
 
     Attributes:
@@ -123,7 +123,7 @@ class BalanceFrame:
         ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
         >>> tgt = SampleFrame.from_frame(
         ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-        >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+        >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
         >>> bf.is_adjusted
         False
         >>> adjusted = bf.adjust(method="ipw")
@@ -134,87 +134,80 @@ class BalanceFrame:
     """
 
     # pyre-fixme[13]: Attributes are initialized in _create() / from_frame()
-    _sf_with_outcomes_pre_adjust: SampleFrame
+    _sf_sample_pre_adjust: SampleFrame
     # pyre-fixme[13]: Attributes are initialized in _create() / from_frame()
-    _sf_with_outcomes: SampleFrame
+    _sf_sample: SampleFrame
     # pyre-fixme[13]: Attributes are initialized in _create() / from_frame()
     _sf_target: SampleFrame | None
     # pyre-fixme[13]: Attributes are initialized in _create() / from_frame()
     _adjustment_model: dict[str, Any] | None
     # pyre-fixme[4]: Attributes are initialized in from_frame() / _create()
     _links = None
-    _id_column: pd.Series | None = None
-    _weight_column: pd.Series | None = None
 
     @property
     def _df_dtypes(self) -> pd.Series | None:
-        """Original dtypes, delegated to ``_sf_with_outcomes._df_dtypes``."""
-        return self._sf_with_outcomes._df_dtypes
+        """Original dtypes, delegated to ``_sf_sample._df_dtypes``."""
+        return self._sf_sample._df_dtypes
 
     @_df_dtypes.setter
     def _df_dtypes(self, value: pd.Series | None) -> None:
-        self._sf_with_outcomes._df_dtypes = value
+        self._sf_sample._df_dtypes = value
 
     @property
     def id_column(self) -> pd.Series | None:  # pyre-ignore[3]
-        """The id column Series."""
-        return self._id_column
-
-    @id_column.setter
-    def id_column(self, value: pd.Series | None) -> None:  # pyre-ignore[2,3]
-        self._id_column = value
+        """The id column as a Series, delegated to ``_sf_sample``."""
+        return self._sf_sample.id_column
 
     @property
     def weight_series(self) -> pd.Series | None:  # pyre-ignore[3]
-        """The weight column Series."""
-        return self._weight_column
+        """The active weight as a Series, delegated to ``_sf_sample``."""
+        try:
+            return self._sf_sample.weight_series
+        except ValueError:
+            return None
 
-    @weight_series.setter
-    def weight_series(self, value: pd.Series | None) -> None:  # pyre-ignore[2,3]
-        self._weight_column = value
-
-    # --- Property descriptors backed by _sf_with_outcomes ---
+    # --- Property descriptors backed by _sf_sample ---
 
     @property
     def _df(self) -> pd.DataFrame:  # pyre-ignore[3]
-        """The internal DataFrame, delegated to ``_sf_with_outcomes._df``."""
-        return self._sf_with_outcomes._df
+        """The internal DataFrame, delegated to ``_sf_sample._df``."""
+        return self._sf_sample._df
 
     @_df.setter
     def _df(self, value: pd.DataFrame | None) -> None:  # pyre-ignore[2,3]
         if value is not None:
-            self._sf_with_outcomes._df = value
+            self._sf_sample._df = value
 
     @property
     def _outcome_columns(self) -> pd.DataFrame | None:
-        """Outcome columns as a DataFrame, delegated to ``_sf_with_outcomes``."""
-        outcome_cols = self._sf_with_outcomes._column_roles.get("outcomes", [])
+        """Outcome columns as a DataFrame, delegated to ``_sf_sample``."""
+        outcome_cols = self._sf_sample._column_roles.get("outcomes", [])
         if not outcome_cols:
             return None
-        return self._sf_with_outcomes._df[outcome_cols]
+        return self._sf_sample._df[outcome_cols]
 
     @_outcome_columns.setter
     def _outcome_columns(self, value: pd.DataFrame | None) -> None:
         if value is None:
-            self._sf_with_outcomes._column_roles["outcomes"] = []
+            self._sf_sample._column_roles["outcomes"] = []
         else:
-            self._sf_with_outcomes._column_roles["outcomes"] = value.columns.tolist()
+            self._sf_sample._column_roles["outcomes"] = value.columns.tolist()
 
     @property
     def _ignored_column_names(self) -> list[str]:  # pyre-ignore[3]
-        """Ignored column names, delegated to ``_sf_with_outcomes.ignored_columns``."""
-        return self._sf_with_outcomes._column_roles.get("ignored", [])
+        """Ignored column names, delegated to ``_sf_sample.ignored_columns``."""
+        return self._sf_sample._column_roles.get("ignored", [])
 
     @_ignored_column_names.setter
     def _ignored_column_names(
         self, value: list[str] | None
     ) -> None:  # pyre-ignore[2,3]
-        self._sf_with_outcomes._column_roles["ignored"] = list(value) if value else []
+        self._sf_sample._column_roles["ignored"] = list(value) if value else []
 
     @property
     def df_ignored(self) -> pd.DataFrame | None:
         """Ignored columns from the responder SampleFrame, or None."""
-        return self._sf_with_outcomes.df_ignored
+        return self._sf_sample.df_ignored
 
     # -----------------------------------------------------------------------
     # Design note: Why __new__ + no-op __init__?
@@ -226,7 +219,7 @@ class BalanceFrame:
     #
     # The solution used here:
     #   - __new__ handles BOTH construction paths:
-    #       1. Public constructor: BalanceFrame(sf_with_outcomes=sf1, sf_target=sf2)
+    #       1. Public constructor: BalanceFrame(sample=sf1, sf_target=sf2)
     #          → validates args and delegates to _create().
     #       2. deepcopy path: BalanceFrame() (no args)
     #          → returns a bare object via object.__new__(cls); deepcopy
@@ -235,41 +228,41 @@ class BalanceFrame:
     # -----------------------------------------------------------------------
     def __new__(
         cls,
-        sf_with_outcomes: SampleFrame | None = None,
+        sample: SampleFrame | None = None,
         sf_target: SampleFrame | None = None,
     ) -> BalanceFrame:
         """Create a BalanceFrame from responder and target SampleFrames.
 
         This uses ``__new__`` so that the natural constructor syntax
-        ``BalanceFrame(sf_with_outcomes=..., sf_target=...)`` works while still
+        ``BalanceFrame(sample=..., sf_target=...)`` works while still
         routing through the validated :meth:`_create` factory.
 
         Args:
-            sf_with_outcomes: The responder / sample data.
+            sample: The responder / sample data.
             sf_target: The target / population data.
 
         Returns:
             A new BalanceFrame pairing the two samples.
 
         Raises:
-            TypeError: If *sf_with_outcomes* or *sf_target* is not a SampleFrame.
-            ValueError: If *sf_with_outcomes* and *sf_target* share no covariate
+            TypeError: If *sample* or *sf_target* is not a SampleFrame.
+            ValueError: If *sample* and *sf_target* share no covariate
                 columns.
         """
-        if sf_with_outcomes is None:
+        if sample is None:
             # Allow object.__new__(cls) for copy.deepcopy() support.
             if sf_target is None:
                 return object.__new__(cls)
             raise TypeError(
-                "BalanceFrame requires at least a 'sf_with_outcomes' argument. "
-                "Usage: BalanceFrame(sf_with_outcomes=sf1) or "
-                "BalanceFrame(sf_with_outcomes=sf1, sf_target=sf2)"
+                "BalanceFrame requires at least a 'sample' argument. "
+                "Usage: BalanceFrame(sample=sf1) or "
+                "BalanceFrame(sample=sf1, sf_target=sf2)"
             )
-        return cls._create(sf_with_outcomes=sf_with_outcomes, sf_target=sf_target)
+        return cls._create(sample=sample, sf_target=sf_target)
 
     def __init__(
         self,
-        sf_with_outcomes: SampleFrame | None = None,
+        sample: SampleFrame | None = None,
         sf_target: SampleFrame | None = None,
     ) -> None:
         # All initialisation happens in _create(); __init__ is intentionally
@@ -279,16 +272,16 @@ class BalanceFrame:
     @classmethod
     def _create(
         cls,
-        sf_with_outcomes: SampleFrame,
+        sample: SampleFrame,
         sf_target: SampleFrame | None = None,
     ) -> Self:
         """Internal factory method.
 
         Validates covariate overlap and builds the BalanceFrame instance.
-        Prefer the public constructor ``BalanceFrame(sf_with_outcomes=..., sf_target=...)``.
+        Prefer the public constructor ``BalanceFrame(sample=..., sf_target=...)``.
 
         Args:
-            sf_with_outcomes: The responder sample.
+            sample: The responder sample.
             sf_target: The target population. If None, creates a target-less
                 BalanceFrame that can be completed later via :meth:`set_target`.
 
@@ -296,12 +289,12 @@ class BalanceFrame:
             A validated BalanceFrame.
 
         Raises:
-            TypeError: If *sf_with_outcomes* or *sf_target* is not a SampleFrame.
+            TypeError: If *sample* or *sf_target* is not a SampleFrame.
             ValueError: If they share no covariate columns.
         """
-        if not isinstance(sf_with_outcomes, SampleFrame):
+        if not isinstance(sample, SampleFrame):
             raise TypeError(
-                f"'sf_with_outcomes' must be a SampleFrame, got {type(sf_with_outcomes).__name__}"
+                f"'sample' must be a SampleFrame, got {type(sample).__name__}"
             )
         if sf_target is not None and not isinstance(sf_target, SampleFrame):
             raise TypeError(
@@ -309,22 +302,28 @@ class BalanceFrame:
             )
 
         instance = object.__new__(cls)
-        instance._sf_with_outcomes_pre_adjust = sf_with_outcomes
-        instance._sf_with_outcomes = sf_with_outcomes  # same object initially
+        instance._sf_sample_pre_adjust = sample
+        instance._sf_sample = sample  # same object initially
         instance._sf_target = sf_target
         instance._adjustment_model = None
-        instance.id_column = sf_with_outcomes.id_column
-        try:
-            instance.weight_series = sf_with_outcomes.weight_series
-        except ValueError:
-            instance.weight_series = None
         instance._links = collections.defaultdict(list)
         if sf_target is not None:
             instance._links["target"] = sf_target
 
+        # When the instance is also a SampleFrame (e.g., Sample inherits
+        # from both BalanceFrame and SampleFrame), copy SampleFrame state
+        # so that inherited SampleFrame properties work on the instance.
+        if isinstance(instance, SampleFrame):
+            instance._df = sample._df
+            instance._id_column_name = sample._id_column_name
+            instance._column_roles = sample._column_roles
+            instance._weight_column_name = sample._weight_column_name
+            instance._weight_metadata = sample._weight_metadata
+            instance._df_dtypes = sample._df_dtypes
+
         # Validate covariate overlap using public properties
         if sf_target is not None:
-            cls._validate_covariate_overlap(sf_with_outcomes, sf_target)
+            cls._validate_covariate_overlap(sample, sf_target)
 
         return instance
 
@@ -359,7 +358,7 @@ class BalanceFrame:
     @property
     def df_responders(self) -> pd.DataFrame:
         """The responder data as a DataFrame."""
-        return self._sf_with_outcomes.df
+        return self._sf_sample.df
 
     @property
     def df_target(self) -> pd.DataFrame | None:
@@ -371,14 +370,14 @@ class BalanceFrame:
     @property
     def df_responders_unadjusted(self) -> pd.DataFrame:
         """The original (pre-adjustment) responder data as a DataFrame."""
-        return self._sf_with_outcomes_pre_adjust.df
+        return self._sf_sample_pre_adjust.df
 
     # --- Backward-compat aliases (to be removed in a future diff) ---
 
     @property
     def responders(self) -> SampleFrame:
-        """Alias for ``_sf_with_outcomes`` (backward compat, will be removed)."""
-        return self._sf_with_outcomes
+        """Alias for ``_sf_sample`` (backward compat, will be removed)."""
+        return self._sf_sample
 
     @property
     def target(self) -> SampleFrame | None:
@@ -387,9 +386,9 @@ class BalanceFrame:
 
     @property
     def unadjusted(self) -> SampleFrame | None:
-        """Alias for ``_sf_with_outcomes_pre_adjust`` if adjusted, else None (backward compat)."""
+        """Alias for ``_sf_sample_pre_adjust`` if adjusted, else None (backward compat)."""
         if self.is_adjusted:
-            return self._sf_with_outcomes_pre_adjust
+            return self._sf_sample_pre_adjust
         return None
 
     def has_target(self) -> bool:
@@ -404,7 +403,7 @@ class BalanceFrame:
             >>> from balance.balance_frame import BalanceFrame
             >>> resp = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp)
+            >>> bf = BalanceFrame(sample=resp)
             >>> bf.has_target()
             False
             >>> tgt = SampleFrame.from_frame(
@@ -450,7 +449,7 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp)
+            >>> bf = BalanceFrame(sample=resp)
             >>> bf.set_target(tgt)
             >>> bf.has_target()
             True
@@ -464,29 +463,29 @@ class BalanceFrame:
             # adjust() will report the error when called.
             try:
                 BalanceFrame._validate_covariate_overlap(
-                    new_copy._sf_with_outcomes, target._sf_with_outcomes
+                    new_copy._sf_sample, target._sf_sample
                 )
             except (ValueError, TypeError):
                 pass
-            new_copy._sf_target = target._sf_with_outcomes
+            new_copy._sf_target = target._sf_sample
             return new_copy
 
         if isinstance(target, SampleFrame):
             # SampleFrame path: default in_place=True for backward compat
             if in_place is None:
                 in_place = True
-            BalanceFrame._validate_covariate_overlap(self._sf_with_outcomes, target)
+            BalanceFrame._validate_covariate_overlap(self._sf_sample, target)
 
             if in_place:
                 self._sf_target = target
                 self._links["target"] = target
                 # Reset adjustment state — old adjustment is no longer valid.
-                self._sf_with_outcomes = self._sf_with_outcomes_pre_adjust
+                self._sf_sample = self._sf_sample_pre_adjust
                 self._adjustment_model = None
                 return self
             else:
                 return type(self)._create(
-                    sf_with_outcomes=copy.deepcopy(self._sf_with_outcomes_pre_adjust),
+                    sample=copy.deepcopy(self._sf_sample_pre_adjust),
                     sf_target=target,
                 )
 
@@ -499,9 +498,7 @@ class BalanceFrame:
         Returns a ``_CallableBool`` so both ``bf.is_adjusted`` (property)
         and ``bf.is_adjusted()`` (legacy call) work.
         """
-        return _CallableBool(
-            self._sf_with_outcomes is not self._sf_with_outcomes_pre_adjust
-        )
+        return _CallableBool(self._sf_sample is not self._sf_sample_pre_adjust)
 
     # --- Adjustment ---
 
@@ -540,7 +537,7 @@ class BalanceFrame:
         """
         if self._sf_target is None:
             raise ValueError("Cannot get covars without a target population.")
-        return self._sf_with_outcomes.df_covars, self._sf_target.df_covars
+        return self._sf_sample.df_covars, self._sf_target.df_covars
 
     def _build_adjusted_frame(
         self,
@@ -558,7 +555,7 @@ class BalanceFrame:
             A new, adjusted BalanceFrame (or subclass instance if called on
             a subclass).
         """
-        new_responders = copy.deepcopy(self._sf_with_outcomes)
+        new_responders = copy.deepcopy(self._sf_sample)
         method_name = (
             method
             if isinstance(method, str)
@@ -594,13 +591,11 @@ class BalanceFrame:
 
         # Use type(self) so subclasses (e.g. Sample) get their own type back.
         new_bf = type(self)._create(
-            sf_with_outcomes=new_responders,
+            sample=new_responders,
             sf_target=self._sf_target,
         )
-        # Point _sf_with_outcomes_pre_adjust to the original (pre-adjustment) data
-        new_bf._sf_with_outcomes_pre_adjust = self._sf_with_outcomes_pre_adjust
-        new_bf.id_column = new_responders.id_column
-        new_bf.weight_series = new_responders.weight_series
+        # Point _sf_sample_pre_adjust to the original (pre-adjustment) data
+        new_bf._sf_sample_pre_adjust = self._sf_sample_pre_adjust
         # Set _links for __str__() and BalanceDF integration
         new_bf._links["unadjusted"] = self
         if "target" in self._links:
@@ -662,7 +657,7 @@ class BalanceFrame:
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [4, 5, 6], "x": [15.0, 25.0, 35.0],
             ...                   "weight": [1.0, 1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> adjusted = bf.adjust(method="ipw")
             >>> adjusted.is_adjusted
             True
@@ -738,7 +733,7 @@ class BalanceFrame:
 
         result = adjustment_function(
             sample_df=resp_covars,
-            sample_weights=self._sf_with_outcomes.df_weights.iloc[:, 0],
+            sample_weights=self._sf_sample.df_weights.iloc[:, 0],
             target_df=target_covars,
             target_weights=sf_target.df_weights.iloc[:, 0],
             **kwargs,
@@ -760,7 +755,7 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> bf.model() is None
             True
         """
@@ -816,11 +811,11 @@ class BalanceFrame:
         responders_sf = SampleFrame.from_sample(sample)
         target_sf = SampleFrame.from_sample(sample._links["target"])
 
-        bf = cls._create(sf_with_outcomes=responders_sf, sf_target=target_sf)
+        bf = cls._create(sample=responders_sf, sf_target=target_sf)
 
         if sample.is_adjusted():
             # Set unadjusted to a DIFFERENT SampleFrame so is_adjusted returns True
-            bf._sf_with_outcomes_pre_adjust = SampleFrame.from_sample(
+            bf._sf_sample_pre_adjust = SampleFrame.from_sample(
                 sample._links["unadjusted"]
             )
             bf._adjustment_model = sample.model()
@@ -850,7 +845,7 @@ class BalanceFrame:
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [4, 5, 6], "x": [15.0, 25.0, 35.0],
             ...                   "weight": [1.0, 1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> s = bf.to_sample()
             >>> s.has_target()
             True
@@ -865,11 +860,11 @@ class BalanceFrame:
             )
 
         resp_sample = Sample.from_frame(
-            self._sf_with_outcomes._df,
-            id_column=self._sf_with_outcomes.id_column_name,
-            weight_column=self._sf_with_outcomes.weight_column,
-            outcome_columns=self._sf_with_outcomes.outcome_columns or None,
-            ignored_columns=self._sf_with_outcomes.ignored_columns or None,
+            self._sf_sample._df,
+            id_column=self._sf_sample.id_column_name,
+            weight_column=self._sf_sample.weight_column,
+            outcome_columns=self._sf_sample.outcome_columns or None,
+            ignored_columns=self._sf_sample.ignored_columns or None,
             standardize_types=False,
         )
         target_sample = Sample.from_frame(
@@ -882,19 +877,17 @@ class BalanceFrame:
         )
         result = resp_sample.set_target(target_sample)
 
-        if self.is_adjusted and self._sf_with_outcomes_pre_adjust is not None:
+        if self.is_adjusted and self._sf_sample_pre_adjust is not None:
             unadj_sf = SampleFrame.from_frame(
-                self._sf_with_outcomes_pre_adjust._df,
-                id_column=self._sf_with_outcomes_pre_adjust.id_column_name,
-                weight_column=self._sf_with_outcomes_pre_adjust.weight_column,
-                outcome_columns=self._sf_with_outcomes_pre_adjust.outcome_columns
-                or None,
-                ignored_columns=self._sf_with_outcomes_pre_adjust.ignored_columns
-                or None,
+                self._sf_sample_pre_adjust._df,
+                id_column=self._sf_sample_pre_adjust.id_column_name,
+                weight_column=self._sf_sample_pre_adjust.weight_column,
+                outcome_columns=self._sf_sample_pre_adjust.outcome_columns or None,
+                ignored_columns=self._sf_sample_pre_adjust.ignored_columns or None,
                 standardize_types=False,
             )
             # pyre-ignore[16]: Sample gains this attr via BalanceFrame inheritance (diff 14.3)
-            result._sf_with_outcomes_pre_adjust = unadj_sf
+            result._sf_sample_pre_adjust = unadj_sf
             # pyre-ignore[16]: Sample gains _links via BalanceFrame inheritance (diff 14.3)
             result._links["unadjusted"] = unadj_sf
             # pyre-ignore[16]: Sample gains this attr via BalanceFrame inheritance (diff 14.3)
@@ -919,7 +912,7 @@ class BalanceFrame:
         if self._sf_target is not None:
             links["target"] = self._sf_target
         if self.is_adjusted:
-            links["unadjusted"] = self._sf_with_outcomes_pre_adjust
+            links["unadjusted"] = self._sf_sample_pre_adjust
         return links
 
     def covars(self, formula: str | list[str] | None = None) -> Any:
@@ -944,7 +937,7 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> bf.covars().df.columns.tolist()
             ['x']
         """
@@ -973,13 +966,13 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 2.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> bf.weights().df.columns.tolist()
             ['weight']
         """
         from balance.balancedf_class import BalanceDFSource, BalanceDFWeights
 
-        # Pass self (not _sf_with_outcomes) so that r_indicator and other methods
+        # Pass self (not _sf_sample) so that r_indicator and other methods
         # that access self._sample._links find the BalanceFrame's _links.
         return BalanceDFWeights(
             cast(BalanceDFSource, self), links=self._build_links_dict()
@@ -1004,11 +997,11 @@ class BalanceFrame:
             ...     outcome_columns=["y"])
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> bf.outcomes().df.columns.tolist()
             ['y']
         """
-        if not self._sf_with_outcomes.outcome_columns:
+        if not self._sf_sample.outcome_columns:
             return None
         from balance.balancedf_class import BalanceDFOutcomes, BalanceDFSource
 
@@ -1041,16 +1034,14 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [0, 1], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [0, 1], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> bf._design_effect_diagnostics()
             (1.0, 2.0, 1.0)
         """
         if n_rows is None:
-            n_rows = len(self._sf_with_outcomes)
+            n_rows = len(self._sf_sample)
         try:
-            de = weights_stats.design_effect(
-                self._sf_with_outcomes.df_weights.iloc[:, 0]
-            )
+            de = weights_stats.design_effect(self._sf_sample.df_weights.iloc[:, 0])
         except (TypeError, ValueError, ZeroDivisionError) as exc:
             logger.debug("Unable to compute design effect: %s", exc)
             return None, None, None
@@ -1094,7 +1085,7 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [0, 1], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [0, 1], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> adjusted = bf.adjust(method="null")
             >>> "method: null" in adjusted._quick_adjustment_details()
             True
@@ -1147,7 +1138,7 @@ class BalanceFrame:
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [5, 6, 7, 8], "x": [0, 0, 1, 1],
             ...                   "weight": [1.0, 1.0, 1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> adjusted = bf.adjust(method="null")
             >>> "Covariate diagnostics:" in adjusted.summary()
             True
@@ -1242,7 +1233,7 @@ class BalanceFrame:
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": ["3", "4"], "x": [0, 1],
             ...                   "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> adjusted = bf.adjust(method="null")
             >>> adjusted.diagnostics().columns.tolist()
             ['metric', 'val', 'var']
@@ -1250,7 +1241,7 @@ class BalanceFrame:
         logger.info("Starting computation of diagnostics of the fitting")
         self._check_if_adjusted()
 
-        outcome_columns = self._sf_with_outcomes.df_outcomes
+        outcome_columns = self._sf_sample.df_outcomes
         outcome_impact = None
         if weights_impact_on_outcome_method is not None and outcome_columns is not None:
             outcome_impact = self.outcomes().weights_impact_on_outcome_ss(
@@ -1301,13 +1292,13 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> bf.df_all["source"].unique().tolist()
             ['self', 'target']
         """
         parts: list[pd.DataFrame] = []
 
-        resp_df = self._sf_with_outcomes._df.copy()
+        resp_df = self._sf_sample._df.copy()
         resp_df["source"] = "self"
         parts.append(resp_df)
 
@@ -1317,7 +1308,7 @@ class BalanceFrame:
             parts.append(tgt_df)
 
         if self.is_adjusted:
-            unadj_df = self._sf_with_outcomes_pre_adjust._df.copy()
+            unadj_df = self._sf_sample_pre_adjust._df.copy()
             unadj_df["source"] = "unadjusted"
             parts.append(unadj_df)
 
@@ -1335,7 +1326,7 @@ class BalanceFrame:
         """
         covars = self.covars()
         outcomes = self.outcomes()
-        ignored = self._sf_with_outcomes.df_ignored
+        ignored = self._sf_sample.df_ignored
         return pd.concat(
             (
                 self.id_column,
@@ -1385,9 +1376,9 @@ class BalanceFrame:
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [4, 5, 6], "x": [15.0, 25.0, 35.0],
             ...                   "weight": [1.0, 1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> filtered = bf.keep_only_some_rows_columns(rows_to_keep="x > 15")
-            >>> len(filtered._sf_with_outcomes._df)
+            >>> len(filtered._sf_sample._df)
             2
         """
         if rows_to_keep is None and columns_to_keep is None:
@@ -1397,16 +1388,16 @@ class BalanceFrame:
 
         if new_bf.has_target():
             # With target: filter all SampleFrames
-            new_bf._sf_with_outcomes = BalanceFrame._filter_sf(
-                new_bf._sf_with_outcomes, rows_to_keep, columns_to_keep
+            new_bf._sf_sample = BalanceFrame._filter_sf(
+                new_bf._sf_sample, rows_to_keep, columns_to_keep
             )
             if new_bf._sf_target is not None:
                 new_bf._sf_target = BalanceFrame._filter_sf(
                     new_bf._sf_target, rows_to_keep, columns_to_keep
                 )
-            if new_bf._sf_with_outcomes_pre_adjust is not None:
-                new_bf._sf_with_outcomes_pre_adjust = BalanceFrame._filter_sf(
-                    new_bf._sf_with_outcomes_pre_adjust, rows_to_keep, columns_to_keep
+            if new_bf._sf_sample_pre_adjust is not None:
+                new_bf._sf_sample_pre_adjust = BalanceFrame._filter_sf(
+                    new_bf._sf_sample_pre_adjust, rows_to_keep, columns_to_keep
                 )
         else:
             # No target: filter the responder SampleFrame
@@ -1416,24 +1407,16 @@ class BalanceFrame:
                         "Note that not all columns_to_keep are in Sample. "
                         "Only those that exist are removed"
                     )
-            new_bf._sf_with_outcomes = BalanceFrame._filter_sf(
-                new_bf._sf_with_outcomes, rows_to_keep, columns_to_keep
+            new_bf._sf_sample = BalanceFrame._filter_sf(
+                new_bf._sf_sample, rows_to_keep, columns_to_keep
             )
             if (
-                new_bf._sf_with_outcomes_pre_adjust is not None
-                and new_bf._sf_with_outcomes_pre_adjust is not new_bf._sf_with_outcomes
+                new_bf._sf_sample_pre_adjust is not None
+                and new_bf._sf_sample_pre_adjust is not new_bf._sf_sample
             ):
-                new_bf._sf_with_outcomes_pre_adjust = BalanceFrame._filter_sf(
-                    new_bf._sf_with_outcomes_pre_adjust, rows_to_keep, columns_to_keep
+                new_bf._sf_sample_pre_adjust = BalanceFrame._filter_sf(
+                    new_bf._sf_sample_pre_adjust, rows_to_keep, columns_to_keep
                 )
-
-        # Sync id_column / weight_series from filtered responders
-        new_bf.id_column = new_bf._sf_with_outcomes.id_column
-        try:
-            new_bf.weight_series = new_bf._sf_with_outcomes.weight_series
-        except ValueError:
-            # Weight column was filtered out — leave it unchanged
-            pass
 
         # Also filter linked BF/Sample objects in _links
         if new_bf._links:
@@ -1549,7 +1532,7 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> "id" in bf.to_csv()
             True
         """
@@ -1577,7 +1560,7 @@ class BalanceFrame:
             ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
             >>> tgt = SampleFrame.from_frame(
             ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
-            >>> bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+            >>> bf = BalanceFrame(sample=resp, sf_target=tgt)
             >>> link = bf.to_download(tempdir=tempfile.gettempdir())
         """
         return _to_download(self.df, tempdir)
@@ -1610,8 +1593,8 @@ class BalanceFrame:
         """
         # Break the shared reference so we don't corrupt the pre-adjustment
         # baseline (both point to the same SampleFrame initially).
-        if self._sf_with_outcomes is self._sf_with_outcomes_pre_adjust:
-            self._sf_with_outcomes_pre_adjust = copy.deepcopy(self._sf_with_outcomes)
+        if self._sf_sample is self._sf_sample_pre_adjust:
+            self._sf_sample_pre_adjust = copy.deepcopy(self._sf_sample)
 
         if isinstance(weights, pd.Series):
             if not all(idx in weights.index for idx in self.df.index):
@@ -1633,12 +1616,10 @@ class BalanceFrame:
             weights_value = np.nan if weights is None else weights
             self._df.loc[:, wc_name] = weights_value
 
-        self.weight_series = self._df[wc_name]
-
     def set_unadjusted(self, second: BalanceFrame) -> Self:
         """Set the unadjusted link for comparative analysis.
 
-        Returns a deep copy with ``_sf_with_outcomes_pre_adjust`` pointing at
+        Returns a deep copy with ``_sf_sample_pre_adjust`` pointing at
         *second*'s responder SampleFrame, and ``_links["unadjusted"]``
         pointing at *second*.
 
@@ -1658,7 +1639,7 @@ class BalanceFrame:
             )
         new_bf = deepcopy(self)
         new_bf._links["unadjusted"] = second
-        new_bf._sf_with_outcomes_pre_adjust = second._sf_with_outcomes
+        new_bf._sf_sample_pre_adjust = second._sf_sample
         return new_bf
 
     # --- Column accessors (moved from Sample) ---
@@ -1687,7 +1668,7 @@ class BalanceFrame:
 
     def _covar_columns(self) -> pd.DataFrame:
         """Return a DataFrame of all covariate columns."""
-        return self._sf_with_outcomes._covar_columns()
+        return self._sf_sample._covar_columns()
 
     # --- Error checks (moved from Sample) ---
 

--- a/balance/balancedf_class.py
+++ b/balance/balancedf_class.py
@@ -52,7 +52,7 @@ class BalanceDFSource(Protocol):
     ``balancedf_class.py``.
 
     Attributes:
-        weight_column: Active weight column as a ``pd.Series``.
+        weight_series: Active weight column as a ``pd.Series``.
         id_column: Row identifier column as a ``pd.Series``.
         _links: Dict mapping relationship names (e.g. ``"target"``,
             ``"unadjusted"``) to other ``BalanceDFSource`` instances.
@@ -64,7 +64,7 @@ class BalanceDFSource(Protocol):
     """
 
     @property
-    def weight_column(self) -> pd.Series:  # noqa: E704
+    def weight_series(self) -> pd.Series:  # noqa: E704
         ...
 
     @property
@@ -174,7 +174,7 @@ class BalanceDF:
     def _weights(
         self: "BalanceDF",
     ) -> pd.Series | None:
-        """Access the weight_column in __sample.
+        """Access the weight_series in __sample.
 
         Args:
             self (BalanceDF): Object
@@ -182,7 +182,7 @@ class BalanceDF:
         Returns:
             pd.Series | None: The weights (with no column name)
         """
-        w = self._sample.weight_column
+        w = self._sample.weight_series
         return w.rename(None)
 
     # NOTE: only in the case of BalanceDFOutcomes can it result in a None value.
@@ -2830,7 +2830,7 @@ class BalanceDFWeights(BalanceDF):
             links (Dict | None): Optional explicit links for BalanceDF.
         """
         super().__init__(
-            sample.weight_column.to_frame(), sample, name="weights", links=links
+            sample.weight_series.to_frame(), sample, name="weights", links=links
         )
 
     @property
@@ -2843,7 +2843,7 @@ class BalanceDFWeights(BalanceDF):
         Returns:
             pd.DataFrame: DataFrame containing the current weight column.
         """
-        return self._sample.weight_column.to_frame()
+        return self._sample.weight_series.to_frame()
 
     # TODO: maybe add better control if there are no weights for unadjusted or target (the current default shows them in the legend, but not in the figure)
     def plot(
@@ -3074,7 +3074,7 @@ class BalanceDFWeights(BalanceDF):
                     "This Sample does not have a target set. "
                     "Use sample.set_target to add target"
                 )
-            target_propensity = np.ones(len(target_sample.weight_column), dtype=float)
+            target_propensity = np.ones(len(target_sample.weight_series), dtype=float)
         elif np.isscalar(target_propensity):
             if target_sample is None:
                 raise ValueError(
@@ -3082,7 +3082,7 @@ class BalanceDFWeights(BalanceDF):
                     "target_propensity is scalar"
                 )
             target_propensity = np.full(
-                len(target_sample.weight_column),
+                len(target_sample.weight_series),
                 float(target_propensity),
                 dtype=float,
             )
@@ -3090,7 +3090,7 @@ class BalanceDFWeights(BalanceDF):
             target_propensity_array = np.asarray(target_propensity)
             if target_propensity_array.ndim == 0:
                 target_propensity_array = target_propensity_array.reshape(1)
-            if target_propensity_array.shape[0] != len(target_sample.weight_column):
+            if target_propensity_array.shape[0] != len(target_sample.weight_series):
                 raise ValueError(
                     "BalanceDFWeights.r_indicator requires target_propensity length "
                     "to match linked target row count"

--- a/balance/balancedf_class.py
+++ b/balance/balancedf_class.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Callable, Dict, Literal, Protocol, runtime_checkable, Tuple
+from typing import Any, Callable, Literal, Protocol, runtime_checkable
 
 import numpy as np
 import numpy.typing as npt
@@ -113,7 +113,7 @@ class BalanceDF:
             name (Literal["outcomes", "weights", "covars"]): The type of object that will be created. In practice, used for "outcomes", "weights" and "covars".
             links (dict[str, BalanceDFSource] | None): Optional explicit links dict
                 (e.g. {"target": ..., "unadjusted": ...}).  When provided,
-                _BalanceDF_child_from_linked_samples uses this instead of
+                _balancedf_child_from_linked_samples uses this instead of
                 sample._links.  This allows BalanceDF to work with sources
                 that do not carry mutable _links (e.g. SampleFrame).
         """
@@ -139,7 +139,7 @@ class BalanceDF:
 
     #  Private API
     @staticmethod
-    def _check_if_not_BalanceDF(
+    def _check_if_not_balancedf(
         BalanceDF_class_obj: "BalanceDF", object_name: str = "sample_BalanceDF"
     ) -> None:
         """Check if an object is BalanceDF, if not then it raises ValueError
@@ -186,9 +186,9 @@ class BalanceDF:
         return w.rename(None)
 
     # NOTE: only in the case of BalanceDFOutcomes can it result in a None value.
-    def _BalanceDF_child_from_linked_samples(
+    def _balancedf_child_from_linked_samples(
         self: "BalanceDF",
-    ) -> Dict[
+    ) -> dict[
         str,
         "BalanceDF"
         | "BalanceDFCovars"
@@ -209,7 +209,7 @@ class BalanceDF:
 
 
         Returns:
-            Dict[str, Union["BalanceDFCovars", "BalanceDFWeights", Union["BalanceDFOutcomes", None]],]:
+            dict[str, BalanceDFCovars | BalanceDFWeights | BalanceDFOutcomes | None]:
             A dict mapping the link relationship to the result.
                 First item is self, and it just returns it without using method on it.
                 The other items are based on the objects in _links. E.g.: it can be 'target'
@@ -256,12 +256,12 @@ class BalanceDF:
 
 
                 # keys depends on which samples are linked to the object:
-                list(s1.covars()._BalanceDF_child_from_linked_samples().keys())  # ['self']
-                list(s3.covars()._BalanceDF_child_from_linked_samples().keys())  # ['self', 'target']
-                list(s3_null.covars()._BalanceDF_child_from_linked_samples().keys())  # ['self', 'target', 'unadjusted']
+                list(s1.covars()._balancedf_child_from_linked_samples().keys())  # ['self']
+                list(s3.covars()._balancedf_child_from_linked_samples().keys())  # ['self', 'target']
+                list(s3_null.covars()._balancedf_child_from_linked_samples().keys())  # ['self', 'target', 'unadjusted']
 
                 # Indeed, all are of the same BalanceDF child type:
-                s3.covars()._BalanceDF_child_from_linked_samples()
+                s3.covars()._balancedf_child_from_linked_samples()
                 # {'self': (balance.balancedf_class.BalanceDFCovars)
                 # covars from <balance.sample_class.Sample object at 0x7f4392ea61c0>:
                 #     a   b  c
@@ -276,7 +276,7 @@ class BalanceDF:
                 # 1  2  6  y
                 # 2  3  8  z}
 
-                s3_null.covars()._BalanceDF_child_from_linked_samples()
+                s3_null.covars()._balancedf_child_from_linked_samples()
                 # {'self': (balance.balancedf_class.BalanceDFCovars)
                 # covars from <balance.sample_class.Sample object at 0x7f4392ea60d0>:
                 #     a   b  c
@@ -298,7 +298,7 @@ class BalanceDF:
                 # 2  3   2  z
                 # 3  1 -42  v}
 
-                the_dict = s3_null.covars()._BalanceDF_child_from_linked_samples()
+                the_dict = s3_null.covars()._balancedf_child_from_linked_samples()
                 [v.__class__ for (k,v) in the_dict.items()]
                 [balance.balancedf_class.BalanceDFCovars,
                 balance.balancedf_class.BalanceDFCovars,
@@ -306,7 +306,7 @@ class BalanceDF:
 
 
                 # This also works for outcomes (returns None if there is none):
-                s3.outcomes()._BalanceDF_child_from_linked_samples()
+                s3.outcomes()._balancedf_child_from_linked_samples()
                 # {'self': (balance.balancedf_class.BalanceDFOutcomes)
                 #  outcomes from <balance.sample_class.Sample object at 0x7f4392ea61c0>:
                 #      o
@@ -317,7 +317,7 @@ class BalanceDF:
                 #  'target': None}
 
                 # And also works for weights:
-                s3.weights()._BalanceDF_child_from_linked_samples()
+                s3.weights()._balancedf_child_from_linked_samples()
                 # {'self': (balance.balancedf_class.BalanceDFWeights)
                 #  weights from <balance.sample_class.Sample object at 0x7f4392ea61c0>:
                 #       w
@@ -334,7 +334,7 @@ class BalanceDF:
         """
         # NOTE: this assumes that the .__name is the same as the creation method (i.e.: .covars(), .weights(), .outcomes())
         BalanceDF_child_method = self.__name
-        d: Dict[
+        d: dict[
             str,
             "BalanceDF"
             | "BalanceDFCovars"
@@ -380,7 +380,7 @@ class BalanceDF:
             self (BalanceDF): Object.
             method (str): A name of a method to call (e.g.: "mean", "std", etc.).
                 Can also be a name of an attribute that is a DataFrame (e.g.: 'df')
-            exclude (Tuple[str], optional): A tuple of strings which indicates which source should be excluded from the output. Defaults to ().
+            exclude (tuple[str], optional): A tuple of strings which indicates which source should be excluded from the output. Defaults to ().
                 E.g.: "self", "target".
 
         Returns:
@@ -445,7 +445,7 @@ class BalanceDF:
                     # target  3   8  z
         """
         output = []
-        for k, v in self._BalanceDF_child_from_linked_samples().items():
+        for k, v in self._balancedf_child_from_linked_samples().items():
             if v is not None and k not in exclude:
                 v_att_method = getattr(v, method)
                 if callable(v_att_method):
@@ -464,7 +464,7 @@ class BalanceDF:
         #     else getattr(v, method)(on_linked_samples=False, *args, **kwargs)
         #     .assign(source=k)
         #     .set_index("source")
-        #     for k, v in self._BalanceDF_child_from_linked_samples().items()
+        #     for k, v in self._balancedf_child_from_linked_samples().items()
         #     if v is not None and k not in exclude
         # )
 
@@ -716,7 +716,7 @@ class BalanceDF:
             **kwargs: passed to :func:`weighted_comparisons_plots.plot_dist`.
 
         Returns:
-            Union[Union[List, np.ndarray], Dict[str, Figure], str, None]:
+            list | np.ndarray | dict[str, Figure] | str | None:
                 If library="plotly" then returns a dictionary containing plots if return_dict_of_figures is True. None otherwise.
                 If library="seaborn" then returns None, unless return_axes is True. Then either a list or an np.array of matplotlib axis.
                 If library="balance" then returns a string with the ASCII text output.
@@ -771,7 +771,7 @@ class BalanceDF:
                 s3_null.covars().plot(library = "balance", comparative = False)
         """
         if on_linked_samples:
-            dfs_to_add = self._BalanceDF_child_from_linked_samples()
+            dfs_to_add = self._balancedf_child_from_linked_samples()
         else:
             dfs_to_add = {"self": self}
 
@@ -1201,7 +1201,7 @@ class BalanceDF:
     def _get_df_and_weights(
         self: "BalanceDF",
         use_model_matrix: bool = True,
-    ) -> Tuple[pd.DataFrame, npt.NDArray | None]:
+    ) -> tuple[pd.DataFrame, npt.NDArray | None]:
         """Extract df values and weights from a BalanceDF object.
 
         Args:
@@ -1210,7 +1210,7 @@ class BalanceDF:
                 If False, use the raw df. Defaults to True.
 
         Returns:
-            Tuple[pd.DataFrame, np.ndarray | None]:
+            tuple[pd.DataFrame, np.ndarray | None]:
                 A pd.DataFrame output from running :func:`model_matrix` or using the raw df, and
                 A np.ndarray of weights from :func:`_weights`, or just None (if there are no weights).
         """
@@ -1260,8 +1260,8 @@ class BalanceDF:
         Returns:
             pd.Series: The result from the comparison function.
         """
-        BalanceDF._check_if_not_BalanceDF(sample_BalanceDF, "sample_BalanceDF")
-        BalanceDF._check_if_not_BalanceDF(target_BalanceDF, "target_BalanceDF")
+        BalanceDF._check_if_not_balancedf(sample_BalanceDF, "sample_BalanceDF")
+        BalanceDF._check_if_not_balancedf(target_BalanceDF, "target_BalanceDF")
 
         sample_df_values, sample_weights = sample_BalanceDF._get_df_and_weights(
             use_model_matrix=use_model_matrix,
@@ -1369,8 +1369,8 @@ class BalanceDF:
         Returns:
             pd.Series: See :func:`weighted_comparisons_stats.kld`.
         """
-        BalanceDF._check_if_not_BalanceDF(sample_BalanceDF, "sample_BalanceDF")
-        BalanceDF._check_if_not_BalanceDF(target_BalanceDF, "target_BalanceDF")
+        BalanceDF._check_if_not_balancedf(sample_BalanceDF, "sample_BalanceDF")
+        BalanceDF._check_if_not_balancedf(target_BalanceDF, "target_BalanceDF")
 
         sample_formula = sample_BalanceDF._kld_formula()
         target_formula = target_BalanceDF._kld_formula()
@@ -1624,7 +1624,7 @@ class BalanceDF:
                     # unadjusted         0.560055  8.746742   NaN  ...  0.265606  0.533422    3.174566
                     # unadjusted - self  0.263555  0.592999   NaN  ...  0.265606  0.315204    0.33963
         """
-        target_from_self = self._BalanceDF_child_from_linked_samples().get("target")
+        target_from_self = self._balancedf_child_from_linked_samples().get("target")
 
         if target is None:
             target = target_from_self
@@ -1735,7 +1735,7 @@ class BalanceDF:
                     # covars   0.0  0.173287   0.086643
         """
 
-        target_from_self = self._BalanceDF_child_from_linked_samples().get("target")
+        target_from_self = self._balancedf_child_from_linked_samples().get("target")
 
         if target is None:
             target = target_from_self
@@ -1827,7 +1827,7 @@ class BalanceDF:
 
                 sample.set_target(target).covars().emd(on_linked_samples=False)
         """
-        target_from_self = self._BalanceDF_child_from_linked_samples().get("target")
+        target_from_self = self._balancedf_child_from_linked_samples().get("target")
 
         if target is None:
             target = target_from_self
@@ -1919,7 +1919,7 @@ class BalanceDF:
 
                 sample.set_target(target).covars().cvmd(on_linked_samples=False)
         """
-        target_from_self = self._BalanceDF_child_from_linked_samples().get("target")
+        target_from_self = self._balancedf_child_from_linked_samples().get("target")
 
         if target is None:
             target = target_from_self
@@ -2013,7 +2013,7 @@ class BalanceDF:
 
                 sample.set_target(target).covars().ks(on_linked_samples=False)
         """
-        target_from_self = self._BalanceDF_child_from_linked_samples().get("target")
+        target_from_self = self._balancedf_child_from_linked_samples().get("target")
 
         if target is None:
             target = target_from_self
@@ -2122,14 +2122,14 @@ class BalanceDF:
                 # just like asmd_improvement
         """
         if unadjusted is None:
-            unadjusted = self._BalanceDF_child_from_linked_samples().get("unadjusted")
+            unadjusted = self._balancedf_child_from_linked_samples().get("unadjusted")
         if unadjusted is None:
             raise ValueError(
                 f"Sample {object.__repr__(self._sample)} has no unadjusted set or unadjusted has no {self.__name}."
             )
 
         if target is None:
-            target = self._BalanceDF_child_from_linked_samples().get("target")
+            target = self._balancedf_child_from_linked_samples().get("target")
         if target is None:
             raise ValueError(
                 f"Sample {object.__repr__(self._sample)} has no target set or target has no {self.__name}."
@@ -2202,7 +2202,7 @@ class BalanceDFOutcomes(BalanceDF):
     def __init__(
         self: "BalanceDFOutcomes",
         sample: BalanceDFSource,
-        links: Dict[str, BalanceDFSource] | None = None,
+        links: dict[str, BalanceDFSource] | None = None,
     ) -> None:
         """A factory function to create BalanceDFOutcomes
 
@@ -2307,7 +2307,7 @@ class BalanceDFOutcomes(BalanceDF):
         if type(target) is bool:
             # Then: get target from self:
             if target:
-                self_target = self._BalanceDF_child_from_linked_samples().get("target")
+                self_target = self._balancedf_child_from_linked_samples().get("target")
                 if self_target is None:
                     logger.warning("Sample does not have target set")
                     return None
@@ -2367,7 +2367,7 @@ class BalanceDFOutcomes(BalanceDF):
                     # n    8.0   7.0
                     # %  100.0  87.5
         """
-        self_target = self._BalanceDF_child_from_linked_samples().get("target")
+        self_target = self._balancedf_child_from_linked_samples().get("target")
         if self_target is None:
             logger.warning("Sample does not have target set")
             return None
@@ -2708,7 +2708,7 @@ class BalanceDFOutcomes(BalanceDF):
             adjusted = sample.set_target(target).adjust(method="null")
             adjusted.outcomes().outcome_variance_ratio()
         """
-        linked = self._BalanceDF_child_from_linked_samples()
+        linked = self._balancedf_child_from_linked_samples()
         unadjusted_outcomes = linked.get("unadjusted")
         if unadjusted_outcomes is None:
             raise ValueError(
@@ -2730,7 +2730,7 @@ class BalanceDFCovars(BalanceDF):
     def __init__(
         self: "BalanceDFCovars",
         sample: BalanceDFSource,
-        links: Dict[str, BalanceDFSource] | None = None,
+        links: dict[str, BalanceDFSource] | None = None,
         formula: str | list[str] | None = None,
     ) -> None:
         """A factory function to create BalanceDFCovars
@@ -2816,7 +2816,7 @@ class BalanceDFWeights(BalanceDF):
     def __init__(
         self: "BalanceDFWeights",
         sample: BalanceDFSource,
-        links: Dict[str, BalanceDFSource] | None = None,
+        links: dict[str, BalanceDFSource] | None = None,
     ) -> None:
         """A factory function to create BalanceDFWeights
 
@@ -2860,7 +2860,7 @@ class BalanceDFWeights(BalanceDF):
                 Defaults to True.
 
         Returns:
-            Union[Union[List, np.ndarray], Dict[str, Figure], None]:
+            list | np.ndarray | dict[str, Figure] | None:
                 If library="plotly" then returns a dictionary containing plots if return_dict_of_figures is True. None otherwise.
                 If library="seaborn" then returns None, unless return_axes is True. Then either a list or an np.array of matplotlib axis.
 
@@ -2980,7 +2980,7 @@ class BalanceDFWeights(BalanceDF):
             adjusted = sample.set_target(target).adjust(method="null")
             adjusted.weights().design_effect_prop()
         """
-        linked = self._BalanceDF_child_from_linked_samples()
+        linked = self._balancedf_child_from_linked_samples()
         unadjusted_weights = linked.get("unadjusted")
         if unadjusted_weights is None:
             raise ValueError(

--- a/balance/cli.py
+++ b/balance/cli.py
@@ -316,7 +316,7 @@ class BalanceCLI:
 
         Note that keep columns that are not the id, weight, a covariate,
         or an explicit outcome column will be placed into
-        ``ignore_columns`` by :meth:`process_batch`.  They are still
+        ``ignored_columns`` by :meth:`process_batch`.  They are still
         carried through the ``Sample`` and available in the output.
 
         Returns:
@@ -335,7 +335,7 @@ class BalanceCLI:
 
         These columns are used to filter the final output DataFrame.
         Keep columns that are not the id, weight, a covariate, or an
-        explicit outcome column will be placed into ``ignore_columns``
+        explicit outcome column will be placed into ``ignored_columns``
         during processing but are still retained by the ``Sample`` and
         included in the output.
 
@@ -714,7 +714,7 @@ class BalanceCLI:
             }
 
         # Build the set of explicitly mentioned columns.  Any column not in
-        # this set is placed into ignore_columns so it is carried through
+        # this set is placed into ignored_columns so it is carried through
         # the Sample but does not participate in the adjustment.
         outcome_columns = self.outcome_columns()
         explicitly_mentioned: set[str] = {
@@ -725,7 +725,7 @@ class BalanceCLI:
         if outcome_columns is not None:
             explicitly_mentioned.update(outcome_columns)
 
-        ignore_columns = [
+        ignored_columns = [
             column for column in batch_df.columns if column not in explicitly_mentioned
         ]
         outcome_columns = tuple(outcome_columns) if outcome_columns else None
@@ -740,7 +740,7 @@ class BalanceCLI:
             id_column=self.id_column(),
             weight_column=self.weight_column(),
             outcome_columns=outcome_columns,
-            ignore_columns=ignore_columns,
+            ignored_columns=ignored_columns,
             check_id_uniqueness=False,
             standardize_types=self.standardize_types(),
         )
@@ -751,7 +751,7 @@ class BalanceCLI:
             id_column=self.id_column(),
             weight_column=self.weight_column(),
             outcome_columns=outcome_columns,
-            ignore_columns=ignore_columns,
+            ignored_columns=ignored_columns,
             check_id_uniqueness=False,
             standardize_types=self.standardize_types(),
         )
@@ -1259,7 +1259,7 @@ def add_arguments_to_parser(parser: ArgumentParser) -> ArgumentParser:
         help=(
             "Comma-separated columns used as outcomes. If not supplied, "
             "columns that are not id, weight, or covariates are placed into "
-            "ignore_columns (carried through but not used in adjustment)."
+            "ignored_columns (carried through but not used in adjustment)."
         ),
     )
     parser.add_argument(

--- a/balance/cli.py
+++ b/balance/cli.py
@@ -801,7 +801,10 @@ class BalanceCLI:
             )
 
             # Update dtypes
-            if self.args.return_df_with_original_dtypes:
+            if (
+                self.args.return_df_with_original_dtypes
+                and adjusted._df_dtypes is not None
+            ):
                 df_to_return = balance.util._astype_in_df_from_dtypes(
                     adjusted.df, adjusted._df_dtypes
                 )
@@ -826,7 +829,10 @@ class BalanceCLI:
                 error_message = f"{module_name}: {e}"
                 logger.exception("The error message is: " + error_message)
                 # Update dtypes
-                if self.args.return_df_with_original_dtypes:
+                if (
+                    self.args.return_df_with_original_dtypes
+                    and sample._df_dtypes is not None
+                ):
                     df_to_return = balance.util._astype_in_df_from_dtypes(
                         sample.df, sample._df_dtypes
                     )

--- a/balance/sample_class.py
+++ b/balance/sample_class.py
@@ -131,7 +131,7 @@ class Sample(BalanceFrame, SampleFrame):
             use_deepcopy=use_deepcopy,
             id_column_candidates=id_column_candidates,
         )
-        return cls._create(sf_with_outcomes=sf, sf_target=None)
+        return cls._create(sample=sf, sf_target=None)
 
     def __deepcopy__(self, memo: dict[int, Any]) -> Sample:
         """Return an independent deep copy of this Sample.
@@ -145,19 +145,19 @@ class Sample(BalanceFrame, SampleFrame):
             setattr(new, k, deepcopy(v, memo))
         return new
 
-    # _sample_frame is kept as an alias for _sf_with_outcomes for backward compat.
+    # _sample_frame is kept as an alias for _sf_sample for backward compat.
     # _balance_frame is no longer needed since Sample IS a BalanceFrame.
 
     @property
     def _sample_frame(self) -> SampleFrame:
-        """Alias for ``_sf_with_outcomes`` (backward compat for internal code)."""
-        return self._sf_with_outcomes
+        """Alias for ``_sf_sample`` (backward compat for internal code)."""
+        return self._sf_sample
 
     @_sample_frame.setter
     def _sample_frame(self, value: SampleFrame | None) -> None:
         if value is not None:
-            self._sf_with_outcomes = value
-            self._sf_with_outcomes_pre_adjust = value
+            self._sf_sample = value
+            self._sf_sample_pre_adjust = value
 
     @property
     def _balance_frame(self) -> BalanceFrame | None:

--- a/balance/sample_class.py
+++ b/balance/sample_class.py
@@ -89,7 +89,7 @@ class Sample(BalanceFrame, SampleFrame):
         weight_column: str | None = None,
         outcome_columns: List[str] | tuple[str, ...] | str | None = None,
         predicted_outcome_columns: List[str] | tuple[str, ...] | str | None = None,
-        ignore_columns: List[str] | tuple[str, ...] | str | None = None,
+        ignored_columns: List[str] | tuple[str, ...] | str | None = None,
         check_id_uniqueness: bool = True,
         standardize_types: bool = True,
         use_deepcopy: bool = True,
@@ -108,7 +108,7 @@ class Sample(BalanceFrame, SampleFrame):
             weight_column: Column to treat as weight.
             outcome_columns: Columns to treat as outcomes.
             predicted_outcome_columns: Columns to treat as predicted outcomes.
-            ignore_columns: Columns to ignore (excluded from covariates).
+            ignored_columns: Columns to ignore (excluded from covariates).
             check_id_uniqueness: Whether to verify id uniqueness.
             standardize_types: Whether to convert int types to float.
             use_deepcopy: Whether to deepcopy the input DataFrame.
@@ -125,7 +125,7 @@ class Sample(BalanceFrame, SampleFrame):
             weight_column=weight_column,
             outcome_columns=outcome_columns,
             predicted_outcome_columns=predicted_outcome_columns,
-            ignore_columns=ignore_columns,
+            ignored_columns=ignored_columns,
             check_id_uniqueness=check_id_uniqueness,
             standardize_types=standardize_types,
             use_deepcopy=use_deepcopy,
@@ -171,7 +171,7 @@ class Sample(BalanceFrame, SampleFrame):
     # All public API methods (df, covars, outcomes, weights,
     # adjust, set_target, has_target, set_unadjusted, is_adjusted, summary,
     # diagnostics, keep_only_some_rows_columns, to_csv, to_download,
-    # model_matrix, set_weights, __str__, __repr__, ignored_columns, model)
+    # model_matrix, set_weights, __str__, __repr__, model)
     # are inherited from BalanceFrame.
 
     # --- Conversion to new API (kept temporarily) ---

--- a/balance/sample_class.py
+++ b/balance/sample_class.py
@@ -40,7 +40,7 @@ class Sample(BalanceFrame, SampleFrame):
     ----------
     id_column : pd.Series
         a column representing the ids of the units in sample
-    weight_column : pd.Series
+    weight_series : pd.Series
         a column representing the weights of the units in sample
     """
 

--- a/balance/sample_class.py
+++ b/balance/sample_class.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import inspect
 import logging
 from copy import deepcopy
-from typing import Any, List
+from typing import Any
 
 from balance.balance_frame import _CallableBool, BalanceFrame  # noqa: F401
 from balance.sample_frame import SampleFrame
@@ -87,13 +87,13 @@ class Sample(BalanceFrame, SampleFrame):
         id_column: str | None = None,
         covar_columns: list[str] | None = None,
         weight_column: str | None = None,
-        outcome_columns: List[str] | tuple[str, ...] | str | None = None,
-        predicted_outcome_columns: List[str] | tuple[str, ...] | str | None = None,
-        ignored_columns: List[str] | tuple[str, ...] | str | None = None,
+        outcome_columns: list[str] | tuple[str, ...] | str | None = None,
+        predicted_outcome_columns: list[str] | tuple[str, ...] | str | None = None,
+        ignored_columns: list[str] | tuple[str, ...] | str | None = None,
         check_id_uniqueness: bool = True,
         standardize_types: bool = True,
         use_deepcopy: bool = True,
-        id_column_candidates: List[str] | tuple[str, ...] | str | None = None,
+        id_column_candidates: list[str] | tuple[str, ...] | str | None = None,
     ) -> Sample:
         """Create a Sample from a pandas DataFrame.
 

--- a/balance/sample_class.py
+++ b/balance/sample_class.py
@@ -85,7 +85,7 @@ class Sample(BalanceFrame, SampleFrame):
         cls,
         df: Any,
         id_column: str | None = None,
-        covars_columns: list[str] | None = None,
+        covar_columns: list[str] | None = None,
         weight_column: str | None = None,
         outcome_columns: List[str] | tuple[str, ...] | str | None = None,
         predicted_outcome_columns: List[str] | tuple[str, ...] | str | None = None,
@@ -103,7 +103,7 @@ class Sample(BalanceFrame, SampleFrame):
         Args:
             df: DataFrame containing the sample data.
             id_column: Column name for respondent ids (must be unique).
-            covars_columns: Explicit covariate column names. If None,
+            covar_columns: Explicit covariate column names. If None,
                 covariates are inferred by exclusion.
             weight_column: Column to treat as weight.
             outcome_columns: Columns to treat as outcomes.
@@ -121,7 +121,7 @@ class Sample(BalanceFrame, SampleFrame):
         sf = SampleFrame.from_frame(
             df=df,
             id_column=id_column,
-            covars_columns=covars_columns,
+            covar_columns=covar_columns,
             weight_column=weight_column,
             outcome_columns=outcome_columns,
             predicted_outcome_columns=predicted_outcome_columns,

--- a/balance/sample_class.py
+++ b/balance/sample_class.py
@@ -7,42 +7,34 @@
 
 from __future__ import annotations
 
-import collections
 import inspect
 import logging
 from copy import deepcopy
-from importlib.metadata import version as importlib_version
-from typing import Any, Callable, Dict, List, Literal
+from typing import Any, List
 
-import numpy as np
-import pandas as pd
-from balance import adjustment as balance_adjustment, util as balance_util
-from balance.csv_utils import to_csv_with_defaults
-from balance.summary_utils import (
-    _build_diagnostics,
-    _build_summary,
-    _concat_metric_val_var,
-)
-from balance.typing import FilePathOrBuffer
-from balance.util import (
-    _assert_type,
-    _detect_high_cardinality_features,
-    HighCardinalityFeature,
-)
-from IPython.lib.display import FileLink
+from balance.balance_frame import _CallableBool, BalanceFrame  # noqa: F401
+from balance.sample_frame import SampleFrame
+from balance.summary_utils import _concat_metric_val_var
 
 logger: logging.Logger = logging.getLogger(__package__)
 
 # Re-export _concat_metric_val_var so existing imports from this module still work
-__all__ = ["Sample", "_concat_metric_val_var"]
+__all__ = ["Sample", "_concat_metric_val_var", "_CallableBool"]
 
 
-class Sample:
+class Sample(BalanceFrame, SampleFrame):
     """
     A class used to represent a sample.
 
     Sample is the main object of balance. It contains a dataframe of unit's observations,
     associated with id and weight.
+
+    Sample inherits from both :class:`~balance.balance_frame.BalanceFrame` and
+    :class:`~balance.sample_frame.SampleFrame`.  Without a target it behaves
+    like a SampleFrame; with a target (after ``set_target()``) it behaves
+    like a BalanceFrame.
+
+    MRO: Sample → BalanceFrame → SampleFrame → object
 
     Attributes
     ----------
@@ -52,1185 +44,144 @@ class Sample:
         a column representing the weights of the units in sample
     """
 
-    # TODO: fix the following missing pyre-strict issues:
-    # The following attributes are updated when initiating Sample using Sample.from_frame
-    # pyre-fixme[4]: Attributes are initialized in from_frame()
-    _df = None
-    # pyre-fixme[4]: Attributes are initialized in from_frame()
-    id_column = None
-    # pyre-fixme[4]: Attributes are initialized in from_frame()
-    _outcome_columns = None
-    # pyre-fixme[4]: Attributes are initialized in from_frame()
-    _ignored_column_names = None
-    # pyre-fixme[4]: Attributes are initialized in from_frame()
-    weight_column = None
-    # pyre-fixme[4]: Attributes are initialized in from_frame()
-    _links = None
-    _adjustment_model: Dict[str, Any] | None = None
-    # pyre-fixme[4]: Attributes are initialized in from_frame()
-    _df_dtypes = None
+    def __new__(
+        cls,
+        responders: SampleFrame | None = None,
+        target: SampleFrame | None = None,
+    ) -> "Sample":
+        """Override __new__ to raise NotImplementedError for direct construction.
 
-    def __init__(self) -> None:
-        # The following checks if the call to Sample() was initiated inside the class itself using from_frame, or outside of it
-        # If the call was made internally, it will enable the creation of an instance of the class.
-        # This is used when from_frame calls `sample = Sample()`. Keeping the full stack allows this also to work by a child of Sample.
-        # If Sample() is called outside of the class structure, it will return the NotImplementedError error.
-        try:
-            calling_functions = [x.function for x in inspect.stack()]
-        except Exception:
-            raise NotImplementedError(
-                "cannot construct Sample class directly... yet (only by invoking Sample.from_frame(...)"
-            )
-
-        if "from_frame" not in calling_functions:
-            raise NotImplementedError(
-                "cannot construct Sample class directly... yet (only by invoking Sample.from_frame(...)"
-            )
-        pass
-
-    def __repr__(self: "Sample") -> str:
-        return (
-            f"({self.__class__.__module__}.{self.__class__.__qualname__})\n"
-            f"{self.__str__()}"
-        )
-
-    def __str__(self: "Sample", pkg_source: str = __package__) -> str:
-        """Return a readable summary of the sample and any applied adjustment.
-
-        The summary reports the number of observations, covariate names, id and
-        weight columns, available outcome columns, and whether a target has been
-        set. When an adjustment is present, quick diagnostics are included such
-        as the adjustment method, trimming configuration, and weight summaries
-        (design effect and implied effective sample size when available).
-
-        Args:
-            pkg_source: Package namespace used in the header of the printed
-                object. Defaults to ``balance`` and is primarily useful for
-                subclasses that wish to identify their own module.
-
-        Returns:
-            str: Multi-line description of the ``Sample`` highlighting key
-                structure and adjustment details.
-
-        Examples:
-        .. code-block:: python
-
-            from balance import Sample
-            import pandas as pd
-            df = pd.DataFrame({
-                "gender": ["f", "m"],
-                "age_group": ["18-24", "25-34"],
-                "id": [1, 2],
-                "weight": [1.2, 0.8],
-            })
-            sample = Sample.from_frame(df, id_column="id", weight_column="weight")
-            adjusted = sample.set_target(sample).adjust(method="ipw")
-            print(adjusted)
-            Adjusted balance Sample object with target set using ipw
-            2 observations x 2 variables: gender,age_group
-            id_column: id, weight_column: weight,
-            outcome_columns: None
-            adjustment details:
-                method: ipw
-                design effect (Deff): 1.013
-                effective sample size (ESS): 2.0
-            target:
-                 balance Sample object
-                2 observations x 2 variables: gender,age_group
-                id_column: id, weight_column: weight,
-                outcome_columns: None
-                2 common variables: age_group,gender
+        Sample should be constructed via ``Sample.from_frame()``.  Direct
+        ``Sample()`` calls raise ``NotImplementedError``.  Internal paths
+        (``from_frame``, ``_create``, ``deepcopy``) are allowed through by
+        checking the call stack.
         """
-        is_adjusted = self.is_adjusted() * "Adjusted "
-        n_rows = self._df.shape[0]
-        n_variables = self._covar_columns().shape[1]
-        has_target = self.has_target() * " with target set"
-        adjustment_method = (
-            " using " + _assert_type(self.model())["method"]
-            if self.model() is not None
-            else ""
-        )
-        variables = ",".join(self._covar_columns_names())
-        id_column_name = self.id_column.name if self.id_column is not None else "None"
-        weight_column_name = (
-            self.weight_column.name if self.weight_column is not None else "None"
-        )
-        outcome_column_names = (
-            ",".join(self._outcome_columns.columns.tolist())
-            if self._outcome_columns is not None
-            else "None"
-        )
-
-        desc = f"""
-        {is_adjusted}{pkg_source} Sample object{has_target}{adjustment_method}
-        {n_rows} observations x {n_variables} variables: {variables}
-        id_column: {id_column_name}, weight_column: {weight_column_name},
-        outcome_columns: {outcome_column_names}
-        """
-
-        if self.is_adjusted():
-            adjustment_details = self._quick_adjustment_details(n_rows)
-            if len(adjustment_details) > 0:
-                desc += """
-        adjustment details:
-            {details}
-                """.format(
-                    details="\n            ".join(adjustment_details)
+        if responders is None and target is None:
+            # Check if called from an internal path (deepcopy, from_frame, _create)
+            try:
+                caller_func = inspect.stack()[1].function
+            except Exception:
+                raise NotImplementedError(
+                    "Sample should not be constructed directly. "
+                    "Use Sample.from_frame() instead."
                 )
-
-        if self.has_target():
-            common_variables = balance_util.choose_variables(
-                self, self._links["target"], variables=None
-            )
-            target_str = self._links["target"].__str__().replace("\n", "\n\t")
-            n_common = len(common_variables)
-            common_variables = ",".join(common_variables)
-            desc += f"""
-            target:
-                 {target_str}
-            {n_common} common variables: {common_variables}
-            """
-        return desc
-
-    def _quick_adjustment_details(
-        self: "Sample", n_rows: int | None = None
-    ) -> List[str]:
-        """Collect quick-to-compute adjustment diagnostics for display.
-
-        This helper centralizes the lightweight adjustment-related statistics
-        surfaced in ``__str__`` so they can be reused by other presentation
-        helpers (for example, :meth:`summary`) without duplicating logic.
-
-        Note: This method formats diagnostics for human-readable output.
-
-        Args:
-            n_rows: Optional row count to use for effective sample size
-                calculations. Defaults to the current sample's row count.
-
-        Returns:
-            List[str]: Human-readable lines describing adjustment method,
-            trimming configuration, and weight diagnostics when available.
-
-        Examples:
-            The ``__str__`` example above shows these details rendered as part
-            of the adjusted sample printout. You can also retrieve them
-            directly for custom displays:
-
-            sample._quick_adjustment_details()  # doctest: +SKIP
-            ['method: ipw', 'design effect (Deff): 1.013', 'effective sample size (ESS): 2.0']
-        """
-
-        adjustment_details: List[str] = []
-        model = self.model()
-        if isinstance(model, dict):
-            method = model.get("method")
-            if isinstance(method, str):
-                adjustment_details.append(f"method: {method}")
-
-            trimming_mean_ratio = model.get("weight_trimming_mean_ratio")
-            if trimming_mean_ratio is not None:
-                adjustment_details.append(
-                    f"weight trimming mean ratio: {trimming_mean_ratio}"
+            if caller_func not in (
+                "__deepcopy__",
+                "__newobj__",
+                "__newobj_ex__",
+                "deepcopy",
+                "_reconstruct",
+                "from_frame",
+                "_create",
+            ):
+                raise NotImplementedError(
+                    "Sample should not be constructed directly. "
+                    "Use Sample.from_frame() instead."
                 )
-
-            trimming_percentile = model.get("weight_trimming_percentile")
-            if trimming_percentile is not None:
-                adjustment_details.append(
-                    f"weight trimming percentile: {trimming_percentile}"
-                )
-
-        if n_rows is None:
-            n_rows = self._df.shape[0]
-
-        design_effect, effective_n, effective_sample_proportion = (
-            self._design_effect_diagnostics(n_rows)
-        )
-        if design_effect is not None:
-            adjustment_details.append(f"design effect (Deff): {design_effect:.3f}")
-            if effective_sample_proportion is not None:
-                adjustment_details.append(
-                    f"effective sample size proportion (ESSP): {effective_sample_proportion:.3f}"
-                )
-            if effective_n is not None:
-                adjustment_details.append(
-                    f"effective sample size (ESS): {effective_n:.1f}"
-                )
-
-        return adjustment_details
-
-    def _design_effect_diagnostics(
-        self, n_rows: int | None = None
-    ) -> tuple[float | None, float | None, float | None]:
-        """
-        Compute design effect and related effective sample statistics.
-
-        Args:
-            n_rows: Optional number of rows to use for scaling. Defaults to the
-                sample size when not provided.
-
-        Returns:
-            Tuple of (design_effect, effective_sample_size, effective_sample_proportion).
-            If the design effect is unavailable or invalid, all values are ``None``.
-        """
-
-        if n_rows is None:
-            n_rows = self._df.shape[0]
-
-        if self.weight_column is None:
-            return None, None, None
-
-        try:
-            design_effect = self.weights().design_effect()
-        except (TypeError, ValueError, ZeroDivisionError) as exc:
-            logger.debug("Unable to compute design effect: %s", exc)
-            return None, None, None
-
-        if design_effect is None or not np.isfinite(design_effect):
-            return None, None, None
-
-        effective_sample_size = None
-        effective_sample_proportion = None
-        if n_rows and design_effect != 0:
-            effective_sample_size = n_rows / design_effect
-            effective_sample_proportion = effective_sample_size / n_rows
-
-        return float(design_effect), effective_sample_size, effective_sample_proportion
-
-    ################################################################################
-    #  Public API
-    ################################################################################
+        return object.__new__(cls)
 
     @classmethod
     def from_frame(
-        cls: type["Sample"],
-        df: pd.DataFrame,
+        cls,
+        df: Any,
         id_column: str | None = None,
-        outcome_columns: List[str] | tuple[str, ...] | str | None = None,
+        covars_columns: list[str] | None = None,
         weight_column: str | None = None,
+        outcome_columns: List[str] | tuple[str, ...] | str | None = None,
+        predicted_outcome_columns: List[str] | tuple[str, ...] | str | None = None,
         ignore_columns: List[str] | tuple[str, ...] | str | None = None,
         check_id_uniqueness: bool = True,
         standardize_types: bool = True,
         use_deepcopy: bool = True,
         id_column_candidates: List[str] | tuple[str, ...] | str | None = None,
-    ) -> "Sample":
-        """
-        Create a new Sample object.
+    ) -> Sample:
+        """Create a Sample from a pandas DataFrame.
 
-        NOTE that all integer columns will be converted by defaults into floats. This behavior can be turned off
-        by setting standardize_types argument to False.
-        The reason this is done by default is because of missing value handling combined with balance current lack of support
-        for pandas Integer types:
-            1. Native numpy integers do not support missing values (NA), while pandas Integers do,
-            as well numpy floats. Also,
-            2. various functions in balance do not support pandas Integers, while they do support numpy floats.
-            3. Hence, since some columns might have missing values, the safest solution is to just convert all integers into numpy floats.
-
-        The id_column is stored as a string, even if the input is an integer.
+        Thin wrapper around :meth:`SampleFrame.from_frame` that builds a
+        SampleFrame and then wraps it in a Sample via :meth:`_create`.
 
         Args:
-            df (pd.DataFrame): containing the sample's data
-            id_column (str | None): the column of the df which contains the respondent's id
-            (should be unique). Defaults to None.
-            outcome_columns (list | tuple | str | None): names of columns to treat as outcome
-            weight_column (str | None): name of column to treat as weight. If not specified, will
-                be guessed (either "weight" or "weights"). If not found, a new column will be created ("weight") and filled with 1.0.
-            ignore_columns (list | tuple | str | None): names of columns to keep on the
-                underlying dataframe but ignore in covariate/outcome handling. These columns
-                are excluded from outcome statistics and covariate selections. Defaults to None.
-            check_id_uniqueness (bool): Whether to check if ids are unique. Defaults to True.
-            standardize_types (bool): Whether to standardize types. Defaults to True.
-                Int64/int64 -> float64
-                Int32/int32 -> float64
-                string -> object
-                pandas.NA -> numpy.nan (within each cell)
-                This is slightly memory intensive (since it copies the data twice),
-                but helps keep various functions working for both Int64 and Int32 input columns.
-            use_deepcopy (Optional, bool): Whether to have a new df copy inside the sample object.
-                If False, then when the sample methods update the internal df then the original df will also be updated.
-                Defaults to True.
-            id_column_candidates (list | tuple | str | None): candidate id column names
-                to use when id_column is not provided. Defaults to None which uses
-                ["id"].
+            df: DataFrame containing the sample data.
+            id_column: Column name for respondent ids (must be unique).
+            covars_columns: Explicit covariate column names. If None,
+                covariates are inferred by exclusion.
+            weight_column: Column to treat as weight.
+            outcome_columns: Columns to treat as outcomes.
+            predicted_outcome_columns: Columns to treat as predicted outcomes.
+            ignore_columns: Columns to ignore (excluded from covariates).
+            check_id_uniqueness: Whether to verify id uniqueness.
+            standardize_types: Whether to convert int types to float.
+            use_deepcopy: Whether to deepcopy the input DataFrame.
+            id_column_candidates: Candidate id column names when ``id_column``
+                is not provided.
 
         Returns:
-            Sample: a sample object
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            df = pd.DataFrame(
-                {
-                    "id": ["1", "2"],
-                    "x": [0, 1],
-                    "weight": [1.0, 2.0],
-                    "y": [0.1, 0.2],
-                }
-            )
-            sample = Sample.from_frame(
-                df,
-                id_column="id",
-                weight_column="weight",
-                outcome_columns="y",
-                standardize_types=False,
-            )
-            isinstance(sample, Sample)
-            # True
+            A new Sample.
         """
-        # Inititate a Sample() class, inside a from_frame constructor
-        sample = cls()
+        sf = SampleFrame.from_frame(
+            df=df,
+            id_column=id_column,
+            covars_columns=covars_columns,
+            weight_column=weight_column,
+            outcome_columns=outcome_columns,
+            predicted_outcome_columns=predicted_outcome_columns,
+            ignore_columns=ignore_columns,
+            check_id_uniqueness=check_id_uniqueness,
+            standardize_types=standardize_types,
+            use_deepcopy=use_deepcopy,
+            id_column_candidates=id_column_candidates,
+        )
+        return cls._create(sf_with_outcomes=sf, sf_target=None)
 
-        sample._df_dtypes = df.dtypes
+    def __deepcopy__(self, memo: dict[int, Any]) -> Sample:
+        """Return an independent deep copy of this Sample.
 
-        if use_deepcopy:
-            sample._df = deepcopy(df)
-        else:
-            sample._df = df
+        Copies all instance attributes, preserving both BalanceFrame and
+        SampleFrame state.
+        """
+        new = object.__new__(type(self))
+        memo[id(self)] = new
+        for k, v in self.__dict__.items():
+            setattr(new, k, deepcopy(v, memo))
+        return new
 
-        # id column
-        try:
-            id_column = balance_util.guess_id_column(
-                df, id_column, possible_id_columns=id_column_candidates
-            )
-        except (ValueError, TypeError) as exc:
-            raise type(exc)(
-                "Error while inferring id_column from DataFrame. Specify a valid "
-                "'id_column' or provide 'id_column_candidates'. Original error: "
-                f"{exc}"
-            ) from exc
-        if any(sample._df[id_column].isnull()):
-            raise ValueError("Null values are not allowed in the id_column")
-        if not all(isinstance(x, str) for x in sample._df[id_column].tolist()):
-            logger.warning("Casting id column to string")
-            sample._df[id_column] = sample._df[id_column].astype(str)
+    # _sample_frame is kept as an alias for _sf_with_outcomes for backward compat.
+    # _balance_frame is no longer needed since Sample IS a BalanceFrame.
 
-        if (check_id_uniqueness) and (
-            sample._df[id_column].nunique() != len(sample._df[id_column])
-        ):
-            raise ValueError("Values in the id_column must be unique")
-        sample.id_column = sample._df[id_column]
-
-        # TODO: in the future, if we could have all functions work with the original data types, that would be better.
-        if standardize_types:
-            # Move from some pandas Integer types to numpy float types.
-            # NOTE: The rationale is that while pandas integers support missing values,
-            #       numpy float types do (storing it as np.nan).
-            #       Furthermore, other functions in the package don't handle pandas Integer objects well, so
-            #       they must be converted to numpy integers (if they have no missing values).
-            #       But since we can't be sure that none of the various objects with the same column will not have NAs,
-            #       we just convert them all to float (either 32 or 64).
-            #       For more details, see: https://stackoverflow.com/a/53853351
-            # This line is after the id_column is set, so to make sure that the conversion happens after it is stored as a string.
-            # Move from Int64Dtype() to dtype('int64'):
-
-            # TODO: convert all numeric values (no matter what the original is) to "float64"?
-            #       (Instead of mentioning all different types)
-            #       using is_numeric_dtype: https://pandas.pydata.org/docs/reference/api/pandas.api.types.is_numeric_dtype.html?highlight=is_numeric_dtype#pandas.api.types.is_numeric_dtype
-            #       Also, consider using
-            #       https://pandas.pydata.org/docs/reference/api/pandas.api.types.is_string_dtype.html
-            #       or https://pandas.pydata.org/docs/reference/api/pandas.api.types.is_object_dtype.html
-            #       from non-numeric.
-            #       e.d.: balance/util.py?lines=512.
-            #           for x in df.columns:
-            #               if (is_numeric_dtype(df[x])) and (not is_bool_dtype(df[x])):
-            #                   df[x] = df[x].astype("float64")
-            input_type = ["Int64", "Int32", "int64", "int32", "int16", "int8"]
-            output_type = [
-                "float64",
-                "float32",  # This changes Int32Dtype() into dtype('int32') (from pandas to numpy)
-                "float64",
-                "float32",
-                "float16",
-                "float16",  # Using float16 since float8 doesn't exist, see: https://stackoverflow.com/a/40507235/256662
-            ]
-            # TODO:(after 2026) that if pandas >=3, this doesn't cause issues for users importing data from SQL
-            # In pandas < 3, convert string dtype to object for compatibility
-            from packaging.version import Version
-
-            if Version(importlib_version("pandas")) < Version("3.0"):
-                input_type.append("string")
-                output_type.append("object")
-            for i_input, i_output in zip(input_type, output_type):
-                sample._df = balance_util._pd_convert_all_types(
-                    sample._df, i_input, i_output
-                )
-
-            # Replace any pandas.NA with numpy.nan avoiding downcasting warnings
-            # By explicitly setting the result of fillna and using infer_objects
-            from balance.util import _safe_fillna_and_infer
-
-            sample._df = _safe_fillna_and_infer(sample._df, np.nan)
-
-            balance_util._warn_of_df_dtypes_change(
-                sample._df_dtypes,
-                sample._df.dtypes,
-                "df",
-                "sample._df",
-            )
-
-        # weight column
-        if weight_column is None:
-            if "weight" in sample._df.columns:
-                logger.warning("Guessing weight column is 'weight'")
-                weight_column = "weight"
-            elif "weights" in sample._df.columns:
-                logger.warning("Guessing weight column is 'weights'")
-                weight_column = "weights"
-            else:
-                # TODO: The current default when weights are not available is "weight", while the method in balanceDF is called "weights",
-                #       and the subclass is called BalanceDFWeights (with and 's' at the end)
-                #       In the future, it would be better to be more consistent and use the same name for all variations (e.g.: "weight").
-                #       Unless, we move to use more weights columns, and this method could be used to get all of them.
-                logger.warning(
-                    "No weights passed. Adding a 'weight' column and setting all values to 1"
-                )
-                weight_column = "weight"
-                if standardize_types:
-                    sample._df.loc[:, weight_column] = (
-                        1.0  # Use 1.0 to ensure float64 type
-                    )
-                else:
-                    sample._df.loc[:, weight_column] = (
-                        1  # Use 1 to preserve int64 type when standardize_types=False
-                    )
-
-        # verify that the weights are not null
-        null_weights = sample._df[weight_column].isnull()
-        if any(null_weights):
-            null_weight_rows = sample._df.loc[null_weights].head()
-            null_weight_rows_count = int(null_weights.sum())
-            raise ValueError(
-                "Null values (including None) are not allowed in the weight_column. "
-                + "If you wish to remove an observation, either remove it from the df, or use a weight of 0. "
-                + f"Found {null_weight_rows_count} row(s) with null weights. Preview (up to 5 rows):\n"
-                + null_weight_rows.to_string(index=False)
-            )
-
-        # verify that the weights are numeric
-        if not np.issubdtype(sample._df[weight_column].dtype, np.number):
-            raise ValueError("Weights must be numeric")
-
-        # verify that the weights are not negative
-        if any(sample._df[weight_column] < 0):
-            raise ValueError("Weights must be non-negative")
-
-        sample.weight_column = sample._df[weight_column]
-
-        # ignore columns
-        if ignore_columns is None:
-            sample._ignored_column_names = []
-        else:
-            if isinstance(ignore_columns, str):
-                ignore_columns = [ignore_columns]
-
-            if not all(isinstance(col, str) for col in ignore_columns):
-                raise ValueError("ignore_columns must be strings")
-
-            missing_ignore = set(ignore_columns).difference(sample._df.columns)
-            if missing_ignore:
-                raise ValueError(
-                    f"ignore columns {missing_ignore} not in df columns {sample._df.columns.values.tolist()}"
-                )
-
-            duplicate_preserving_order = list(dict.fromkeys(ignore_columns))
-            reserved_columns = {id_column, weight_column} - {None}
-            overlap_reserved = set(duplicate_preserving_order).intersection(
-                reserved_columns
-            )
-            if overlap_reserved:
-                raise ValueError(
-                    f"ignore columns cannot include id/weight columns: {overlap_reserved}"
-                )
-            sample._ignored_column_names = duplicate_preserving_order
-
-        # outcome columns
-        if outcome_columns is None:
-            sample._outcome_columns = None
-        else:
-            if isinstance(outcome_columns, str):
-                outcome_columns = [outcome_columns]
-
-            overlapping_columns = set(outcome_columns).intersection(
-                getattr(sample, "_ignored_column_names", [])
-            )
-            if overlapping_columns:
-                raise ValueError(
-                    f"Columns cannot be both ignored and outcomes: {overlapping_columns}"
-                )
-            try:
-                sample._outcome_columns = sample._df.loc[:, outcome_columns]
-            except KeyError:
-                _all_columns = sample._df.columns.values.tolist()
-                raise ValueError(
-                    f"outcome columns {outcome_columns} not in df columns {_all_columns}"
-                )
-
-        sample._links = collections.defaultdict(list)
-        return sample
-
-    ####################
-    # Class base methods
-    ####################
     @property
-    def df(self: "Sample") -> pd.DataFrame:
-        """Produce a DataFrame (of the self) from a Sample object.
-
-        Args:
-            self (Sample): Sample object.
-
-        Returns:
-            pd.DataFrame: with id_columns, and the df values of covars(), outcome() and weights() of the self in the Sample object.
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            df = pd.DataFrame(
-                {
-                    "id": ["1", "2"],
-                    "x": [0, 1],
-                    "weight": [1.0, 2.0],
-                    "y": [0.1, 0.2],
-                }
-            )
-            sample = Sample.from_frame(
-                df,
-                id_column="id",
-                weight_column="weight",
-                outcome_columns="y",
-                standardize_types=False,
-            )
-            sample.df.columns.tolist()
-            # ['id', 'x', 'y', 'weight']
-        """
-        return pd.concat(
-            (
-                self.id_column,
-                self.covars().df if self.covars() is not None else None,
-                self.outcomes().df if self.outcomes() is not None else None,
-                self.weights().df if self.weights() is not None else None,
-                self.ignored_columns() if self.ignored_columns() is not None else None,
-            ),
-            axis=1,
-        )
-
-    def outcomes(
-        self: "Sample",
-    ) -> (
-        Any
-    ):  # -> "Optional[Type[BalanceDFOutcomes]]" (not imported due to circular dependency)
-        """
-        Produce a BalanceOutcomeDF from a Sample object.
-        See :class:BalanceDFOutcomes.
-
-        Args:
-            self (Sample): Sample object.
-
-        Returns:
-            BalanceDFOutcomes or None
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {
-                        "id": ["1", "2"],
-                        "x": [0, 1],
-                        "weight": [1.0, 2.0],
-                        "y": [0.1, 0.2],
-                    }
-                ),
-                id_column="id",
-                weight_column="weight",
-                outcome_columns="y",
-                standardize_types=False,
-            )
-            sample.outcomes().df.columns.tolist()
-            # ['y']
-        """
-        if self._outcome_columns is not None:
-            # NOTE: must import here so to avoid circular dependency
-            from balance.balancedf_class import BalanceDFOutcomes
-
-            # pyre-fixme[6]: Sample satisfies BalanceDFSource structurally
-            return BalanceDFOutcomes(self)
-        else:
-            return None
-
-    def weights(
-        self: "Sample",
-    ) -> (
-        Any
-    ):  # -> "Optional[Type[BalanceDFWeights]]" (not imported due to circular dependency)
-        """
-        Produce a BalanceDFWeights from a Sample object.
-        See :class:BalanceDFWeights.
-
-        Args:
-            self (Sample): Sample object.
-
-        Returns:
-            BalanceDFWeights
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {
-                        "id": ["1", "2"],
-                        "x": [0, 1],
-                        "weight": [1.0, 2.0],
-                        "y": [0.1, 0.2],
-                    }
-                ),
-                id_column="id",
-                weight_column="weight",
-                outcome_columns="y",
-                standardize_types=False,
-            )
-            sample.weights().df.columns.tolist()
-            # ['weight']
-        """
-        # NOTE: must import here so to avoid circular dependency
-        from balance.balancedf_class import BalanceDFWeights
-
-        # pyre-fixme[6]: Sample satisfies BalanceDFSource structurally
-        return BalanceDFWeights(self)
-
-    def covars(
-        self: "Sample", formula: str | list[str] | None = None
-    ) -> (
-        Any
-    ):  # -> "Optional[Type[BalanceDFCovars]]" (not imported due to circular dependency)
-        """
-        Produce a BalanceDFCovars from a Sample object.
-        See :class:BalanceDFCovars.
-
-        Args:
-            self (Sample): Sample object.
-            formula (str | list[str] | None, optional): Optional formula string
-                (or list of formulas) used when creating model matrices from the
-                returned ``BalanceDFCovars`` object. If provided, methods that
-                rely on model matrices (or distribution-comparison methods that
-                opt into model-matrix behavior for formula-based covariates) will
-                use this formula. Defaults to None.
-
-        Returns:
-            BalanceDFCovars
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {
-                        "id": ["1", "2"],
-                        "x": [0, 1],
-                        "weight": [1.0, 2.0],
-                        "y": [0.1, 0.2],
-                    }
-                ),
-                id_column="id",
-                weight_column="weight",
-                outcome_columns="y",
-                standardize_types=False,
-            )
-            sample.covars().df.columns.tolist()
-            # ['x']
-        """
-        # NOTE: must import here so to avoid circular dependency
-        from balance.balancedf_class import BalanceDFCovars
-
-        # pyre-fixme[6]: Sample satisfies BalanceDFSource structurally
-        return BalanceDFCovars(self, formula=formula)
-
-    def ignored_columns(self: "Sample") -> pd.DataFrame | None:
-        """Return columns marked as ignored on the sample.
-
-        These columns stay on the underlying dataframe for tracking purposes
-        but are excluded from covariate selection and outcome statistics.
-
-        Returns:
-            Optional[pd.DataFrame]: DataFrame of ignored columns, or None when
-            no ignored columns are defined.
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            df = pd.DataFrame(
-                {"id": [1, 2], "note": ["x", "y"], "age": [20, 21], "out": [0, 1]}
-            )
-            sample = Sample.from_frame(
-                df, id_column="id", outcome_columns="out", ignore_columns=["note"], weight_column=None
-            )
-            sample.ignored_columns().columns.tolist()
-            # ['note']
-        """
-
-        if len(getattr(self, "_ignored_column_names", [])) == 0:
-            return None
-        return self._df[self._ignored_column_names]
-
-    def model(
-        self: "Sample",
-    ) -> Dict[str, Any] | None:
-        """
-        Returns the adjustment model dictionary if Sample has been adjusted.
-        Otherwise returns None.
-
-        The ``_adjustment_model`` attribute is initialized as ``None`` at the class
-        level and is set to a dictionary containing model details when
-        :meth:`adjust` is called. This method simply returns that attribute,
-        which will be ``None`` for unadjusted samples.
-
-        Args:
-            self (Sample): Sample object.
-
-        Returns:
-            Dict[str, Any] or None: Dictionary containing adjustment model details
-                (e.g., method name, fitted model, performance metrics) if the sample
-                has been adjusted, otherwise None.
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            sample.model() is None
-            # True
-        """
-        return self._adjustment_model
-
-    def model_matrix(self: "Sample") -> pd.DataFrame:
-        """
-        Returns the model matrix of sample using :func:`model_matrix`,
-        while adding na indicator for null values (see :func:`add_na_indicator`).
-
-        Returns:
-            pd.DataFrame: model matrix of sample
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            sample.model_matrix().shape
-            # (2, 1)
-        """
-        res = _assert_type(
-            balance_util.model_matrix(self, add_na=True)["sample"], pd.DataFrame
-        )
-        return res
-
-    ############################################
-    # Adjusting and adapting weights of a sample
-    ############################################
-    def adjust(
-        self: "Sample",
-        target: "Sample" | None = None,
-        method: (
-            Literal["cbps", "ipw", "null", "poststratify", "rake"] | Callable[..., Any]
-        ) = "ipw",
-        *args: Any,
-        **kwargs: Any,
-    ) -> "Sample":
-        """
-        Perform adjustment of one sample to match another.
-        This function returns a new sample.
-
-        Args:
-            target ("Sample" | None): Second sample object which should be matched.
-                If None, the set target of the object is used for matching.
-            method (str): method for adjustment: cbps, ipw, null, poststratify, rake
-
-        Returns:
-            Sample: an adjusted Sample object
-
-        Note:
-            During adjustment, the method automatically detects and warns about high-cardinality
-            categorical features (features where most values are unique). These features
-            typically don't provide meaningful signal for adjustment and may lead to
-            unstable or uniform weights. The warning helps identify features that should be
-            reviewed or excluded from the adjustment.
-
-        Examples:
-        .. code-block:: python
-
-                import balance
-                from sklearn.ensemble import HistGradientBoostingClassifier
-                from balance import Sample
-                from balance import load_data
-
-                # Load simulated data
-                target_df, sample_df = load_data()
-
-                sample
-
-                sample = Sample.from_frame(sample_df, outcome_columns=["happiness"])
-                # Often times we don't have the outcome for the target. In this case we've added it just to validate later that the weights indeed help us reduce the bias
-                target = Sample.from_frame(target_df, outcome_columns=["happiness"])
-
-                sample_with_target = sample.set_target(target)
-                adjusted = sample_with_target.adjust()
-
-                hgb = HistGradientBoostingClassifier(
-                    random_state=0, categorical_features="from_dtype"
-                )
-                adjusted_hgb = sample_with_target.adjust(
-                    model=hgb,
-                    use_model_matrix=False,
-                )
-
-                # Print ASMD tables for both adjusted and adjusted_hgb
-                print("\\n=== Adjusted ASMD ===")
-                print(adjusted.covars().asmd().T)
-
-                print("\\n=== Adjusted_HGB ASMD ===")
-                print(adjusted_hgb.covars().asmd().T)
-
-                # output (values will vary by model and random seed)
-                #
-                # === Adjusted ASMD ===
-                # source                  self  unadjusted  unadjusted - self
-                # age_group[T.25-34]  0.021777    0.005688          -0.016090
-                # age_group[T.35-44]  0.055884    0.312711           0.256827
-                # age_group[T.45+]    0.169816    0.378828           0.209013
-                # gender[Female]      0.097916    0.375699           0.277783
-                # gender[Male]        0.103989    0.379314           0.275324
-                # gender[_NA]         0.010578    0.006296          -0.004282
-                # income              0.205469    0.494217           0.288748
-                # mean(asmd)          0.119597    0.326799           0.207202
-                #
-                # === Adjusted_HGB ASMD ===
-                # source                  self  unadjusted  unadjusted - self
-                # age_group[T.25-34]       ...    0.005688            ...
-                # age_group[T.35-44]       ...    0.312711            ...
-                # age_group[T.45+]         ...    0.378828            ...
-                # gender[Female]           ...    0.375699            ...
-                # gender[Male]             ...    0.379314            ...
-                # gender[_NA]              ...    0.006296            ...
-                # income                   ...    0.494217            ...
-                # mean(asmd)               ...    0.326799            ...
-        """
-        if target is None:
-            self._no_target_error()
-            target = self._links["target"]
-
-        new_sample = deepcopy(self)
-        if isinstance(method, str):
-            adjustment_function = balance_adjustment._find_adjustment_method(method)
-        elif callable(method):
-            adjustment_function = method
-        else:
-            raise ValueError("Method should be one of existing weighting methods")
-
-        # Detect high cardinality features in both sample and target covariates
-        sample_covars_df = self.covars().df
-        target_covars_df = target.covars().df
-
-        num_rows_sample = sample_covars_df.shape[0]
-        num_rows_target = target_covars_df.shape[0]
-        if (
-            num_rows_sample > 0
-            # TODO: the values of 100_000 and 10 are arbitrary,
-            #       and should be replaced with a more principled approach (in the far future)
-            and num_rows_target > 100_000
-            and num_rows_target >= 10 * num_rows_sample
-        ):
-            logger.warning(
-                "Large target detected: %s target rows vs %s sample rows. "
-                "When the target is much larger than the sample (here >10x and >100k rows), "
-                "the target's contribution to variance becomes negligible. "
-                "Standard errors will be driven almost entirely by the sample, "
-                "similar to a one-sample inference setting.",
-                num_rows_target,
-                num_rows_sample,
-            )
-
-        sample_high_card = _detect_high_cardinality_features(sample_covars_df)
-        target_high_card = _detect_high_cardinality_features(target_covars_df)
-
-        # Merge the results, taking the maximum unique_count for each column
-        high_cardinality_dict: dict[str, HighCardinalityFeature] = {}
-        for feature in sample_high_card + target_high_card:
-            if (
-                feature.column not in high_cardinality_dict
-                or feature.unique_count
-                > high_cardinality_dict[feature.column].unique_count
-            ):
-                high_cardinality_dict[feature.column] = feature
-
-        high_cardinality_features = sorted(
-            high_cardinality_dict.values(),
-            key=lambda f: f.unique_count,
-            reverse=True,
-        )
-
-        if high_cardinality_features:
-            formatted_details = ", ".join(
-                f"{feature.column} (unique={feature.unique_count}; "
-                f"unique_ratio={feature.unique_ratio:.2f}"
-                f"{'; missing values present' if feature.has_missing else ''}"
-                f")"
-                for feature in high_cardinality_features
-            )
-            logger.warning(
-                "High-cardinality features detected that may not provide signal: "
-                + formatted_details
-            )
-
-        adjusted = adjustment_function(
-            *args,
-            sample_df=sample_covars_df,
-            sample_weights=self.weight_column,
-            target_df=target_covars_df,
-            target_weights=target.weight_column,
-            **kwargs,
-        )
-        new_sample.set_weights(adjusted["weight"])
-        new_sample._adjustment_model = adjusted["model"]
-        new_sample._links["unadjusted"] = self
-        new_sample._links["target"] = target
-
-        return new_sample
-
-    def set_weights(self, weights: pd.Series | float | None) -> None:
-        """
-        Adjusting the weights of a Sample object.
-        This will overwrite the weight_column of the Sample.
-        Note that the weights are assigned by index if weights is a pd.Series
-        (of Sample.df and weights series)
-
-        Args:
-            weights (pd.Series | float | None): Series of weights to add to sample.
-                If None or float values, the same weight (or None) will be assigned to all units.
-
-        Returns:
-            None, but adapting the Sample weight column to weights
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            sample.set_weights(pd.Series([1.0, 3.0], index=sample.df.index))
-            sample.weights().df["weight"].tolist()
-            # [1.0, 3.0]
-        """
-        if isinstance(weights, pd.Series):
-            if not all(idx in weights.index for idx in self.df.index):
-                logger.warning(
-                    """Note that not all Sample units will be assigned weights,
-                    since weights are missing some of the indices in Sample.df"""
-                )
-
-        if isinstance(weights, pd.Series):
-            # For Series weights, always ensure weight column is float64 for proper weighting operations
-            if not pd.api.types.is_float_dtype(self._df[self.weight_column.name]):
-                self._df[self.weight_column.name] = self._df[
-                    self.weight_column.name
-                ].astype("float64")
-
-            # Convert weights to float64 if not already
-            if not pd.api.types.is_float_dtype(weights):
-                weights = weights.astype("float64")
-
-            # Now assign the weights
-            self._df.loc[:, self.weight_column.name] = weights
-        else:
-            # For scalar weights, always ensure weight column is float64 for proper weighting operations
-            if not pd.api.types.is_float_dtype(self._df[self.weight_column.name]):
-                self._df[self.weight_column.name] = self._df[
-                    self.weight_column.name
-                ].astype("float64")
-
-            # Now assign the weights
-            weights_value = np.nan if weights is None else weights
-            self._df.loc[:, self.weight_column.name] = weights_value
-
-        self.weight_column = self._df[self.weight_column.name]
-
-    ####################################
-    # Handling links to other dataframes
-    ####################################
-    def set_unadjusted(self, second_sample: "Sample") -> "Sample":
-        """
-        Used to set the unadjusted link to Sample.
-        This is useful in case one wants to compare two samples.
-
-        Args:
-            second_sample (Sample): A second Sample to be set as unadjusted of Sample.
-
-        Returns:
-            Sample: a new copy of Sample with unadjusted link attached to the self object.
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            linked = sample.set_unadjusted(sample)
-            linked.is_adjusted()
-            # False
-        """
-        if isinstance(second_sample, Sample):
-            newsample = deepcopy(self)
-            newsample._links["unadjusted"] = second_sample
-            return newsample
-        else:
-            raise TypeError(
-                "set_unadjusted must be called with second_sample argument of type Sample"
-            )
-
-    def is_adjusted(self) -> bool:
-        """Check if a Sample object is adjusted and has target attached
-
-        Returns:
-            bool: whether the Sample is adjusted or not.
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            sample.is_adjusted()
-            # False
-        """
-        return ("unadjusted" in self._links) and ("target" in self._links)
-
-    def set_target(self, target: "Sample") -> "Sample":
-        """
-        Used to set the target linked to Sample.
-
-        Args:
-            target (Sample): A Sample object to be linked as target
-
-        Returns:
-            Sample: new copy of Sample with target link attached
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            target = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["3", "4"], "x": [0, 1], "weight": [1.0, 1.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            sample.set_target(target).has_target()
-            # True
-        """
-        if isinstance(target, Sample):
-            newsample = deepcopy(self)
-            newsample._links["target"] = target
-            return newsample
-        else:
-            raise ValueError("A target, a Sample object, must be specified")
-
-    def has_target(self) -> bool:
-        """
-        Check if a Sample object has target attached.
-
-        Returns:
-            bool: whether the Sample has target attached
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            target = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["3", "4"], "x": [0, 1], "weight": [1.0, 1.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            sample.set_target(target).has_target()
-            # True
-        """
-        return "target" in self._links
-
-    # --- Conversion to new API ---
+    def _sample_frame(self) -> SampleFrame:
+        """Alias for ``_sf_with_outcomes`` (backward compat for internal code)."""
+        return self._sf_with_outcomes
+
+    @_sample_frame.setter
+    def _sample_frame(self, value: SampleFrame | None) -> None:
+        if value is not None:
+            self._sf_with_outcomes = value
+            self._sf_with_outcomes_pre_adjust = value
+
+    @property
+    def _balance_frame(self) -> BalanceFrame | None:
+        """Returns self since Sample IS a BalanceFrame now."""
+        return self if self.has_target() else None
+
+    @_balance_frame.setter
+    def _balance_frame(self, value: Any) -> None:
+        pass  # no-op: Sample IS the BalanceFrame
+
+    # All public API methods (df, covars, outcomes, weights,
+    # adjust, set_target, has_target, set_unadjusted, is_adjusted, summary,
+    # diagnostics, keep_only_some_rows_columns, to_csv, to_download,
+    # model_matrix, set_weights, __str__, __repr__, ignored_columns, model)
+    # are inherited from BalanceFrame.
+
+    # --- Conversion to new API (kept temporarily) ---
 
     def to_sample_frame(self) -> Any:
         """Convert this Sample to a :class:`~balance.sample_frame.SampleFrame`.
 
         Preserves all data and column roles (id, weight, outcomes, ignored
-        columns mapped to misc).  The returned SampleFrame is independent
-        of the original Sample.
+        columns).  The returned SampleFrame is independent of the original
+        Sample.
 
         Returns:
             SampleFrame: A new SampleFrame mirroring this Sample.
@@ -1244,7 +195,6 @@ class Sample:
             >>> list(sf.df_covars.columns)
             ['x']
         """
-        # Lazy import: sample_class ↔ sample_frame have a circular dependency.
         from balance.sample_frame import SampleFrame
 
         return SampleFrame.from_sample(self)
@@ -1273,496 +223,6 @@ class Sample:
             >>> bf.is_adjusted
             False
         """
-        # Lazy import: sample_class ↔ balance_frame have a circular dependency.
         from balance.balance_frame import BalanceFrame
 
         return BalanceFrame.from_sample(self)
-
-    # TODO: Add a method that plots the distribution of the outcome (adjusted v.s. unadjusted
-    #       if adjusted, and only unadjusted otherwise)
-
-    ##############################################
-    # Summary of metrics and diagnostics of Sample
-    ##############################################
-    def summary(self) -> str:
-        """
-        Provides a summary of covariate balance, design effect and model properties (if applicable)
-        of a sample.
-
-        The summary consolidates high-level diagnostics that are most helpful after adjustment,
-        including covariate balance, weight health, outcome behavior, and basic model fit when
-        available.
-
-        For more details see: :func:`BalanceDF.asmd`, :func:`BalanceDF.asmd_improvement`
-        and :func:`weights_stats.design_effect`
-
-        Returns:
-            str: a summary description of properties of an adjusted sample.
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            survey = Sample.from_frame(
-                pd.DataFrame(
-                    {"x": (0, 1, 1, 0), "id": range(4), "y": (0.1, 0.5, 0.4, 0.9), "w": (1, 2, 1, 1)}
-                ),
-                id_column="id",
-                outcome_columns="y",
-                weight_column="w",
-            )
-            target = Sample.from_frame(
-                pd.DataFrame({"x": (0, 0, 1, 1), "id": range(4)}),
-                id_column="id",
-            )
-            adjusted = survey.set_target(target).adjust(method="null")
-            print(adjusted.summary())
-            Adjustment details:
-                method: null_adjustment
-            Covariate diagnostics:
-                Covar ASMD reduction: 0.0%
-                Covar ASMD (1 variables): 0.173 -> 0.173
-                Covar mean KLD reduction: 0.0%
-                Covar mean KLD (1 variables): 0.020 -> 0.020
-            Weight diagnostics:
-                design effect (Deff): 1.120
-                effective sample size proportion (ESSP): 0.893
-                effective sample size (ESS): 3.6
-            Outcome weighted means:
-                           y
-            source
-            self       0.480
-            unadjusted 0.480
-        """
-        # Compute intermediate values from self, then delegate to the
-        # standalone _build_summary() function.
-        covars_asmd = None
-        covars_kld = None
-        asmd_improvement_pct = None
-
-        if self.is_adjusted() or self.has_target():
-            covars_asmd = self.covars().asmd()
-            covars_kld = self.covars().kld(aggregate_by_main_covar=True)
-
-        if self.is_adjusted():
-            asmd_improvement_pct = 100 * self.covars().asmd_improvement()
-
-        quick_adjustment_details: List[str] = []
-        if self.is_adjusted():
-            quick_adjustment_details = self._quick_adjustment_details(self._df.shape[0])
-
-        design_effect, effective_sample_size, effective_sample_proportion = (
-            self._design_effect_diagnostics(self._df.shape[0])
-        )
-
-        outcome_means = None
-        if self._outcome_columns is not None:
-            outcome_means = self.outcomes().mean()
-
-        return _build_summary(
-            is_adjusted=self.is_adjusted(),
-            has_target=self.has_target(),
-            covars_asmd=covars_asmd,
-            covars_kld=covars_kld,
-            asmd_improvement_pct=asmd_improvement_pct,
-            quick_adjustment_details=quick_adjustment_details,
-            design_effect=design_effect,
-            effective_sample_size=effective_sample_size,
-            effective_sample_proportion=effective_sample_proportion,
-            model_dict=self.model(),
-            outcome_means=outcome_means,
-        )
-
-    def diagnostics(
-        self: "Sample",
-        weights_impact_on_outcome_method: str | None = "t_test",
-        weights_impact_on_outcome_conf_level: float = 0.95,
-    ) -> pd.DataFrame:
-        # TODO: mention the other diagnostics
-        # TODO: update/improve the wiki pages doc is linking to.
-        # TODO: move explanation on weights normalization to some external page
-        """
-        Output a table of diagnostics about adjusted Sample object.
-
-        size
-        ======================
-        All values in the "size" metrics are AFTER any rows/columns were filtered.
-        So, for example, if we use respondents from previous days but filter them for diagnostics purposes, then
-        sample_obs and target_obs will NOT include them in the counting. The same is true for sample_covars and target_covars.
-        In the "size" metrics we have the following 'var's:
-        - sample_obs - number of respondents
-        - sample_covars -  number of covariates (main covars, before any transformations were used)
-        - target_obs - number of users used to represent the target pop
-        - target_covars - like sample_covars, but for target.
-
-        weights_diagnostics
-        ======================
-        In the "weights_diagnostics" metric we have the following 'var's:
-        - design effect (de), effective sample size (n/de), effective sample ratio (1/de). See also:
-            - https://en.wikipedia.org/wiki/Design_effect
-            - https://en.wikipedia.org/wiki/Effective_sample_size
-        - sum
-        - describe of the (normalized to sample size) weights (mean, median, std, etc.)
-        - prop of the (normalized to sample size) weights that are below or above some numbers (1/2, 1, 2, etc.)
-        - nonparametric_skew and weighted_median_breakdown_point
-
-        Why is the diagnostics focused on weights normalized to sample size
-        -------------------------------------------------------------------
-        There are 3 well known normalizations of weights:
-        1. to sum to 1
-        2. to sum to target population
-        3. to sum to n (sample size)
-
-        Each one has their own merits:
-        1. is good if wanting to easily calculate avg of some response var (then we just use sum(w*y) and no need for /sum(w))
-        2. is good for sum of stuff. For example, how many people in the US use android? For this we'd like the weight of
-            each person to represent their share of the population and then we just sum the weights of the people who use android in the survey.
-        3. is good for understanding relative "importance" of a respondent as compared to the weights of others in the survey.
-            So if someone has a weight that is >1 it means that this respondent (conditional on their covariates) was 'rare' in the survey,
-            so the model we used decided to give them a larger weight to account for all the people like him/her that didn't answer.
-
-        For diagnostics purposes, option 3 is most useful for discussing the distribution of the weights
-        (e.g.: how many respondents got a weight >2 or smaller <0.5).
-        This is a method (standardized  across surveys) to helping us identify how many of the respondents are "dominating"
-        and have a large influence on the conclusion we draw from the survey.
-
-        model_glance
-        ======================
-        Properties of the model fitted, depends on the model used for weighting.
-
-        covariates ASMD
-        ======================
-        Includes covariates ASMD before and after adjustment (per level of covariate and aggregated) and the ASMD improvement.
-
-        Args:
-            self (Sample): only after running an adjustment with Sample.adjust.
-            weights_impact_on_outcome_method (Optional[str]): If provided, include
-                outcome-weight impact diagnostics using the specified method.
-                Defaults to "t_test".
-            weights_impact_on_outcome_conf_level (float): Confidence level for
-                the outcome impact interval. Defaults to 0.95.
-
-        Returns:
-            pd.DataFrame: with 3 columns: ("metric", "val", "var"),
-                indicating various tracking metrics on the model.
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            target = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["3", "4"], "x": [0, 1], "weight": [1.0, 1.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            adjusted = sample.set_target(target).adjust(method="null")
-            adjusted.diagnostics().columns.tolist()
-            # ['metric', 'val', 'var']
-        """
-        logger.info("Starting computation of diagnostics of the fitting")
-        self._check_if_adjusted()
-
-        # Compute outcome impact if applicable
-        outcome_impact = None
-        if (
-            weights_impact_on_outcome_method is not None
-            and self._outcome_columns is not None
-        ):
-            outcome_impact = self.outcomes().weights_impact_on_outcome_ss(
-                method=weights_impact_on_outcome_method,
-                conf_level=weights_impact_on_outcome_conf_level,
-                round_ndigits=None,
-            )
-
-        result = _build_diagnostics(
-            covars_df=self.covars().df,
-            target_covars_df=self._links["target"].covars().df,
-            weights_summary=self.weights().summary(),
-            model_dict=self.model(),
-            covars_asmd=self.covars().asmd(),
-            covars_asmd_main=self.covars().asmd(aggregate_by_main_covar=True),
-            outcome_columns=self._outcome_columns,
-            weights_impact_on_outcome_method=weights_impact_on_outcome_method,
-            weights_impact_on_outcome_conf_level=weights_impact_on_outcome_conf_level,
-            outcome_impact=outcome_impact,
-        )
-
-        logger.info("Done computing diagnostics")
-        return result
-
-    ############################################
-    # Column and rows modifiers - use carefully!
-    ############################################
-    def keep_only_some_rows_columns(
-        self: "Sample",
-        rows_to_keep: str | None = None,
-        columns_to_keep: List[str] | None = None,
-    ) -> "Sample":
-        # TODO: split this into two functions (one for rows and one for columns)
-        """
-        This function returns the sample object after filtering rows and/or columns from _df and _links objects
-        (which includes unadjusted and target objects).
-
-        This function is useful when wanting to calculate metrics, such as ASMD, but only on some of the features,
-        or part of the observations.
-
-        Args:
-            self (Sample): a sample object (preferably after adjustment)
-            rows_to_keep (str | None, optional): A string with a condition to eval (on some of the columns).
-                This will run df.eval(rows_to_keep) which will return a pd.Series of bool by which
-                we will filter the Sample object.
-                This effects both the df of covars AND the weights column (weight_column)
-                AND the outcome column (_outcome_columns), AND the id_column column.
-                Input should be a boolean feature, or a condition such as: 'gender == "Female" & age >= 18'.
-                Defaults to None.
-            columns_to_keep (List[str] | None, optional): the covariates of interest.
-                Defaults to None, which returns all columns.
-
-        Returns:
-            Sample: If both rows and columns to keep are None, returns the original object unchanged.
-                Otherwise, returns a copy of the original object with filtering applied - first the rows, then the columns.
-                This performs the transformation on both the sample's df and its linked dfs (unadjusted, target).
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {
-                        "id": ["1", "2"],
-                        "x": [0, 1],
-                        "weight": [1.0, 2.0],
-                        "y": [0.1, 0.2],
-                    }
-                ),
-                id_column="id",
-                weight_column="weight",
-                outcome_columns="y",
-                standardize_types=False,
-            )
-            sample.keep_only_some_rows_columns(rows_to_keep="x == 1").df.shape
-            # (1, 4)
-        """
-        if (rows_to_keep is None) and (columns_to_keep is None):
-            return self
-
-        # Let's make sure to not ruin our old object:
-        self = deepcopy(self)
-
-        if rows_to_keep is not None:
-            # let's filter the weights Series and then the df rows
-            ss = self.df.eval(rows_to_keep)  # rows to keep after the subset # noqa
-            logger.info(
-                f"From self -> (rows_filtered/total_rows) = ({ss.sum()}/{len(ss)})"
-            )
-            # filter ids
-            self.id_column = self.id_column[ss]
-            # filter weights
-            self.weight_column = self.weight_column[ss]
-            # filter _df
-            self._df = self._df[ss]
-            # filter outcomes
-            if self._outcome_columns is not None:
-                self._outcome_columns = self._outcome_columns[ss]
-            # filter links
-            for k, v in self._links.items():
-                try:
-                    ss = v.df.eval(rows_to_keep)  # rows to keep after the subset # noqa
-                    logger.info(
-                        f"From {k} -> (rows_filtered/total_rows) = ({ss.sum()}/{len(ss)})"
-                    )
-                    v.id_column = v.id_column[ss]
-                    v.weight_column = v.weight_column[ss]
-                    v._df = v._df[ss]
-                    if v._outcome_columns is not None:
-                        v._outcome_columns = v._outcome_columns[ss]
-                except pd.errors.UndefinedVariableError:
-                    # This can happen, for example, if the row filtering condition depends somehow on a feature that is
-                    # in the sample but not in the _links. For example, if filtering over one of the
-                    # outcome variables, it would filter out these rows from sample, but it wouldn't have this column to
-                    # use in target. So this is meant to capture that when this happens the function won't fail but simply
-                    # report it to the user.
-                    logger.warning(
-                        f"couldn't filter _links['{k}'] using {rows_to_keep}"
-                    )
-
-        if columns_to_keep is not None:
-            if not (set(columns_to_keep) <= set(self.df.columns)):
-                logger.warning(
-                    "Note that not all columns_to_keep are in Sample. Only those exists are removed"
-                )
-            # let's remove columns...
-            self._df = self._df.loc[:, self._df.columns.isin(columns_to_keep)]
-            for v in self._links.values():
-                v._df = v._df.loc[:, v._df.columns.isin(columns_to_keep)]
-
-        return self
-
-    ################
-    # Saving results
-    ################
-    def to_download(self, tempdir: str | None = None) -> FileLink:
-        """Creates a downloadable link of the DataFrame of the Sample object.
-
-        File name starts with tmp_balance_out_, and some random file name (using :func:`uuid.uuid4`).
-
-        Args:
-            self (Sample): Object.
-            tempdir (str | None, optional): Defaults to None (which then uses a temporary folder using :func:`tempfile.gettempdir`).
-
-        Returns:
-            FileLink: Embedding a local file link in an IPython session, based on path. Using :func:FileLink.
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            import tempfile
-            from IPython.lib.display import FileLink
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            isinstance(sample.to_download(tempdir=tempfile.gettempdir()), FileLink)
-            # True
-        """
-        return balance_util._to_download(self.df, tempdir)
-
-    def to_csv(
-        self, path_or_buf: FilePathOrBuffer | None = None, **kwargs: Any
-    ) -> str | None:
-        """Write df with ids from BalanceDF to a comma-separated values (csv) file.
-
-        Uses :func:`pd.DataFrame.to_csv`.
-
-        If an 'index' argument is not provided then it defaults to False.
-
-        Args:
-            self: Object.
-            path_or_buf (FilePathOrBuffer | None, optional): location where to save the csv.
-
-        Returns:
-            str | None: If path_or_buf is None, returns the resulting csv format as a string. Otherwise returns None.
-
-        Examples:
-        .. code-block:: python
-
-            import pandas as pd
-            from balance.sample_class import Sample
-            sample = Sample.from_frame(
-                pd.DataFrame(
-                    {"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}
-                ),
-                id_column="id",
-                weight_column="weight",
-                standardize_types=False,
-            )
-            csv_text = sample.to_csv()
-            "id" in csv_text
-            # True
-        """
-        return to_csv_with_defaults(self.df, path_or_buf, **kwargs)
-
-    ################################################################################
-    #  Private API
-    ################################################################################
-
-    ##################
-    # Column accessors
-    ##################
-    def _special_columns_names(self: "Sample") -> List[str]:
-        """
-        Returns names of all special columns (id column,
-        weight column, outcome columns, and ignored columns) in Sample.
-
-        Returns:
-            List[str]: names of special columns
-        """
-        return (
-            [i.name for i in [self.id_column, self.weight_column] if i is not None]
-            + (
-                self._outcome_columns.columns.tolist()
-                if self._outcome_columns is not None
-                else []
-            )
-            + getattr(self, "_ignored_column_names", [])
-        )
-
-    # TODO: _special_columns is just like df. Unclear if we need both or not, and why.
-    def _special_columns(self: "Sample") -> pd.DataFrame:
-        """
-        Returns dataframe of all special columns (id column,
-        weight column and outcome columns) in Sample.
-
-        Returns:
-            pd.DataFrame: special columns
-        """
-        return self._df[self._special_columns_names()]
-
-    def _covar_columns_names(self: "Sample") -> List[str]:
-        """
-        Returns names of all covars in Sample.
-
-        Returns:
-            List[str]: names of covars
-        """
-        return [
-            c for c in self._df.columns.values if c not in self._special_columns_names()
-        ]
-
-    def _covar_columns(self: "Sample") -> pd.DataFrame:
-        """
-        Returns dataframe of all covars columns in Sample.
-
-        Returns:
-            pd.DataFrame: covars columns
-        """
-        return self._df[self._covar_columns_names()]
-
-    ################
-    #  Errors checks
-    ################
-    def _check_if_adjusted(self) -> None:
-        """
-        Raises a ValueError if sample is not adjusted
-        """
-        if not self.is_adjusted():
-            raise ValueError(
-                "This is not an adjusted Sample. Use sample.adjust to adjust the sample to target"
-            )
-
-    def _no_target_error(self: "Sample") -> None:
-        """
-        Raises a ValueError if sample doesn't have target
-        """
-        if not self.has_target():
-            raise ValueError(
-                "This Sample does not have a target set. Use sample.set_target to add target"
-            )
-
-    def _check_outcomes_exists(self) -> None:
-        """
-        Raises a ValueError if sample doesn't have outcome_columns specified.
-        """
-        if self.outcomes() is None:
-            raise ValueError("This Sample does not have outcome columns specified")

--- a/balance/sample_frame.py
+++ b/balance/sample_frame.py
@@ -63,7 +63,7 @@ class SampleFrame:
     # pyre-fixme[13]: Initialized in _create() which bypasses __init__
     _column_roles: dict[str, list[str]]
     # pyre-fixme[13]: Initialized in _create() which bypasses __init__
-    _active_weight_column: str | None
+    _weight_column_name: str | None
     # pyre-fixme[13]: Initialized in _create() which bypasses __init__
     _weight_metadata: dict[str, Any]
     # pyre-fixme[13]: Initialized in _create() which bypasses __init__
@@ -116,7 +116,7 @@ class SampleFrame:
         new_instance._df = self._df.copy()
         new_instance._id_column_name = self._id_column_name
         new_instance._column_roles = deepcopy(self._column_roles, memo)
-        new_instance._active_weight_column = self._active_weight_column
+        new_instance._weight_column_name = self._weight_column_name
         new_instance._weight_metadata = deepcopy(self._weight_metadata, memo)
         new_instance._links = deepcopy(getattr(self, "_links", {}), memo)
         _df_dtypes = getattr(self, "_df_dtypes", None)
@@ -147,7 +147,7 @@ class SampleFrame:
             "predicted": list(predicted_outcome_columns or []),
             "ignored": list(ignored_columns or []),
         }
-        instance._active_weight_column = weight_columns[0] if weight_columns else None
+        instance._weight_column_name = weight_columns[0] if weight_columns else None
         # Defaults; set via set_weight_metadata() etc.
         instance._weight_metadata = {}
         instance._links = {}
@@ -446,7 +446,7 @@ class SampleFrame:
         return list(self._column_roles["covars"])
 
     @property
-    def weight_columns(self) -> list[str]:
+    def weight_columns_all(self) -> list[str]:
         """Names of all registered weight columns.
 
         Returns a copy so that callers cannot accidentally mutate the
@@ -462,7 +462,7 @@ class SampleFrame:
             ...     df=pd.DataFrame({"id": [1], "x": [10], "w1": [1.0], "w2": [2.0]}),
             ...     id_column="id", covar_columns=["x"],
             ...     weight_columns=["w1", "w2"])
-            >>> sf.weight_columns
+            >>> sf.weight_columns_all
             ['w1', 'w2']
         """
         return list(self._column_roles["weights"])
@@ -531,7 +531,7 @@ class SampleFrame:
         return list(self._column_roles["ignored"])
 
     @property
-    def active_weight_column(self) -> str | None:
+    def weight_column(self) -> str | None:
         """Name of the currently active weight column, or None.
 
         Returns:
@@ -543,10 +543,10 @@ class SampleFrame:
             >>> df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20],
             ...                    "weight": [1.0, 2.0]})
             >>> sf = SampleFrame.from_frame(df)
-            >>> sf.active_weight_column
+            >>> sf.weight_column
             'weight'
         """
-        return self._active_weight_column
+        return self._weight_column_name
 
     @property
     def id_column_name(self) -> str:
@@ -614,8 +614,8 @@ class SampleFrame:
             >>> list(sf.df_weights["weight"])  # internal data unchanged
             [1.0, 2.0]
         """
-        if self._active_weight_column:
-            return self._df[[self._active_weight_column]].copy()
+        if self._weight_column_name:
+            return self._df[[self._weight_column_name]].copy()
         return pd.DataFrame(index=self._df.index)
 
     @property
@@ -692,7 +692,7 @@ class SampleFrame:
         return self._df[self._id_column_name].copy()
 
     @property
-    def weight_column(self) -> pd.Series:
+    def weight_series(self) -> pd.Series:
         """Active weight column as a Series (BalanceDFSource protocol).
 
         Returns the active weight column values as a ``pd.Series``.  This is
@@ -712,12 +712,12 @@ class SampleFrame:
             >>> df = pd.DataFrame({"id": [1, 2], "x": [10, 20],
             ...                    "weight": [1.0, 2.0]})
             >>> sf = SampleFrame.from_frame(df)
-            >>> sf.weight_column.tolist()
+            >>> sf.weight_series.tolist()
             [1.0, 2.0]
         """
-        if not self._active_weight_column:
+        if not self._weight_column_name:
             raise ValueError("No active weight column is set.")
-        return self._df[self._active_weight_column].copy()
+        return self._df[self._weight_column_name].copy()
 
     def _covar_columns(self) -> pd.DataFrame:
         """Return the covariate DataFrame (BalanceDFSource protocol).
@@ -787,22 +787,22 @@ class SampleFrame:
             ...                    "weight": [1.0, 2.0]})
             >>> sf = SampleFrame.from_frame(df)
             >>> sf.set_weights(pd.Series([3.0, 4.0]))
-            >>> sf.weight_column.tolist()
+            >>> sf.weight_series.tolist()
             [3.0, 4.0]
         """
-        if not self._active_weight_column:
+        if not self._weight_column_name:
             raise ValueError("No active weight column is set.")
         if weights is None:
-            self._df[self._active_weight_column] = 1.0
+            self._df[self._weight_column_name] = 1.0
         elif isinstance(weights, (int, float)):
-            self._df[self._active_weight_column] = float(weights)
+            self._df[self._weight_column_name] = float(weights)
         else:
             if len(weights) != len(self._df):
                 raise ValueError(
                     f"'weights' length ({len(weights)}) doesn't match "
                     f"DataFrame length ({len(self._df)})"
                 )
-            self._df[self._active_weight_column] = weights.to_numpy()
+            self._df[self._weight_column_name] = weights.to_numpy()
 
     # --- BalanceDF integration ---
 
@@ -942,7 +942,7 @@ class SampleFrame:
             {}
         """
         if column is None:
-            column = self._active_weight_column
+            column = self._weight_column_name
         return self._weight_metadata.get(column, {}) if column is not None else {}
 
     def set_active_weight(self, column_name: str) -> None:
@@ -972,7 +972,7 @@ class SampleFrame:
                 f"'{column_name}' is not a weight column. "
                 f"Weight columns: {self._column_roles['weights']}"
             )
-        self._active_weight_column = column_name
+        self._weight_column_name = column_name
 
     def rename_weight_column(self, old_name: str, new_name: str) -> None:
         """Rename a weight column in-place.
@@ -1004,8 +1004,8 @@ class SampleFrame:
         idx = self._column_roles["weights"].index(old_name)
         self._column_roles["weights"][idx] = new_name
         # Update active weight pointer
-        if self._active_weight_column == old_name:
-            self._active_weight_column = new_name
+        if self._weight_column_name == old_name:
+            self._weight_column_name = new_name
         # Migrate metadata
         if old_name in self._weight_metadata:
             self._weight_metadata[new_name] = self._weight_metadata.pop(old_name)
@@ -1134,7 +1134,7 @@ class SampleFrame:
             )
 
         _id_col = sample.id_column
-        _weight_col = sample.weight_column
+        _weight_col = sample.weight_series
         if _id_col is None:
             raise ValueError(
                 "Sample must have an id_column before converting to SampleFrame."
@@ -1177,7 +1177,7 @@ class SampleFrame:
         return (
             f"SampleFrame: {n_obs} observations x {n_covars} covariates: {covar_names}\n"
             f"  id_column: {self._id_column_name}, "
-            f"weight_columns: {self._column_roles['weights']}, "
+            f"weight_columns_all: {self._column_roles['weights']}, "
             f"outcome_columns: {outcome_info}"
         )
 

--- a/balance/sample_frame.py
+++ b/balance/sample_frame.py
@@ -7,7 +7,7 @@
 
 """SampleFrame: an explicit-role DataFrame container for the Balance library.
 
-Stores covariates, weights, outcomes, predicted, and misc columns with
+Stores covariates, weights, outcomes, predicted, and ignored columns with
 explicit role metadata, replacing the inference-by-exclusion pattern used
 in the legacy Sample class.
 """
@@ -22,7 +22,7 @@ import numpy as np
 import pandas as pd
 
 if TYPE_CHECKING:
-    from balance.balancedf_class import BalanceDFSource
+    from balance.balancedf_class import BalanceDFSource  # noqa: F401
 
 
 logger: logging.Logger = logging.getLogger(__package__)
@@ -33,7 +33,7 @@ class SampleFrame:
 
     SampleFrame stores data as a single internal pd.DataFrame but with
     explicit metadata tracking which columns belong to which role:
-    covars (X), weights (W), outcomes (Y), predicted_outcomes (Y_hat), misc.
+    covars (X), weights (W), outcomes (Y), predicted_outcomes (Y_hat), ignored.
 
     Must be constructed via SampleFrame.from_frame() or SampleFrame.from_sample().
 
@@ -66,27 +66,17 @@ class SampleFrame:
     _active_weight_column: str | None
     # pyre-fixme[13]: Initialized in _create() which bypasses __init__
     _weight_metadata: dict[str, Any]
+    # pyre-fixme[13]: Initialized in _create() which bypasses __init__
+    _links: dict[str, Any]
+    # pyre-fixme[13]: Initialized in _create() which bypasses __init__
+    _df_dtypes: pd.Series | None
     # SampleFrame is a single-DataFrame container and does NOT manage
-    # multi-sample relationships.  _links is exposed as a read-only property
-    # returning an empty dict to satisfy the BalanceDFSource protocol.
-    # Link management belongs in BalanceDF/BalanceFrame, which can pass
-    # explicit links via the BalanceDF(links=...) parameter.
+    # multi-sample relationships.  _links is initialised to an empty dict
+    # in _create() to satisfy the BalanceDFSource protocol.  BalanceFrame
+    # overrides _links with a defaultdict(list) in its own _create().
 
     def __init__(self) -> None:
-        raise NotImplementedError(
-            "SampleFrame must be constructed via from_frame() or from_sample(). "
-            "Direct construction is not supported."
-        )
-
-    @property
-    def _links(self) -> dict[str, BalanceDFSource]:
-        """Return an empty links dict (satisfies BalanceDFSource protocol).
-
-        SampleFrame is a single-DataFrame container and does not manage
-        multi-sample relationships.  Link management belongs in
-        BalanceDF/BalanceFrame.
-        """
-        return {}
+        pass
 
     def __len__(self) -> int:
         """Return the number of rows in the SampleFrame.
@@ -121,13 +111,16 @@ class SampleFrame:
             >>> sf2._df is sf._df
             False
         """
-        new_instance = object.__new__(SampleFrame)
+        new_instance = object.__new__(type(self))
         memo[id(self)] = new_instance
         new_instance._df = self._df.copy()
         new_instance._id_column_name = self._id_column_name
         new_instance._column_roles = deepcopy(self._column_roles, memo)
         new_instance._active_weight_column = self._active_weight_column
         new_instance._weight_metadata = deepcopy(self._weight_metadata, memo)
+        new_instance._links = deepcopy(getattr(self, "_links", {}), memo)
+        _df_dtypes = getattr(self, "_df_dtypes", None)
+        new_instance._df_dtypes = _df_dtypes.copy() if _df_dtypes is not None else None
         return new_instance
 
     @classmethod
@@ -139,8 +132,9 @@ class SampleFrame:
         weight_columns: list[str],
         outcome_columns: list[str] | None = None,
         predicted_outcome_columns: list[str] | None = None,
-        misc_columns: list[str] | None = None,
+        ignore_columns: list[str] | None = None,
         _skip_copy: bool = False,
+        _df_dtypes: pd.Series | None = None,
     ) -> SampleFrame:
         """Internal factory method. Use from_frame() instead."""
         instance = object.__new__(cls)
@@ -151,11 +145,13 @@ class SampleFrame:
             "weights": list(weight_columns),
             "outcomes": list(outcome_columns or []),
             "predicted": list(predicted_outcome_columns or []),
-            "misc": list(misc_columns or []),
+            "ignored": list(ignore_columns or []),
         }
         instance._active_weight_column = weight_columns[0] if weight_columns else None
         # Defaults; set via set_weight_metadata() etc.
         instance._weight_metadata = {}
+        instance._links = {}
+        instance._df_dtypes = _df_dtypes
         return instance
 
     # --- Construction ---
@@ -169,7 +165,7 @@ class SampleFrame:
         weight_column: str | None = None,
         outcome_columns: list[str] | tuple[str, ...] | str | None = None,
         predicted_outcome_columns: list[str] | tuple[str, ...] | str | None = None,
-        misc_columns: list[str] | tuple[str, ...] | str | None = None,
+        ignore_columns: list[str] | tuple[str, ...] | str | None = None,
         check_id_uniqueness: bool = True,
         standardize_types: bool = True,
         use_deepcopy: bool = True,
@@ -190,7 +186,7 @@ class SampleFrame:
                 (``"id"``, ``"ID"``, etc.).
             covars_columns (list of str, optional): Explicit list of covariate
                 column names. If None, inferred by exclusion (all columns
-                minus id, weight, outcome, predicted, and misc columns).
+                minus id, weight, outcome, predicted, and ignored columns).
             weight_column (str, optional): Name of the column containing
                 sampling weights. If None, guesses ``"weight"``/``"weights"``
                 or creates one filled with 1.0.
@@ -198,8 +194,8 @@ class SampleFrame:
                 treat as outcome variables.
             predicted_outcome_columns (list of str or str, optional): Column
                 names to treat as predicted outcome variables.
-            misc_columns (list of str or str, optional): Column names to treat
-                as miscellaneous (excluded from covariates).
+            ignore_columns (list of str or str, optional): Column names to
+                ignore (excluded from covariates).
             check_id_uniqueness (bool): Whether to verify id uniqueness.
                 Defaults to True.
             standardize_types (bool): Whether to standardize dtypes.
@@ -208,14 +204,13 @@ class SampleFrame:
                 Defaults to True.
             id_column_candidates (list of str, optional): Candidate id column
                 names to try when ``id_column`` is None.
-
         Returns:
             SampleFrame: A validated SampleFrame with standardized dtypes.
 
         Raises:
             ValueError: If the id column contains nulls or duplicates, if the
                 weight column contains nulls or negative values, or if
-                specified outcome/predicted/misc columns are missing from the
+                specified outcome/predicted/ignore columns are missing from the
                 DataFrame.
 
         Examples:
@@ -238,8 +233,8 @@ class SampleFrame:
             outcome_columns = [outcome_columns]
         if isinstance(predicted_outcome_columns, str):
             predicted_outcome_columns = [predicted_outcome_columns]
-        if isinstance(misc_columns, str):
-            misc_columns = [misc_columns]
+        if isinstance(ignore_columns, str):
+            ignore_columns = [ignore_columns]
 
         # Deep copy
         df_dtypes = df.dtypes
@@ -364,14 +359,21 @@ class SampleFrame:
                     f"predicted outcome columns {list(missing_predicted)} not in df columns {_df.columns.values.tolist()}"
                 )
 
-        # --- Misc columns validation ---
-        misc_list: list[str] | None = None
-        if misc_columns is not None:
-            misc_list = list(misc_columns)
-            missing_misc = set(misc_list).difference(_df.columns)
-            if missing_misc:
+        # --- Ignore columns validation ---
+        ignore_list: list[str] | None = None
+        if ignore_columns is not None:
+            ignore_list = list(dict.fromkeys(ignore_columns))  # deduplicate
+            missing_ignore = set(ignore_list).difference(_df.columns)
+            if missing_ignore:
                 raise ValueError(
-                    f"misc columns {list(missing_misc)} not in df columns {_df.columns.values.tolist()}"
+                    f"ignore columns {list(missing_ignore)} not in df columns {_df.columns.values.tolist()}"
+                )
+            # ignore_columns must not overlap with id/weight columns
+            reserved = {id_col_name, weight_column} - {None}
+            overlap_reserved = set(ignore_list).intersection(reserved)
+            if overlap_reserved:
+                raise ValueError(
+                    f"ignore columns cannot include id/weight columns: {overlap_reserved}"
                 )
 
         # --- Covariate columns ---
@@ -384,7 +386,7 @@ class SampleFrame:
                 )
         else:
             # Infer by exclusion
-            ignored = (predicted_list or []) + (misc_list or [])
+            ignored = (predicted_list or []) + (ignore_list or [])
             special = {id_col_name, weight_column}
             special.update(outcome_list or [])
             special.update(ignored or [])
@@ -395,7 +397,7 @@ class SampleFrame:
             "covars": covar_list,
             "outcomes": outcome_list or [],
             "predicted": predicted_list or [],
-            "misc": misc_list or [],
+            "ignored": ignore_list or [],
         }
         roles = list(role_to_columns.keys())
         for i in range(len(roles)):
@@ -415,8 +417,9 @@ class SampleFrame:
             weight_columns=[weight_column],
             outcome_columns=outcome_list,
             predicted_outcome_columns=predicted_list,
-            misc_columns=misc_list,
+            ignore_columns=ignore_list,
             _skip_copy=True,
+            _df_dtypes=df_dtypes,
         )
 
     # --- Column role accessors ---
@@ -507,25 +510,25 @@ class SampleFrame:
         return list(self._column_roles["predicted"])
 
     @property
-    def misc_columns(self) -> list[str]:
-        """Names of the miscellaneous columns.
+    def ignore_columns(self) -> list[str]:
+        """Names of the ignored columns.
 
         Returns a copy so that callers cannot accidentally mutate the
         internal column-role registry.
 
         Returns:
-            list[str]: Misc column names (empty list if none).
+            list[str]: Ignored column names (empty list if none).
 
         Examples:
             >>> import pandas as pd
             >>> from balance.sample_frame import SampleFrame
             >>> df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20],
             ...                    "weight": [1.0, 1.0], "region": ["US", "UK"]})
-            >>> sf = SampleFrame.from_frame(df, misc_columns=["region"])
-            >>> sf.misc_columns
+            >>> sf = SampleFrame.from_frame(df, ignore_columns=["region"])
+            >>> sf.ignore_columns
             ['region']
         """
-        return list(self._column_roles["misc"])
+        return list(self._column_roles["ignored"])
 
     @property
     def active_weight_column(self) -> str | None:
@@ -641,53 +644,49 @@ class SampleFrame:
         return self._df[cols].copy() if cols else None
 
     @property
-    def df_misc(self) -> pd.DataFrame | None:
-        """Misc columns, or None.
+    def df_ignored(self) -> pd.DataFrame | None:
+        """Ignored columns, or None.
 
         Returns a copy so that callers cannot accidentally mutate the
         internal data.
 
         Returns:
-            pd.DataFrame | None: A copy of miscellaneous columns, or
-                None if no misc columns are registered.
+            pd.DataFrame | None: A copy of ignored columns, or
+                None if no ignored columns are registered.
 
         Examples:
             >>> import pandas as pd
             >>> from balance.sample_frame import SampleFrame
             >>> df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20],
             ...                    "weight": [1.0, 1.0], "region": ["US", "UK"]})
-            >>> sf = SampleFrame.from_frame(df, misc_columns=["region"])
-            >>> m = sf.df_misc
+            >>> sf = SampleFrame.from_frame(df, ignore_columns=["region"])
+            >>> m = sf.df_ignored
             >>> m["region"] = ["XX", "XX"]
-            >>> list(sf.df_misc["region"])  # internal data unchanged
+            >>> list(sf.df_ignored["region"])  # internal data unchanged
             ['US', 'UK']
         """
-        cols = self._column_roles["misc"]
+        cols = self._column_roles["ignored"]
         return self._df[cols].copy() if cols else None
 
     def ignored_columns(self) -> pd.DataFrame | None:
-        """Return ignored (misc) columns as a DataFrame, or None.
-
-        This is an alias for :attr:`df_misc`, provided for API parity with
-        :class:`~balance.sample_class.Sample` which uses ``ignored_columns()``
-        to access miscellaneous/ignored columns.
+        """Return ignored columns as a DataFrame, or None.
 
         Returns:
-            pd.DataFrame | None: A copy of miscellaneous columns, or
-                None if no misc columns are registered.
+            pd.DataFrame | None: A copy of ignored columns, or
+                None if no ignored columns are registered.
 
         Examples:
             >>> import pandas as pd
             >>> from balance.sample_frame import SampleFrame
             >>> df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20],
             ...                    "weight": [1.0, 1.0], "region": ["US", "UK"]})
-            >>> sf = SampleFrame.from_frame(df, misc_columns=["region"])
+            >>> sf = SampleFrame.from_frame(df, ignore_columns=["region"])
             >>> sf.ignored_columns()
                    region
             0     US
             1     UK
         """
-        return self.df_misc
+        return self.df_ignored
 
     @property
     def id_column(self) -> pd.Series:
@@ -827,11 +826,15 @@ class SampleFrame:
 
     # --- BalanceDF integration ---
 
-    def covars(self) -> Any:
+    def covars(self, formula: str | list[str] | None = None) -> Any:
         """Return a :class:`~balance.balancedf_class.BalanceDFCovars` for this SampleFrame.
 
         Creates a covariate analysis view backed by this SampleFrame,
         inheriting any linked sources set via ``_links``.
+
+        Args:
+            formula: Optional formula string (or list) for model matrix
+                construction. Passed through to BalanceDFCovars.
 
         Returns:
             BalanceDFCovars: Covariate view backed by this SampleFrame.
@@ -847,7 +850,8 @@ class SampleFrame:
         """
         from balance.balancedf_class import BalanceDFCovars
 
-        return BalanceDFCovars(self)
+        # pyre-ignore[6]: SampleFrame satisfies BalanceDFSource at runtime
+        return BalanceDFCovars(self, formula=formula)
 
     def weights(self) -> Any:
         """Return a :class:`~balance.balancedf_class.BalanceDFWeights` for this SampleFrame.
@@ -869,6 +873,7 @@ class SampleFrame:
         """
         from balance.balancedf_class import BalanceDFWeights
 
+        # pyre-ignore[6]: SampleFrame satisfies BalanceDFSource at runtime
         return BalanceDFWeights(self)
 
     def outcomes(self) -> Any | None:
@@ -895,6 +900,7 @@ class SampleFrame:
         # Deferred import to avoid circular dependency with balancedf_class
         from balance.balancedf_class import BalanceDFOutcomes
 
+        # pyre-ignore[6]: SampleFrame satisfies BalanceDFSource at runtime
         return BalanceDFOutcomes(self)
 
     @property
@@ -988,6 +994,42 @@ class SampleFrame:
             )
         self._active_weight_column = column_name
 
+    def rename_weight_column(self, old_name: str, new_name: str) -> None:
+        """Rename a weight column in-place.
+
+        Renames the column in the DataFrame, updates the column roles list,
+        active weight pointer, and weight metadata.
+
+        Args:
+            old_name: Current name of the weight column.
+            new_name: New name for the weight column.
+
+        Raises:
+            ValueError: If *old_name* is not a registered weight column,
+                or if *new_name* already exists in the DataFrame.
+        """
+        if old_name not in self._column_roles["weights"]:
+            raise ValueError(
+                f"'{old_name}' is not a weight column. "
+                f"Weight columns: {self._column_roles['weights']}"
+            )
+        if new_name in self._df.columns:
+            raise ValueError(
+                f"'{new_name}' already exists in the DataFrame. "
+                "Choose a different name."
+            )
+        # Rename in DataFrame
+        self._df = self._df.rename(columns={old_name: new_name})
+        # Update column roles
+        idx = self._column_roles["weights"].index(old_name)
+        self._column_roles["weights"][idx] = new_name
+        # Update active weight pointer
+        if self._active_weight_column == old_name:
+            self._active_weight_column = new_name
+        # Migrate metadata
+        if old_name in self._weight_metadata:
+            self._weight_metadata[new_name] = self._weight_metadata.pop(old_name)
+
     def add_weight_column(
         self,
         name: str,
@@ -1001,16 +1043,21 @@ class SampleFrame:
 
         Args:
             name (str): Name for the new weight column.
-            values (pd.Series): Weight values, must be the same length as
-                the DataFrame.
+            values (pd.Series): Weight values.  Must match the DataFrame
+                length, unless it is a shorter ``pd.Series`` — in which case
+                values are aligned by index and missing rows are filled with
+                NaN (this supports adjustment functions that drop rows
+                internally, e.g., ``na_action="drop"``).  Note: this column
+                is a *history* column, not the active weight — the active
+                weight is set separately via ``set_weights()``.
             metadata (dict, optional): Provenance metadata for the new
                 column.
 
         Raises:
             ValueError: If *name* is already a registered weight column,
                 if *name* already exists in the DataFrame as a non-weight
-                column, or if *values* has a different length than the
-                DataFrame.
+                column, or if *values* is longer than the DataFrame or is
+                a non-Series with a different length.
 
         Examples:
             >>> import pandas as pd
@@ -1034,10 +1081,16 @@ class SampleFrame:
                 f"Choose a different name."
             )
         if len(values) != len(self._df):
-            raise ValueError(
-                f"'values' length ({len(values)}) doesn't match "
-                f"DataFrame length ({len(self._df)})"
-            )
+            if isinstance(values, pd.Series) and len(values) < len(self._df):
+                # Align by index, padding missing rows with NaN.
+                # This supports adjustment functions that drop rows internally
+                # (e.g., na_action="drop") and return fewer weights.
+                values = values.reindex(self._df.index)
+            else:
+                raise ValueError(
+                    f"'values' length ({len(values)}) doesn't match "
+                    f"DataFrame length ({len(self._df)})"
+                )
         self._df[name] = values.to_numpy()
         self._column_roles["weights"].append(name)
         if metadata is not None:
@@ -1048,8 +1101,8 @@ class SampleFrame:
         """Convert a :class:`~balance.sample_class.Sample` to a SampleFrame.
 
         Preserves the Sample's tabular data and column role assignments:
-        id column, weight column, outcome columns, and ignored columns
-        (mapped to ``misc``).  Covariate columns are inferred by exclusion,
+        id column, weight column, outcome columns, and ignored columns.
+        Covariate columns are inferred by exclusion,
         matching the Sample's own logic.
 
         The internal DataFrame is deep-copied so that the resulting
@@ -1100,8 +1153,18 @@ class SampleFrame:
                 f"'sample' must be a Sample instance, got {type(sample).__name__}"
             )
 
-        id_col_name: str = sample.id_column.name
-        weight_col_name: str = sample.weight_column.name
+        _id_col = sample.id_column
+        _weight_col = sample.weight_column
+        if _id_col is None:
+            raise ValueError(
+                "Sample must have an id_column before converting to SampleFrame."
+            )
+        if _weight_col is None:
+            raise ValueError(
+                "Sample must have a weight_column before converting to SampleFrame."
+            )
+        id_col_name: str = str(_id_col.name)
+        weight_col_name: str = str(_weight_col.name)
 
         outcome_cols: list[str] | None = None
         if sample._outcome_columns is not None:
@@ -1119,7 +1182,7 @@ class SampleFrame:
             covars_columns=sample._covar_columns_names(),
             weight_columns=[weight_col_name],
             outcome_columns=outcome_cols,
-            misc_columns=ignored_cols if ignored_cols else None,
+            ignore_columns=ignored_cols if ignored_cols else None,
         )
 
     def __repr__(self) -> str:

--- a/balance/sample_frame.py
+++ b/balance/sample_frame.py
@@ -132,7 +132,7 @@ class SampleFrame:
         weight_columns: list[str],
         outcome_columns: list[str] | None = None,
         predicted_outcome_columns: list[str] | None = None,
-        ignore_columns: list[str] | None = None,
+        ignored_columns: list[str] | None = None,
         _skip_copy: bool = False,
         _df_dtypes: pd.Series | None = None,
     ) -> SampleFrame:
@@ -145,7 +145,7 @@ class SampleFrame:
             "weights": list(weight_columns),
             "outcomes": list(outcome_columns or []),
             "predicted": list(predicted_outcome_columns or []),
-            "ignored": list(ignore_columns or []),
+            "ignored": list(ignored_columns or []),
         }
         instance._active_weight_column = weight_columns[0] if weight_columns else None
         # Defaults; set via set_weight_metadata() etc.
@@ -165,7 +165,7 @@ class SampleFrame:
         weight_column: str | None = None,
         outcome_columns: list[str] | tuple[str, ...] | str | None = None,
         predicted_outcome_columns: list[str] | tuple[str, ...] | str | None = None,
-        ignore_columns: list[str] | tuple[str, ...] | str | None = None,
+        ignored_columns: list[str] | tuple[str, ...] | str | None = None,
         check_id_uniqueness: bool = True,
         standardize_types: bool = True,
         use_deepcopy: bool = True,
@@ -194,7 +194,7 @@ class SampleFrame:
                 treat as outcome variables.
             predicted_outcome_columns (list of str or str, optional): Column
                 names to treat as predicted outcome variables.
-            ignore_columns (list of str or str, optional): Column names to
+            ignored_columns (list of str or str, optional): Column names to
                 ignore (excluded from covariates).
             check_id_uniqueness (bool): Whether to verify id uniqueness.
                 Defaults to True.
@@ -233,8 +233,8 @@ class SampleFrame:
             outcome_columns = [outcome_columns]
         if isinstance(predicted_outcome_columns, str):
             predicted_outcome_columns = [predicted_outcome_columns]
-        if isinstance(ignore_columns, str):
-            ignore_columns = [ignore_columns]
+        if isinstance(ignored_columns, str):
+            ignored_columns = [ignored_columns]
 
         # Deep copy
         df_dtypes = df.dtypes
@@ -361,14 +361,14 @@ class SampleFrame:
 
         # --- Ignore columns validation ---
         ignore_list: list[str] | None = None
-        if ignore_columns is not None:
-            ignore_list = list(dict.fromkeys(ignore_columns))  # deduplicate
+        if ignored_columns is not None:
+            ignore_list = list(dict.fromkeys(ignored_columns))  # deduplicate
             missing_ignore = set(ignore_list).difference(_df.columns)
             if missing_ignore:
                 raise ValueError(
                     f"ignore columns {list(missing_ignore)} not in df columns {_df.columns.values.tolist()}"
                 )
-            # ignore_columns must not overlap with id/weight columns
+            # ignored_columns must not overlap with id/weight columns
             reserved = {id_col_name, weight_column} - {None}
             overlap_reserved = set(ignore_list).intersection(reserved)
             if overlap_reserved:
@@ -417,7 +417,7 @@ class SampleFrame:
             weight_columns=[weight_column],
             outcome_columns=outcome_list,
             predicted_outcome_columns=predicted_list,
-            ignore_columns=ignore_list,
+            ignored_columns=ignore_list,
             _skip_copy=True,
             _df_dtypes=df_dtypes,
         )
@@ -510,7 +510,7 @@ class SampleFrame:
         return list(self._column_roles["predicted"])
 
     @property
-    def ignore_columns(self) -> list[str]:
+    def ignored_columns(self) -> list[str]:
         """Names of the ignored columns.
 
         Returns a copy so that callers cannot accidentally mutate the
@@ -524,8 +524,8 @@ class SampleFrame:
             >>> from balance.sample_frame import SampleFrame
             >>> df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20],
             ...                    "weight": [1.0, 1.0], "region": ["US", "UK"]})
-            >>> sf = SampleFrame.from_frame(df, ignore_columns=["region"])
-            >>> sf.ignore_columns
+            >>> sf = SampleFrame.from_frame(df, ignored_columns=["region"])
+            >>> sf.ignored_columns
             ['region']
         """
         return list(self._column_roles["ignored"])
@@ -659,7 +659,7 @@ class SampleFrame:
             >>> from balance.sample_frame import SampleFrame
             >>> df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20],
             ...                    "weight": [1.0, 1.0], "region": ["US", "UK"]})
-            >>> sf = SampleFrame.from_frame(df, ignore_columns=["region"])
+            >>> sf = SampleFrame.from_frame(df, ignored_columns=["region"])
             >>> m = sf.df_ignored
             >>> m["region"] = ["XX", "XX"]
             >>> list(sf.df_ignored["region"])  # internal data unchanged
@@ -667,26 +667,6 @@ class SampleFrame:
         """
         cols = self._column_roles["ignored"]
         return self._df[cols].copy() if cols else None
-
-    def ignored_columns(self) -> pd.DataFrame | None:
-        """Return ignored columns as a DataFrame, or None.
-
-        Returns:
-            pd.DataFrame | None: A copy of ignored columns, or
-                None if no ignored columns are registered.
-
-        Examples:
-            >>> import pandas as pd
-            >>> from balance.sample_frame import SampleFrame
-            >>> df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20],
-            ...                    "weight": [1.0, 1.0], "region": ["US", "UK"]})
-            >>> sf = SampleFrame.from_frame(df, ignore_columns=["region"])
-            >>> sf.ignored_columns()
-                   region
-            0     US
-            1     UK
-        """
-        return self.df_ignored
 
     @property
     def id_column(self) -> pd.Series:
@@ -1182,7 +1162,7 @@ class SampleFrame:
             covar_columns=sample._covar_columns_names(),
             weight_columns=[weight_col_name],
             outcome_columns=outcome_cols,
-            ignore_columns=ignored_cols if ignored_cols else None,
+            ignored_columns=ignored_cols if ignored_cols else None,
         )
 
     def __repr__(self) -> str:

--- a/balance/sample_frame.py
+++ b/balance/sample_frame.py
@@ -332,7 +332,13 @@ class SampleFrame:
                 + null_weight_rows.to_string(index=False)
             )
 
-        if not np.issubdtype(_df[weight_column].dtype, np.number):
+        try:
+            is_numeric = np.issubdtype(_df[weight_column].dtype, np.number)
+        except TypeError:
+            # Extension dtypes (e.g. pandas StringDtype) can't be interpreted
+            # by np.issubdtype — treat them as non-numeric.
+            is_numeric = False
+        if not is_numeric:
             raise ValueError("Weights must be numeric")
 
         if any(_df[weight_column] < 0):

--- a/balance/sample_frame.py
+++ b/balance/sample_frame.py
@@ -128,7 +128,7 @@ class SampleFrame:
         cls,
         df: pd.DataFrame,
         id_column: str,
-        covars_columns: list[str],
+        covar_columns: list[str],
         weight_columns: list[str],
         outcome_columns: list[str] | None = None,
         predicted_outcome_columns: list[str] | None = None,
@@ -141,7 +141,7 @@ class SampleFrame:
         instance._df = df if _skip_copy else df.copy()
         instance._id_column_name = id_column
         instance._column_roles = {
-            "covars": list(covars_columns),
+            "covars": list(covar_columns),
             "weights": list(weight_columns),
             "outcomes": list(outcome_columns or []),
             "predicted": list(predicted_outcome_columns or []),
@@ -161,7 +161,7 @@ class SampleFrame:
         cls,
         df: pd.DataFrame,
         id_column: str | None = None,
-        covars_columns: list[str] | None = None,
+        covar_columns: list[str] | None = None,
         weight_column: str | None = None,
         outcome_columns: list[str] | tuple[str, ...] | str | None = None,
         predicted_outcome_columns: list[str] | tuple[str, ...] | str | None = None,
@@ -184,7 +184,7 @@ class SampleFrame:
             id_column (str, optional): Name of the column to use as row
                 identifier. If None, guessed from common names
                 (``"id"``, ``"ID"``, etc.).
-            covars_columns (list of str, optional): Explicit list of covariate
+            covar_columns (list of str, optional): Explicit list of covariate
                 column names. If None, inferred by exclusion (all columns
                 minus id, weight, outcome, predicted, and ignored columns).
             weight_column (str, optional): Name of the column containing
@@ -377,8 +377,8 @@ class SampleFrame:
                 )
 
         # --- Covariate columns ---
-        if covars_columns is not None:
-            covar_list = list(covars_columns)
+        if covar_columns is not None:
+            covar_list = list(covar_columns)
             missing_covars = set(covar_list).difference(_df.columns)
             if missing_covars:
                 raise ValueError(
@@ -413,7 +413,7 @@ class SampleFrame:
         return cls._create(
             df=_df,
             id_column=id_col_name,
-            covars_columns=covar_list,
+            covar_columns=covar_list,
             weight_columns=[weight_column],
             outcome_columns=outcome_list,
             predicted_outcome_columns=predicted_list,
@@ -425,7 +425,7 @@ class SampleFrame:
     # --- Column role accessors ---
 
     @property
-    def covars_columns(self) -> list[str]:
+    def covar_columns(self) -> list[str]:
         """Names of the covariate columns.
 
         Returns a copy so that callers cannot accidentally mutate the
@@ -440,7 +440,7 @@ class SampleFrame:
             >>> df = pd.DataFrame({"id": ["1", "2"], "age": [25, 30],
             ...                    "income": [50000, 60000], "weight": [1.0, 1.0]})
             >>> sf = SampleFrame.from_frame(df)
-            >>> sf.covars_columns
+            >>> sf.covar_columns
             ['age', 'income']
         """
         return list(self._column_roles["covars"])
@@ -460,7 +460,7 @@ class SampleFrame:
             >>> from balance.sample_frame import SampleFrame
             >>> sf = SampleFrame._create(
             ...     df=pd.DataFrame({"id": [1], "x": [10], "w1": [1.0], "w2": [2.0]}),
-            ...     id_column="id", covars_columns=["x"],
+            ...     id_column="id", covar_columns=["x"],
             ...     weight_columns=["w1", "w2"])
             >>> sf.weight_columns
             ['w1', 'w2']
@@ -981,7 +981,7 @@ class SampleFrame:
             >>> from balance.sample_frame import SampleFrame
             >>> sf = SampleFrame._create(
             ...     df=pd.DataFrame({"id": [1], "x": [10], "w1": [1.0], "w2": [2.0]}),
-            ...     id_column="id", covars_columns=["x"],
+            ...     id_column="id", covar_columns=["x"],
             ...     weight_columns=["w1", "w2"])
             >>> sf.set_active_weight("w2")
             >>> list(sf.df_weights.columns)
@@ -1179,7 +1179,7 @@ class SampleFrame:
         return cls._create(
             df=df,
             id_column=id_col_name,
-            covars_columns=sample._covar_columns_names(),
+            covar_columns=sample._covar_columns_names(),
             weight_columns=[weight_col_name],
             outcome_columns=outcome_cols,
             ignore_columns=ignored_cols if ignored_cols else None,

--- a/balance/stats_and_plots/impact_of_weights_on_outcome.py
+++ b/balance/stats_and_plots/impact_of_weights_on_outcome.py
@@ -258,12 +258,12 @@ def _align_samples_by_id(
             "Outcome values differ between adjusted Samples for common ids."
         )
 
-    weights0 = _assert_type(adjusted0.weight_column).to_numpy()
+    weights0 = _assert_type(adjusted0.weight_series).to_numpy()
     weights0_series = pd.Series(weights0, index=ids0)
     weights0_aligned = weights0_series.reindex(common_ids).to_numpy()
 
     weights1_series = pd.Series(
-        _assert_type(adjusted1.weight_column).to_numpy(),
+        _assert_type(adjusted1.weight_series).to_numpy(),
         index=ids1,
     ).reindex(common_ids)
 

--- a/balance/stats_and_plots/impact_of_weights_on_outcome.py
+++ b/balance/stats_and_plots/impact_of_weights_on_outcome.py
@@ -12,6 +12,7 @@ from typing import Iterable, TYPE_CHECKING
 import numpy as np
 import pandas as pd
 from balance.stats_and_plots.weights_stats import _check_weights_are_valid
+from balance.util import _assert_type
 from balance.utils.input_validation import _coerce_to_numeric_and_validate
 from scipy import stats
 
@@ -236,13 +237,15 @@ def _align_samples_by_id(
         ValueError: If IDs have duplicates, no common IDs exist, outcome values
             differ, or no valid weights exist.
     """
-    ids0 = adjusted0.id_column.to_numpy()
-    ids1 = adjusted1.id_column.to_numpy()
+    id_col0 = _assert_type(adjusted0.id_column)
+    id_col1 = _assert_type(adjusted1.id_column)
+    ids0 = id_col0.to_numpy()
+    ids1 = id_col1.to_numpy()
     if pd.Index(ids0).has_duplicates or pd.Index(ids1).has_duplicates:
         raise ValueError("Samples must have unique ids to compare outcomes.")
 
-    y0_indexed = y0.set_index(adjusted0.id_column)
-    y1_indexed = y1.set_index(adjusted1.id_column)
+    y0_indexed = y0.set_index(id_col0)
+    y1_indexed = y1.set_index(id_col1)
 
     common_ids = y0_indexed.index.intersection(y1_indexed.index)
     if common_ids.empty:
@@ -255,12 +258,12 @@ def _align_samples_by_id(
             "Outcome values differ between adjusted Samples for common ids."
         )
 
-    weights0 = adjusted0.weight_column.to_numpy()
+    weights0 = _assert_type(adjusted0.weight_column).to_numpy()
     weights0_series = pd.Series(weights0, index=ids0)
     weights0_aligned = weights0_series.reindex(common_ids).to_numpy()
 
     weights1_series = pd.Series(
-        adjusted1.weight_column.to_numpy(),
+        _assert_type(adjusted1.weight_column).to_numpy(),
         index=ids1,
     ).reindex(common_ids)
 

--- a/balance/stats_and_plots/impact_of_weights_on_outcome.py
+++ b/balance/stats_and_plots/impact_of_weights_on_outcome.py
@@ -199,8 +199,8 @@ def _validate_adjusted_samples(
     if not isinstance(adjusted0, Sample) or not isinstance(adjusted1, Sample):
         raise ValueError("compare_adjusted_weighted_outcome_ss expects Sample inputs.")
 
-    adjusted0._check_if_adjusted()
-    adjusted1._check_if_adjusted()
+    adjusted0._require_adjusted()
+    adjusted1._require_adjusted()
 
     outcomes0 = adjusted0.outcomes()
     outcomes1 = adjusted1.outcomes()

--- a/balance/stats_and_plots/weighted_comparisons_plots.py
+++ b/balance/stats_and_plots/weighted_comparisons_plots.py
@@ -671,6 +671,10 @@ def seaborn_plot_dist(
     variables = choose_variables(*(d["df"] for d in dfs), variables=variables)
     logger.debug(f"plotting variables {variables}")
 
+    if len(variables) == 0:
+        logger.warning("No variables to plot — returning early.")
+        return [] if return_axes else None
+
     #  Set up subplots
     f, axes = plt.subplots(len(variables), 1, figsize=(7, 7 * len(variables)))
     axes_list: List[plt.Axes]

--- a/balance/utils/input_validation.py
+++ b/balance/utils/input_validation.py
@@ -245,7 +245,7 @@ def _check_weighting_methods_input(
 # This is so to avoid various cyclic imports (since various files call sample_class, and then sample_class also calls these files)
 # TODO: (p2) move away from this method once we restructure Sample and BalanceDF objects...
 def _isinstance_sample(obj: Any) -> bool:
-    """Check if an object is an instance of Sample.
+    """Check if an object is an instance of Sample, BalanceFrame, or SampleFrame.
 
     The import is done inside the function to avoid circular import issues at
     module load time. Since this module is part of the balance package, the
@@ -255,11 +255,10 @@ def _isinstance_sample(obj: Any) -> bool:
         obj: The object to check.
 
     Returns:
-        bool: True if obj is a Sample instance, False otherwise.
+        bool: True if obj has a ``covars()`` method (Sample, BalanceFrame,
+            or SampleFrame), False otherwise.
     """
-    from balance import sample_class
-
-    return isinstance(obj, sample_class.Sample)
+    return hasattr(obj, "covars") and callable(getattr(obj, "covars", None))
 
 
 def guess_id_column(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ target-version = ["py39", "py310", "py311", "py312", "py313"]
 first_party_detection = false
 
 [tool.pytest.ini_options]
+markers = [
+    "requires_sklearn_1_4: test requires scikit-learn >= 1.4 (deselected otherwise)",
+]
 filterwarnings = [
     # Ignore third-party deprecation warnings from matplotlib's internal dependencies
     "ignore:'oneOf' deprecated:DeprecationWarning:matplotlib._fontconfig_pattern",

--- a/scripts/make_docs.sh
+++ b/scripts/make_docs.sh
@@ -94,6 +94,8 @@ if [[ $ONLY_DOCUSAURUS == false ]]; then
     --output-dir website/static/html/tutorials
   jupyter nbconvert tutorials/comparing_cbps_in_r_vs_python_using_sim_data.ipynb --execute --to html \
     --output-dir website/static/html/tutorials
+  jupyter nbconvert tutorials/balance_quickstart_new_api.ipynb --execute --to html \
+    --output-dir website/static/html/tutorials
 fi
 
 echo "-----------------------------------"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,58 @@
 
 """Test configuration shared across pytest runs"""
 
+from __future__ import annotations
+
 import matplotlib
 
 # Force a non-interactive backend so tests do not require a Tk installation.
 matplotlib.use("Agg", force=True)
 
 import plotly.io as pio  # noqa: E402
+import pytest  # noqa: E402
 
 # Force plotly to use a non-interactive renderer so tests don't open a browser.
 pio.renderers.default = "json"
+
+
+# ---------------------------------------------------------------------------
+# Deselect (rather than skip) tests that require scikit-learn >= 1.4.
+#
+# Using ``@unittest.skipIf`` for version-gated tests emits noisy "SKIPPED"
+# warnings in CI output.  By deselecting at collection time the tests simply
+# disappear from the run — no warnings, no noise.
+# ---------------------------------------------------------------------------
+
+
+def _has_sklearn_1_4() -> bool:
+    """Return True if scikit-learn >= 1.4 is available."""
+    try:
+        import sklearn
+
+        return tuple(int(x) for x in sklearn.__version__.split(".")[:2]) >= (1, 4)
+    except Exception:
+        return False
+
+
+_SKLEARN_1_4_AVAILABLE: bool = _has_sklearn_1_4()
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Deselect tests marked ``requires_sklearn_1_4`` when sklearn < 1.4."""
+    if _SKLEARN_1_4_AVAILABLE:
+        return  # nothing to deselect
+
+    keep: list[pytest.Item] = []
+    deselected: list[pytest.Item] = []
+    for item in items:
+        if item.get_closest_marker("requires_sklearn_1_4"):
+            deselected.append(item)
+        else:
+            keep.append(item)
+
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = keep

--- a/tests/test_adjust_null.py
+++ b/tests/test_adjust_null.py
@@ -64,4 +64,10 @@ class TestAdjustNull(
         self.assertEqual(res["model"]["method"], "null_adjustment")
 
         result = sample.adjust(target, method="null")
-        self.assertEqual(sample.weights().df, result.weights().df)
+        # Weight values should be identical; column name may differ
+        # (BF uses "weight_adjusted" internally).
+        pd.testing.assert_series_equal(
+            sample.weights().df.iloc[:, 0],
+            result.weights().df.iloc[:, 0],
+            check_names=False,
+        )

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -45,21 +45,21 @@ class TestBalanceFrameConstruction(BalanceTestCase):
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
 
     def test_basic_construction(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
         self.assertIsInstance(bf, BalanceFrame)
         self.assertIs(bf.responders, self.resp_sf)
         self.assertIs(bf.target, self.tgt_sf)
 
     def test_is_adjusted_false_on_creation(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
         self.assertFalse(bf.is_adjusted)
 
     def test_unadjusted_none_on_creation(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
         self.assertIsNone(bf.unadjusted)
 
     def test_model_none_on_creation(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
         self.assertIsNone(bf.model())
 
     def test_missing_responders_raises(self) -> None:
@@ -67,7 +67,7 @@ class TestBalanceFrameConstruction(BalanceTestCase):
             BalanceFrame(sf_target=self.tgt_sf)
 
     def test_no_target_construction(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
+        bf = BalanceFrame(sample=self.resp_sf)
         self.assertIsInstance(bf, BalanceFrame)
         self.assertIs(bf.responders, self.resp_sf)
         self.assertIsNone(bf.target)
@@ -82,14 +82,14 @@ class TestBalanceFrameConstruction(BalanceTestCase):
     def test_non_sampleframe_responders_raises(self) -> None:
         with self.assertRaises(TypeError):
             BalanceFrame._create(
-                sf_with_outcomes="not a SampleFrame",  # pyre-ignore[6]
+                sample="not a SampleFrame",  # pyre-ignore[6]
                 sf_target=self.tgt_sf,
             )
 
     def test_non_sampleframe_target_raises(self) -> None:
         with self.assertRaises(TypeError):
             BalanceFrame._create(
-                sf_with_outcomes=self.resp_sf,
+                sample=self.resp_sf,
                 sf_target=pd.DataFrame(),  # pyre-ignore[6]
             )
 
@@ -109,7 +109,7 @@ class TestBalanceFrameCovarOverlap(BalanceTestCase):
             weight_columns=["w"],
         )
         with self.assertRaises(ValueError) as ctx:
-            BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+            BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         self.assertIn("no covariate columns", str(ctx.exception))
 
     def test_partial_overlap_warns(self) -> None:
@@ -126,7 +126,7 @@ class TestBalanceFrameCovarOverlap(BalanceTestCase):
             weight_columns=["w"],
         )
         with self.assertLogs("balance", level="WARNING") as cm:
-            bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+            bf = BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         self.assertTrue(any("different covariate columns" in msg for msg in cm.output))
         self.assertIsInstance(bf, BalanceFrame)
 
@@ -146,7 +146,7 @@ class TestBalanceFrameCovarOverlap(BalanceTestCase):
         # Capture any balance logger warnings — there should be none
         with self.assertLogs("balance", level="INFO") as cm:
             logging.getLogger("balance").info("sentinel")
-            bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+            bf = BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         warning_msgs = [m for m in cm.output if "WARNING" in m]
         self.assertEqual(len(warning_msgs), 0)
         self.assertIsInstance(bf, BalanceFrame)
@@ -166,7 +166,7 @@ class TestBalanceFrameDeepCopy(BalanceTestCase):
             covar_columns=["x"],
             weight_columns=["w"],
         )
-        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+        bf = BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         bf_copy = copy.deepcopy(bf)
         self.assertIsInstance(bf_copy, BalanceFrame)
         self.assertFalse(bf_copy.is_adjusted)
@@ -190,7 +190,7 @@ class TestBalanceFrameRepr(BalanceTestCase):
             covar_columns=["x"],
             weight_columns=["w"],
         )
-        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+        bf = BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         r = repr(bf)
         # New format uses Sample-style display
         self.assertIn("with target set", r)
@@ -211,7 +211,7 @@ class TestBalanceFrameRepr(BalanceTestCase):
             covar_columns=["x"],
             weight_columns=["w"],
         )
-        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+        bf = BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         # __repr__ includes __str__ output
         self.assertIn(str(bf), repr(bf))
 
@@ -231,7 +231,7 @@ class TestBalanceFrameCreateDirect(BalanceTestCase):
             covar_columns=["x"],
             weight_columns=["w"],
         )
-        bf = BalanceFrame._create(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+        bf = BalanceFrame._create(sample=resp_sf, sf_target=tgt_sf)
         self.assertIsInstance(bf, BalanceFrame)
         self.assertFalse(bf.is_adjusted)
 
@@ -252,7 +252,7 @@ class TestBalanceFrameCreateDirect(BalanceTestCase):
             covar_columns=["x"],
             weight_columns=["w"],
         )
-        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+        bf = BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         # Access all properties
         self.assertIsNotNone(bf.responders)
         self.assertIsNotNone(bf.target)
@@ -285,7 +285,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
         )
         self.resp_sf = SampleFrame.from_frame(resp_df, outcome_columns=["happiness"])
         self.tgt_sf = SampleFrame.from_frame(tgt_df, outcome_columns=["happiness"])
-        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        self.bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
 
     def test_adjust_ipw(self) -> None:
         adjusted = self.bf.adjust(method="ipw")
@@ -443,29 +443,29 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
 
     def test_has_target_false_without_target(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
+        bf = BalanceFrame(sample=self.resp_sf)
         self.assertFalse(bf.has_target())
 
     def test_has_target_true_with_target(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
         self.assertTrue(bf.has_target())
 
     def test_set_target_in_place(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
+        bf = BalanceFrame(sample=self.resp_sf)
         result = bf.set_target(self.tgt_sf)
         self.assertIs(result, bf)
         self.assertTrue(bf.has_target())
         self.assertIs(bf.target, self.tgt_sf)
 
     def test_set_target_copy(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
+        bf = BalanceFrame(sample=self.resp_sf)
         new_bf = bf.set_target(self.tgt_sf, in_place=False)
         self.assertIsNot(new_bf, bf)
         self.assertTrue(new_bf.has_target())
         self.assertFalse(bf.has_target())
 
     def test_set_target_replaces_existing(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
         tgt2_df = pd.DataFrame(
             {
                 "id": ["7", "8"],
@@ -479,7 +479,7 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         self.assertIs(bf.target, tgt2_sf)
 
     def test_set_target_resets_adjustment(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
         adjusted = bf.adjust(method="null")
         self.assertTrue(adjusted.is_adjusted)
         # Replace target on the adjusted frame — should reset adjustment state
@@ -498,12 +498,12 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         self.assertIsNone(retargeted.model())
 
     def test_set_target_non_sampleframe_raises(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
+        bf = BalanceFrame(sample=self.resp_sf)
         with self.assertRaises(TypeError):
             bf.set_target("not a SampleFrame")  # pyre-ignore[6]
 
     def test_set_target_no_overlap_raises(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
+        bf = BalanceFrame(sample=self.resp_sf)
         bad_tgt = SampleFrame._create(
             df=pd.DataFrame({"id": [1], "z": [10.0], "w": [1.0]}),
             id_column="id",
@@ -515,13 +515,13 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         self.assertIn("no covariate columns", str(ctx.exception))
 
     def test_adjust_without_target_raises(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
+        bf = BalanceFrame(sample=self.resp_sf)
         with self.assertRaises(ValueError) as ctx:
             bf.adjust(method="ipw")
         self.assertIn("does not have a target set", str(ctx.exception))
 
     def test_no_target_repr(self) -> None:
-        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
+        bf = BalanceFrame(sample=self.resp_sf)
         r = repr(bf)
         # The new __str__ uses Sample-style format: no "with target set" text
         self.assertNotIn("with target set", r)
@@ -551,7 +551,7 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
         )
         self.resp_sf = SampleFrame.from_frame(resp_df, outcome_columns=["happiness"])
         self.tgt_sf = SampleFrame.from_frame(tgt_df, outcome_columns=["happiness"])
-        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        self.bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
 
     def test_covars_returns_balancedf_covars(self) -> None:
         from balance.balancedf_class import BalanceDFCovars
@@ -685,7 +685,7 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
                 {"id": [4, 5, 6], "x": [15.0, 25.0, 35.0], "weight": [1.0, 1.0, 1.0]}
             )
         )
-        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+        bf = BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         self.assertIsNone(bf.outcomes())
 
     def test_outcomes_df(self) -> None:
@@ -739,7 +739,7 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
         # --- New BalanceFrame API ---
         new_resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         new_tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        new_bf = BalanceFrame(sf_with_outcomes=new_resp, sf_target=new_tgt)
+        new_bf = BalanceFrame(sample=new_resp, sf_target=new_tgt)
         new_adjusted = new_bf.adjust(method="ipw")
         new_covars_mean = new_adjusted.covars().mean()
         new_covars_asmd = new_adjusted.covars().asmd()
@@ -784,9 +784,9 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
         # New API
         new_resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         new_tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        new_adjusted = BalanceFrame(
-            sf_with_outcomes=new_resp, sf_target=new_tgt
-        ).adjust(method="ipw")
+        new_adjusted = BalanceFrame(sample=new_resp, sf_target=new_tgt).adjust(
+            method="ipw"
+        )
         new_deff = new_adjusted.weights().design_effect()
 
         self.assertAlmostEqual(old_deff, new_deff, places=5)
@@ -819,7 +819,7 @@ class TestBalanceFrameSummaryDiagnostics(BalanceTestCase):
             outcome_columns=["y"],
         )
         tgt_sf = SampleFrame.from_frame(self.tgt_df)
-        self.bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+        self.bf = BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         self.bf_adjusted = self.bf.adjust(method="null")
 
     # --- summary() tests ---
@@ -944,7 +944,7 @@ class TestBalanceFrameSummaryDiagnostics(BalanceTestCase):
 
         resp_sf = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         tgt_sf = SampleFrame.from_frame(target_head)
-        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+        bf = BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         bf_adjusted = bf.adjust(method="ipw")
 
         old_diag = old_adjusted.diagnostics()
@@ -975,7 +975,7 @@ class TestBalanceFrameSummaryDiagnostics(BalanceTestCase):
 
         resp_sf = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         tgt_sf = SampleFrame.from_frame(target_head)
-        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+        bf = BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         bf_adjusted = bf.adjust(method="ipw")
 
         self.assertEqual(old_adjusted.summary(), bf_adjusted.summary())
@@ -1028,7 +1028,7 @@ class TestBalanceFrameParityHelpers(BalanceTestCase):
         )
         self.resp_sf = SampleFrame.from_frame(self.resp_df, ignored_columns=["region"])
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
-        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        self.bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
 
     def test_df_ignored_present(self) -> None:
         result = self.bf.responders.df_ignored
@@ -1043,7 +1043,7 @@ class TestBalanceFrameParityHelpers(BalanceTestCase):
         tgt = SampleFrame.from_frame(
             pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]})
         )
-        bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+        bf = BalanceFrame(sample=resp, sf_target=tgt)
         self.assertIsNone(bf.responders.df_ignored)
 
     def test_id_column_returns_series(self) -> None:
@@ -1080,7 +1080,7 @@ class TestBalanceFrameDfExportFilter(BalanceTestCase):
         )
         self.resp_sf = SampleFrame.from_frame(self.resp_df, outcome_columns=["y"])
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
-        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        self.bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
         self.bf_adjusted = self.bf.adjust(method="null")
 
     # --- df_all property (combined view) ---
@@ -1172,7 +1172,7 @@ class TestBalanceFrameDfExportFilter(BalanceTestCase):
             covar_columns=["x1"],
             weight_columns=[],
         )
-        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+        bf = BalanceFrame(sample=resp_sf, sf_target=tgt_sf)
         filtered = bf.keep_only_some_rows_columns(columns_to_keep=["x1"])
         self.assertIn("x1", filtered.responders._df.columns)
         self.assertIn("id", filtered.responders._df.columns)
@@ -1235,7 +1235,7 @@ class TestBalanceFrameMissingIntegration(BalanceTestCase):
         )
         self.resp_sf = SampleFrame.from_frame(self.resp_df, outcome_columns=["y"])
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
-        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        self.bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
 
     def test_full_pipeline_adjust_summary_diagnostics_to_csv(self) -> None:
         """Full pipeline: adjust -> summary -> diagnostics -> to_csv all succeed."""
@@ -1281,7 +1281,7 @@ class TestBalanceFrameMissingIntegration(BalanceTestCase):
         roundtrip = pd.read_csv(io.StringIO(csv_str))
         self.assertNotIn("source", roundtrip.columns)
         # Row count matches responders (this fixture has 4 rows)
-        self.assertEqual(len(roundtrip), len(self.bf._sf_with_outcomes))
+        self.assertEqual(len(roundtrip), len(self.bf._sf_sample))
 
     def test_keep_only_some_rows_columns_expression_matches_no_rows(self) -> None:
         """Filter expression that matches no rows produces a 0-row BalanceFrame."""
@@ -1354,7 +1354,7 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
         # --- New BalanceFrame API ---
         new_resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         new_tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        new_bf = BalanceFrame(sf_with_outcomes=new_resp, sf_target=new_tgt)
+        new_bf = BalanceFrame(sample=new_resp, sf_target=new_tgt)
         new_adjusted = new_bf.adjust(method=method)
 
         # --- covars().mean() ---
@@ -1451,7 +1451,7 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
                 }
             ),
         )
-        bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+        bf = BalanceFrame(sample=resp, sf_target=tgt)
 
         mean_df = bf.covars().mean()
         self.assertEqual(mean_df.index.name, "source")
@@ -1479,7 +1479,7 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
                 }
             ),
         )
-        bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+        bf = BalanceFrame(sample=resp, sf_target=tgt)
         adjusted = bf.adjust(method="null")
 
         mean_df = adjusted.covars().mean()
@@ -1508,7 +1508,7 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
                 }
             ),
         )
-        bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+        bf = BalanceFrame(sample=resp, sf_target=tgt)
 
         original_weights = bf.responders.df_weights.copy()
 
@@ -1537,9 +1537,7 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
 
         resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        new_adjusted = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt).adjust(
-            method="ipw"
-        )
+        new_adjusted = BalanceFrame(sample=resp, sf_target=tgt).adjust(method="ipw")
 
         old_diag = old_adjusted.diagnostics()
         new_diag = new_adjusted.diagnostics()
@@ -1560,9 +1558,7 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
 
         resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        new_adjusted = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt).adjust(
-            method="ipw"
-        )
+        new_adjusted = BalanceFrame(sample=resp, sf_target=tgt).adjust(method="ipw")
 
         old_means = old_adjusted.covars().mean()
         new_means = new_adjusted.covars().mean()
@@ -1693,7 +1689,7 @@ class TestBalanceFrameToSample(BalanceTestCase):
         )
         self.resp_sf = SampleFrame.from_frame(self.resp_df)
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
-        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
+        self.bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
 
     def test_to_sample_has_target(self) -> None:
         s = self.bf.to_sample()
@@ -1743,7 +1739,7 @@ class TestBalanceFrameToSample(BalanceTestCase):
             }
         )
         resp_sf = SampleFrame.from_frame(resp_df, outcome_columns=["y"])
-        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=self.tgt_sf)
+        bf = BalanceFrame(sample=resp_sf, sf_target=self.tgt_sf)
         s = bf.to_sample()
         self.assertIsNotNone(s._outcome_columns)
         assert s._outcome_columns is not None

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -19,6 +19,7 @@ from balance.datasets import load_data
 from balance.sample_class import Sample
 from balance.sample_frame import SampleFrame
 from balance.testutil import BalanceTestCase
+from balance.util import _assert_type
 
 
 class TestBalanceFrameConstruction(BalanceTestCase):
@@ -44,29 +45,29 @@ class TestBalanceFrameConstruction(BalanceTestCase):
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
 
     def test_basic_construction(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
         self.assertIsInstance(bf, BalanceFrame)
         self.assertIs(bf.responders, self.resp_sf)
         self.assertIs(bf.target, self.tgt_sf)
 
     def test_is_adjusted_false_on_creation(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
         self.assertFalse(bf.is_adjusted)
 
     def test_unadjusted_none_on_creation(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
         self.assertIsNone(bf.unadjusted)
 
     def test_model_none_on_creation(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
         self.assertIsNone(bf.model())
 
     def test_missing_responders_raises(self) -> None:
         with self.assertRaises(TypeError):
-            BalanceFrame(target=self.tgt_sf)
+            BalanceFrame(sf_target=self.tgt_sf)
 
     def test_no_target_construction(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
         self.assertIsInstance(bf, BalanceFrame)
         self.assertIs(bf.responders, self.resp_sf)
         self.assertIsNone(bf.target)
@@ -81,15 +82,15 @@ class TestBalanceFrameConstruction(BalanceTestCase):
     def test_non_sampleframe_responders_raises(self) -> None:
         with self.assertRaises(TypeError):
             BalanceFrame._create(
-                responders="not a SampleFrame",  # pyre-ignore[6]
-                target=self.tgt_sf,
+                sf_with_outcomes="not a SampleFrame",  # pyre-ignore[6]
+                sf_target=self.tgt_sf,
             )
 
     def test_non_sampleframe_target_raises(self) -> None:
         with self.assertRaises(TypeError):
             BalanceFrame._create(
-                responders=self.resp_sf,
-                target=pd.DataFrame(),  # pyre-ignore[6]
+                sf_with_outcomes=self.resp_sf,
+                sf_target=pd.DataFrame(),  # pyre-ignore[6]
             )
 
 
@@ -108,7 +109,7 @@ class TestBalanceFrameCovarOverlap(BalanceTestCase):
             weight_columns=["w"],
         )
         with self.assertRaises(ValueError) as ctx:
-            BalanceFrame(responders=resp_sf, target=tgt_sf)
+            BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         self.assertIn("no covariate columns", str(ctx.exception))
 
     def test_partial_overlap_warns(self) -> None:
@@ -125,7 +126,7 @@ class TestBalanceFrameCovarOverlap(BalanceTestCase):
             weight_columns=["w"],
         )
         with self.assertLogs("balance", level="WARNING") as cm:
-            bf = BalanceFrame(responders=resp_sf, target=tgt_sf)
+            bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         self.assertTrue(any("different covariate columns" in msg for msg in cm.output))
         self.assertIsInstance(bf, BalanceFrame)
 
@@ -145,7 +146,7 @@ class TestBalanceFrameCovarOverlap(BalanceTestCase):
         # Capture any balance logger warnings — there should be none
         with self.assertLogs("balance", level="INFO") as cm:
             logging.getLogger("balance").info("sentinel")
-            bf = BalanceFrame(responders=resp_sf, target=tgt_sf)
+            bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         warning_msgs = [m for m in cm.output if "WARNING" in m]
         self.assertEqual(len(warning_msgs), 0)
         self.assertIsInstance(bf, BalanceFrame)
@@ -165,7 +166,7 @@ class TestBalanceFrameDeepCopy(BalanceTestCase):
             covars_columns=["x"],
             weight_columns=["w"],
         )
-        bf = BalanceFrame(responders=resp_sf, target=tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         bf_copy = copy.deepcopy(bf)
         self.assertIsInstance(bf_copy, BalanceFrame)
         self.assertFalse(bf_copy.is_adjusted)
@@ -189,15 +190,15 @@ class TestBalanceFrameRepr(BalanceTestCase):
             covars_columns=["x"],
             weight_columns=["w"],
         )
-        bf = BalanceFrame(responders=resp_sf, target=tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         r = repr(bf)
-        self.assertIn("unadjusted", r)
-        self.assertIn("2 responders", r)
-        self.assertIn("3 target observations", r)
-        self.assertIn("1 covariates", r)
+        # New format uses Sample-style display
+        self.assertIn("with target set", r)
+        self.assertIn("2 observations", r)
+        self.assertIn("1 variables", r)
         self.assertIn("x", r)
 
-    def test_str_equals_repr(self) -> None:
+    def test_str_in_repr(self) -> None:
         resp_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [1], "x": [10.0], "w": [1.0]}),
             id_column="id",
@@ -210,8 +211,9 @@ class TestBalanceFrameRepr(BalanceTestCase):
             covars_columns=["x"],
             weight_columns=["w"],
         )
-        bf = BalanceFrame(responders=resp_sf, target=tgt_sf)
-        self.assertEqual(str(bf), repr(bf))
+        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
+        # __repr__ includes __str__ output
+        self.assertIn(str(bf), repr(bf))
 
 
 class TestBalanceFrameCreateDirect(BalanceTestCase):
@@ -229,7 +231,7 @@ class TestBalanceFrameCreateDirect(BalanceTestCase):
             covars_columns=["x"],
             weight_columns=["w"],
         )
-        bf = BalanceFrame._create(responders=resp_sf, target=tgt_sf)
+        bf = BalanceFrame._create(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         self.assertIsInstance(bf, BalanceFrame)
         self.assertFalse(bf.is_adjusted)
 
@@ -250,7 +252,7 @@ class TestBalanceFrameCreateDirect(BalanceTestCase):
             covars_columns=["x"],
             weight_columns=["w"],
         )
-        bf = BalanceFrame(responders=resp_sf, target=tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         # Access all properties
         self.assertIsNotNone(bf.responders)
         self.assertIsNotNone(bf.target)
@@ -265,11 +267,25 @@ class TestBalanceFrameCreateDirect(BalanceTestCase):
 class TestBalanceFrameAdjust(BalanceTestCase):
     def setUp(self) -> None:
         super().setUp()
-        target_df, sample_df = load_data()
-        assert target_df is not None and sample_df is not None
-        self.resp_sf = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
-        self.tgt_sf = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        self.bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        resp_df = pd.DataFrame(
+            {
+                "id": [str(i) for i in range(1, 6)],
+                "x": [0, 1, 1, 0, 1],
+                "happiness": [0.1, 0.5, 0.4, 0.9, 0.2],
+                "weight": [1.0, 1.0, 1.0, 1.0, 1.0],
+            }
+        )
+        tgt_df = pd.DataFrame(
+            {
+                "id": [str(i) for i in range(6, 11)],
+                "x": [0, 0, 1, 1, 0],
+                "happiness": [0.3, 0.6, 0.7, 0.2, 0.5],
+                "weight": [1.0, 1.0, 1.0, 1.0, 1.0],
+            }
+        )
+        self.resp_sf = SampleFrame.from_frame(resp_df, outcome_columns=["happiness"])
+        self.tgt_sf = SampleFrame.from_frame(tgt_df, outcome_columns=["happiness"])
+        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
 
     def test_adjust_ipw(self) -> None:
         adjusted = self.bf.adjust(method="ipw")
@@ -281,7 +297,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
         self.assertEqual(model["method"], "ipw")
 
     def test_adjust_preserves_original_weights(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         # Original weight column still present alongside adjusted
         all_w_cols = adjusted.responders.weight_columns
         self.assertIn("weight", all_w_cols)
@@ -329,7 +345,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
         self.assertEqual(model["method"], "dummy")
 
     def test_adjust_unadjusted_stored(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         unadj = adjusted.unadjusted
         self.assertIsNotNone(unadj)
         assert unadj is not None  # for Pyre narrowing
@@ -337,33 +353,33 @@ class TestBalanceFrameAdjust(BalanceTestCase):
         self.assertListEqual(list(unadj.df_weights.columns), ["weight"])
 
     def test_adjust_repr_shows_adjusted(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         self.assertIn("adjusted", repr(adjusted))
         self.assertNotIn("unadjusted", repr(adjusted))
 
     def test_adjust_weight_metadata(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         meta = adjusted.responders.weight_metadata("weight_adjusted")
-        self.assertEqual(meta["method"], "ipw")
+        self.assertEqual(meta["method"], "null")
         self.assertIn("model", meta)
 
     def test_adjust_already_adjusted_raises(self) -> None:
         """Calling adjust() on an already-adjusted BalanceFrame raises ValueError."""
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         with self.assertRaises(ValueError) as ctx:
-            adjusted.adjust(method="ipw")
+            adjusted.adjust(method="null")
         self.assertIn("already-adjusted", str(ctx.exception))
 
     def test_adjust_stores_method_name_in_model(self) -> None:
         """adjust() stores the method name in the adjustment model dict."""
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         model = adjusted.model()
         self.assertIsInstance(model, dict)
         assert model is not None
-        self.assertEqual(model["method"], "ipw")
+        self.assertEqual(model["method"], "null_adjustment")
 
     def test_adjust_stores_custom_method_name_in_model(self) -> None:
-        """adjust() stores 'custom' when a callable method is used."""
+        """adjust() stores the callable's __name__ when a callable method is used."""
 
         def custom_method(
             sample_df: pd.DataFrame,
@@ -377,7 +393,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
         model = adjusted.model()
         self.assertIsInstance(model, dict)
         assert model is not None
-        self.assertEqual(model["method"], "custom")
+        self.assertEqual(model["method"], "custom_method")
         self.assertEqual(model["info"], "test")
 
     def test_adjust_invalid_method_raises(self) -> None:
@@ -392,7 +408,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
 
     def test_adjust_deepcopy_adjusted(self) -> None:
         """Deepcopy of an adjusted BalanceFrame preserves adjustment state."""
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         adjusted_copy = copy.deepcopy(adjusted)
         self.assertTrue(adjusted_copy.is_adjusted)
         self.assertIsNotNone(adjusted_copy.unadjusted)
@@ -427,29 +443,29 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
 
     def test_has_target_false_without_target(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
         self.assertFalse(bf.has_target())
 
     def test_has_target_true_with_target(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
         self.assertTrue(bf.has_target())
 
     def test_set_target_in_place(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
         result = bf.set_target(self.tgt_sf)
         self.assertIs(result, bf)
         self.assertTrue(bf.has_target())
         self.assertIs(bf.target, self.tgt_sf)
 
     def test_set_target_copy(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
         new_bf = bf.set_target(self.tgt_sf, in_place=False)
         self.assertIsNot(new_bf, bf)
         self.assertTrue(new_bf.has_target())
         self.assertFalse(bf.has_target())
 
     def test_set_target_replaces_existing(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
         tgt2_df = pd.DataFrame(
             {
                 "id": ["7", "8"],
@@ -463,7 +479,7 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         self.assertIs(bf.target, tgt2_sf)
 
     def test_set_target_resets_adjustment(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
         adjusted = bf.adjust(method="null")
         self.assertTrue(adjusted.is_adjusted)
         # Replace target on the adjusted frame — should reset adjustment state
@@ -476,17 +492,18 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
             }
         )
         tgt2_sf = SampleFrame.from_frame(tgt2_df)
-        adjusted.set_target(tgt2_sf)
-        self.assertFalse(adjusted.is_adjusted)
-        self.assertIsNone(adjusted.model())
+        # set_target returns a NEW BalanceFrame; the original stays adjusted.
+        retargeted = adjusted.set_target(tgt2_sf)
+        self.assertFalse(retargeted.is_adjusted)
+        self.assertIsNone(retargeted.model())
 
     def test_set_target_non_sampleframe_raises(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
         with self.assertRaises(TypeError):
             bf.set_target("not a SampleFrame")  # pyre-ignore[6]
 
     def test_set_target_no_overlap_raises(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
         bad_tgt = SampleFrame._create(
             df=pd.DataFrame({"id": [1], "z": [10.0], "w": [1.0]}),
             id_column="id",
@@ -498,16 +515,17 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         self.assertIn("no covariate columns", str(ctx.exception))
 
     def test_adjust_without_target_raises(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
         with self.assertRaises(ValueError) as ctx:
             bf.adjust(method="ipw")
-        self.assertIn("without a target", str(ctx.exception))
+        self.assertIn("does not have a target set", str(ctx.exception))
 
     def test_no_target_repr(self) -> None:
-        bf = BalanceFrame(responders=self.resp_sf)
+        bf = BalanceFrame(sf_with_outcomes=self.resp_sf)
         r = repr(bf)
-        self.assertIn("no target", r)
-        self.assertIn("3 responders", r)
+        # The new __str__ uses Sample-style format: no "with target set" text
+        self.assertNotIn("with target set", r)
+        self.assertIn("3 observations", r)
 
 
 class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
@@ -515,11 +533,25 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        target_df, sample_df = load_data()
-        assert target_df is not None and sample_df is not None
-        self.resp_sf = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
-        self.tgt_sf = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        self.bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        resp_df = pd.DataFrame(
+            {
+                "id": [str(i) for i in range(1, 6)],
+                "x": [0, 1, 1, 0, 1],
+                "happiness": [0.1, 0.5, 0.4, 0.9, 0.2],
+                "weight": [1.0, 1.0, 1.0, 1.0, 1.0],
+            }
+        )
+        tgt_df = pd.DataFrame(
+            {
+                "id": [str(i) for i in range(6, 11)],
+                "x": [0, 0, 1, 1, 0],
+                "happiness": [0.3, 0.6, 0.7, 0.2, 0.5],
+                "weight": [1.0, 1.0, 1.0, 1.0, 1.0],
+            }
+        )
+        self.resp_sf = SampleFrame.from_frame(resp_df, outcome_columns=["happiness"])
+        self.tgt_sf = SampleFrame.from_frame(tgt_df, outcome_columns=["happiness"])
+        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
 
     def test_covars_returns_balancedf_covars(self) -> None:
         from balance.balancedf_class import BalanceDFCovars
@@ -538,7 +570,7 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
         self.assertTrue(len(names) > 0)
 
     def test_covars_mean(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         mean_df = adjusted.covars().mean()
         self.assertIsInstance(mean_df, pd.DataFrame)
         self.assertEqual(mean_df.index.name, "source")
@@ -547,28 +579,28 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
         self.assertIn("unadjusted", mean_df.index)
 
     def test_covars_std(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         std_df = adjusted.covars().std()
         self.assertIsInstance(std_df, pd.DataFrame)
         self.assertIn("self", std_df.index)
 
     def test_covars_var_of_mean(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         vom = adjusted.covars().var_of_mean()
         self.assertIsInstance(vom, pd.DataFrame)
 
     def test_covars_ci_of_mean(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         ci = adjusted.covars().ci_of_mean()
         self.assertIsInstance(ci, pd.DataFrame)
 
     def test_covars_mean_with_ci(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         mwci = adjusted.covars().mean_with_ci()
         self.assertIsInstance(mwci, pd.DataFrame)
 
     def test_covars_summary(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         summary = adjusted.covars().summary()
         self.assertIsInstance(summary, pd.DataFrame)
 
@@ -578,17 +610,17 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
         self.assertTrue(len(mm) > 0)
 
     def test_covars_asmd(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         asmd_df = adjusted.covars().asmd()
         self.assertIsInstance(asmd_df, pd.DataFrame)
 
     def test_covars_asmd_improvement(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         improvement = adjusted.covars().asmd_improvement()
         self.assertIsInstance(improvement, (float, np.floating))
 
     def test_covars_links_unadjusted(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         linked = adjusted.covars()._BalanceDF_child_from_linked_samples()
         self.assertIn("self", linked)
         self.assertIn("target", linked)
@@ -619,18 +651,18 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
         self.assertTrue(len(w_df) > 0)
 
     def test_weights_summary(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         summary = adjusted.weights().summary()
         self.assertIsInstance(summary, pd.DataFrame)
 
     def test_weights_design_effect(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         deff = adjusted.weights().design_effect()
         self.assertIsInstance(deff, float)
         self.assertTrue(deff >= 1.0)
 
     def test_weights_trim(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         weights_obj = adjusted.weights()
         # trim() mutates in place and returns None
         result = weights_obj.trim()
@@ -653,7 +685,7 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
                 {"id": [4, 5, 6], "x": [15.0, 25.0, 35.0], "weight": [1.0, 1.0, 1.0]}
             )
         )
-        bf = BalanceFrame(responders=resp_sf, target=tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         self.assertIsNone(bf.outcomes())
 
     def test_outcomes_df(self) -> None:
@@ -665,7 +697,7 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
         self.assertIn("happiness", o_df.columns)
 
     def test_outcomes_summary(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         result = adjusted.outcomes()
         self.assertIsNotNone(result)
         assert result is not None
@@ -680,7 +712,7 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
         self.assertIsInstance(rrr, pd.DataFrame)
 
     def test_outcomes_target_response_rates(self) -> None:
-        adjusted = self.bf.adjust(method="ipw")
+        adjusted = self.bf.adjust(method="null")
         result = adjusted.outcomes()
         self.assertIsNotNone(result)
         assert result is not None
@@ -693,6 +725,8 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
 
         target_df, sample_df = load_data()
         assert target_df is not None and sample_df is not None
+        sample_df = sample_df.head(50)
+        target_df = target_df.head(100)
 
         # --- Old Sample API ---
         old_sample = Sample.from_frame(sample_df, outcome_columns=["happiness"])
@@ -705,7 +739,7 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
         # --- New BalanceFrame API ---
         new_resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         new_tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        new_bf = BalanceFrame(responders=new_resp, target=new_tgt)
+        new_bf = BalanceFrame(sf_with_outcomes=new_resp, sf_target=new_tgt)
         new_adjusted = new_bf.adjust(method="ipw")
         new_covars_mean = new_adjusted.covars().mean()
         new_covars_asmd = new_adjusted.covars().asmd()
@@ -738,6 +772,8 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
 
         target_df, sample_df = load_data()
         assert target_df is not None and sample_df is not None
+        sample_df = sample_df.head(50)
+        target_df = target_df.head(100)
 
         # Old API
         old_sample = Sample.from_frame(sample_df, outcome_columns=["happiness"])
@@ -748,9 +784,9 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
         # New API
         new_resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         new_tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        new_adjusted = BalanceFrame(responders=new_resp, target=new_tgt).adjust(
-            method="ipw"
-        )
+        new_adjusted = BalanceFrame(
+            sf_with_outcomes=new_resp, sf_target=new_tgt
+        ).adjust(method="ipw")
         new_deff = new_adjusted.weights().design_effect()
 
         self.assertAlmostEqual(old_deff, new_deff, places=5)
@@ -783,7 +819,7 @@ class TestBalanceFrameSummaryDiagnostics(BalanceTestCase):
             outcome_columns=["y"],
         )
         tgt_sf = SampleFrame.from_frame(self.tgt_df)
-        self.bf = BalanceFrame(responders=resp_sf, target=tgt_sf)
+        self.bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         self.bf_adjusted = self.bf.adjust(method="null")
 
     # --- summary() tests ---
@@ -822,12 +858,11 @@ class TestBalanceFrameSummaryDiagnostics(BalanceTestCase):
 
         old_summary = old_adjusted.summary()
         new_summary = self.bf_adjusted.summary()
-        # The new API uses the user-provided method name ("null") while the
-        # old API uses the internal function name ("null_adjustment").
-        # Normalise before comparison so the rest of the output is verified.
+        # The old Sample API normalises method to "null" while BF preserves
+        # the raw name "null_adjustment".  Normalise both before comparing.
         self.assertEqual(
             old_summary.replace("null_adjustment", "null"),
-            new_summary,
+            new_summary.replace("null_adjustment", "null"),
         )
 
     # --- diagnostics() tests ---
@@ -867,13 +902,15 @@ class TestBalanceFrameSummaryDiagnostics(BalanceTestCase):
 
         self.assertEqual(old_diag.shape, new_diag.shape)
         self.assertEqual(old_diag["metric"].tolist(), new_diag["metric"].tolist())
-        # The new API uses "null" while the old API uses "null_adjustment"
-        # for the method name in the var column.  Normalise before comparing.
-        old_vars = [
-            v.replace("null_adjustment", "null") if isinstance(v, str) else v
-            for v in old_diag["var"].tolist()
-        ]
-        self.assertEqual(old_vars, new_diag["var"].tolist())
+
+        # The old Sample API normalises the method name to "null" while BF
+        # preserves the raw name "null_adjustment".  Normalise both sides.
+        def _normalise(v: object) -> object:
+            return v.replace("null_adjustment", "null") if isinstance(v, str) else v
+
+        old_vars = [_normalise(v) for v in old_diag["var"].tolist()]
+        new_vars = [_normalise(v) for v in new_diag["var"].tolist()]
+        self.assertEqual(old_vars, new_vars)
 
         # Compare numeric vals with tolerance
         for i in range(len(old_diag)):
@@ -890,8 +927,9 @@ class TestBalanceFrameSummaryDiagnostics(BalanceTestCase):
         target_df, sample_df = load_data()
         assert sample_df is not None
         assert target_df is not None
+        sample_df = sample_df.head(50)
 
-        target_head = target_df.head(200).drop(columns=["happiness"], errors="ignore")
+        target_head = target_df.head(100).drop(columns=["happiness"], errors="ignore")
 
         old_sample = Sample.from_frame(
             sample_df,
@@ -906,7 +944,7 @@ class TestBalanceFrameSummaryDiagnostics(BalanceTestCase):
 
         resp_sf = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         tgt_sf = SampleFrame.from_frame(target_head)
-        bf = BalanceFrame(responders=resp_sf, target=tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         bf_adjusted = bf.adjust(method="ipw")
 
         old_diag = old_adjusted.diagnostics()
@@ -920,8 +958,9 @@ class TestBalanceFrameSummaryDiagnostics(BalanceTestCase):
         target_df, sample_df = load_data()
         assert sample_df is not None
         assert target_df is not None
+        sample_df = sample_df.head(50)
 
-        target_head = target_df.head(200).drop(columns=["happiness"], errors="ignore")
+        target_head = target_df.head(100).drop(columns=["happiness"], errors="ignore")
 
         old_sample = Sample.from_frame(
             sample_df,
@@ -936,7 +975,7 @@ class TestBalanceFrameSummaryDiagnostics(BalanceTestCase):
 
         resp_sf = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         tgt_sf = SampleFrame.from_frame(target_head)
-        bf = BalanceFrame(responders=resp_sf, target=tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         bf_adjusted = bf.adjust(method="ipw")
 
         self.assertEqual(old_adjusted.summary(), bf_adjusted.summary())
@@ -989,7 +1028,7 @@ class TestBalanceFrameParityHelpers(BalanceTestCase):
         )
         self.resp_sf = SampleFrame.from_frame(self.resp_df, ignore_columns=["region"])
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
-        self.bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
 
     def test_ignored_columns_present(self) -> None:
         result = self.bf.ignored_columns()
@@ -1004,7 +1043,7 @@ class TestBalanceFrameParityHelpers(BalanceTestCase):
         tgt = SampleFrame.from_frame(
             pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]})
         )
-        bf = BalanceFrame(responders=resp, target=tgt)
+        bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
         self.assertIsNone(bf.ignored_columns())
 
     def test_ignored_columns_delegates_to_responders(self) -> None:
@@ -1015,6 +1054,7 @@ class TestBalanceFrameParityHelpers(BalanceTestCase):
     def test_id_column_returns_series(self) -> None:
         result = self.bf.id_column
         self.assertIsInstance(result, pd.Series)
+        assert result is not None
         self.assertEqual(result.tolist(), ["1", "2", "3"])
 
     def test_id_column_delegates_to_responders(self) -> None:
@@ -1045,34 +1085,46 @@ class TestBalanceFrameDfExportFilter(BalanceTestCase):
         )
         self.resp_sf = SampleFrame.from_frame(self.resp_df, outcome_columns=["y"])
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
-        self.bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
         self.bf_adjusted = self.bf.adjust(method="null")
 
-    # --- df property ---
+    # --- df_all property (combined view) ---
 
-    def test_df_unadjusted_has_source_column(self) -> None:
-        result = self.bf.df
+    def test_df_all_unadjusted_has_source_column(self) -> None:
+        result = self.bf.df_all
         self.assertIn("source", result.columns)
         self.assertCountEqual(result["source"].unique().tolist(), ["self", "target"])
 
-    def test_df_unadjusted_row_count(self) -> None:
-        result = self.bf.df
+    def test_df_all_unadjusted_row_count(self) -> None:
+        result = self.bf.df_all
         self.assertEqual(len(result), 6)  # 3 resp + 3 target
 
-    def test_df_adjusted_has_unadjusted_source(self) -> None:
-        result = self.bf_adjusted.df
+    def test_df_all_adjusted_has_unadjusted_source(self) -> None:
+        result = self.bf_adjusted.df_all
         self.assertCountEqual(
             result["source"].unique().tolist(),
             ["self", "target", "unadjusted"],
         )
 
-    def test_df_adjusted_row_count(self) -> None:
-        result = self.bf_adjusted.df
+    def test_df_all_adjusted_row_count(self) -> None:
+        result = self.bf_adjusted.df_all
         self.assertEqual(len(result), 9)  # 3 resp + 3 target + 3 unadjusted
 
-    def test_df_contains_all_columns(self) -> None:
-        result = self.bf.df
+    def test_df_all_contains_all_columns(self) -> None:
+        result = self.bf.df_all
         for col in ["id", "x1", "x2", "weight", "source"]:
+            self.assertIn(col, result.columns)
+
+    # --- df property (flat, user-facing) ---
+
+    def test_df_returns_responders_only(self) -> None:
+        result = self.bf.df
+        self.assertNotIn("source", result.columns)
+        self.assertEqual(len(result), 3)  # responders only
+
+    def test_df_contains_data_columns(self) -> None:
+        result = self.bf.df
+        for col in ["id", "x1", "x2", "weight"]:
             self.assertIn(col, result.columns)
 
     # --- keep_only_some_rows_columns ---
@@ -1125,7 +1177,7 @@ class TestBalanceFrameDfExportFilter(BalanceTestCase):
             covars_columns=["x1"],
             weight_columns=[],
         )
-        bf = BalanceFrame(responders=resp_sf, target=tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
         filtered = bf.keep_only_some_rows_columns(columns_to_keep=["x1"])
         self.assertIn("x1", filtered.responders._df.columns)
         self.assertIn("id", filtered.responders._df.columns)
@@ -1137,15 +1189,15 @@ class TestBalanceFrameDfExportFilter(BalanceTestCase):
         result = self.bf.to_csv()
         self.assertIsInstance(result, str)
         assert result is not None
-        self.assertIn("source", result)
-        self.assertIn("self", result)
-        self.assertIn("target", result)
+        # df (flat) does not include "source" column
+        self.assertIn("id", result)
+        self.assertIn("weight", result)
 
     def test_to_csv_roundtrip(self) -> None:
         csv_text = self.bf.to_csv()
         roundtrip_df = pd.read_csv(io.StringIO(csv_text))
-        self.assertEqual(len(roundtrip_df), 6)
-        self.assertIn("source", roundtrip_df.columns)
+        self.assertEqual(len(roundtrip_df), 3)  # responders only
+        self.assertNotIn("source", roundtrip_df.columns)
 
     def test_to_csv_to_file(self) -> None:
         import tempfile
@@ -1153,7 +1205,7 @@ class TestBalanceFrameDfExportFilter(BalanceTestCase):
         with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
             self.bf.to_csv(f.name)
             roundtrip = pd.read_csv(f.name)
-            self.assertEqual(len(roundtrip), 6)
+            self.assertEqual(len(roundtrip), 3)  # responders only
 
     # --- to_download ---
 
@@ -1188,7 +1240,7 @@ class TestBalanceFrameMissingIntegration(BalanceTestCase):
         )
         self.resp_sf = SampleFrame.from_frame(self.resp_df, outcome_columns=["y"])
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
-        self.bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
 
     def test_full_pipeline_adjust_summary_diagnostics_to_csv(self) -> None:
         """Full pipeline: adjust -> summary -> diagnostics -> to_csv all succeed."""
@@ -1208,8 +1260,8 @@ class TestBalanceFrameMissingIntegration(BalanceTestCase):
         self.assertIsInstance(csv_str, str)
         assert csv_str is not None
         roundtrip = pd.read_csv(io.StringIO(csv_str))
-        sources = set(roundtrip["source"].unique())
-        self.assertEqual(sources, {"self", "target", "unadjusted"})
+        # df (flat) does not include "source" column
+        self.assertNotIn("source", roundtrip.columns)
 
     def test_null_method_adjustment(self) -> None:
         """Null method adjustment leaves weights unchanged."""
@@ -1219,22 +1271,22 @@ class TestBalanceFrameMissingIntegration(BalanceTestCase):
         model = adjusted.model()
         self.assertIsNotNone(model)
         assert model is not None
-        self.assertEqual(model["method"], "null")
+        self.assertEqual(model["method"], "null_adjustment")
 
         orig_weights = self.resp_sf.df_weights.iloc[:, 0].tolist()
         adj_weights = adjusted.responders.df_weights.iloc[:, 0].tolist()
         for orig, adj in zip(orig_weights, adj_weights):
             self.assertAlmostEqual(orig, adj, places=8)
 
-    def test_to_csv_unadjusted_has_no_unadjusted_source(self) -> None:
-        """to_csv() on an unadjusted BalanceFrame has only self/target sources."""
+    def test_to_csv_unadjusted_is_flat(self) -> None:
+        """to_csv() on an unadjusted BalanceFrame exports flat responders only."""
         csv_str = self.bf.to_csv()
         self.assertIsInstance(csv_str, str)
         assert csv_str is not None
         roundtrip = pd.read_csv(io.StringIO(csv_str))
-        sources = set(roundtrip["source"].unique())
-        self.assertEqual(sources, {"self", "target"})
-        self.assertNotIn("unadjusted", sources)
+        self.assertNotIn("source", roundtrip.columns)
+        # Row count matches responders (this fixture has 4 rows)
+        self.assertEqual(len(roundtrip), len(self.bf._sf_with_outcomes))
 
     def test_keep_only_some_rows_columns_expression_matches_no_rows(self) -> None:
         """Filter expression that matches no rows produces a 0-row BalanceFrame."""
@@ -1290,6 +1342,14 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
         for a given adjustment method."""
         target_df, sample_df = load_data()
         assert target_df is not None and sample_df is not None
+        # Poststratify needs all cell combos present; use more rows for it.
+        # NOTE: we compare method against the literal in a bool variable so
+        # that Pyre doesn't narrow (and then widen to LiteralString) the
+        # Literal-typed ``method`` parameter.
+        use_full_data = method == "poststratify"
+        if not use_full_data:
+            sample_df = sample_df.head(50)
+            target_df = target_df.head(100)
 
         # --- Old Sample API ---
         old_sample = Sample.from_frame(sample_df, outcome_columns=["happiness"])
@@ -1299,7 +1359,7 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
         # --- New BalanceFrame API ---
         new_resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         new_tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        new_bf = BalanceFrame(responders=new_resp, target=new_tgt)
+        new_bf = BalanceFrame(sf_with_outcomes=new_resp, sf_target=new_tgt)
         new_adjusted = new_bf.adjust(method=method)
 
         # --- covars().mean() ---
@@ -1357,10 +1417,8 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
         self.assertIsInstance(csv_output, str)
         assert csv_output is not None
         roundtrip = pd.read_csv(io.StringIO(csv_output))
-        self.assertCountEqual(
-            roundtrip["source"].unique().tolist(),
-            ["self", "target", "unadjusted"],
-        )
+        # df (flat, user-facing) does not have a "source" column
+        self.assertNotIn("source", roundtrip.columns)
 
     def test_ipw_end_to_end_equivalence(self) -> None:
         """Full workflow equivalence for IPW (inverse propensity weighting)."""
@@ -1380,12 +1438,25 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
 
     def test_unadjusted_covars_mean_sources(self) -> None:
         """Verify unadjusted BalanceFrame covars().mean() has self+target only."""
-        target_df, sample_df = load_data()
-        assert target_df is not None and sample_df is not None
-
-        resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
-        tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        bf = BalanceFrame(responders=resp, target=tgt)
+        resp = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [str(i) for i in range(5)],
+                    "x": [1.0, 2, 3, 4, 5],
+                    "weight": [1.0] * 5,
+                }
+            ),
+        )
+        tgt = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [str(i) for i in range(5, 10)],
+                    "x": [2.0, 3, 4, 5, 6],
+                    "weight": [1.0] * 5,
+                }
+            ),
+        )
+        bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
 
         mean_df = bf.covars().mean()
         self.assertEqual(mean_df.index.name, "source")
@@ -1395,13 +1466,26 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
 
     def test_adjusted_covars_mean_sources(self) -> None:
         """Verify adjusted BalanceFrame covars().mean() has self+target+unadjusted."""
-        target_df, sample_df = load_data()
-        assert target_df is not None and sample_df is not None
-
-        resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
-        tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        bf = BalanceFrame(responders=resp, target=tgt)
-        adjusted = bf.adjust(method="ipw")
+        resp = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [str(i) for i in range(5)],
+                    "x": [1.0, 2, 3, 4, 5],
+                    "weight": [1.0] * 5,
+                }
+            ),
+        )
+        tgt = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [str(i) for i in range(5, 10)],
+                    "x": [2.0, 3, 4, 5, 6],
+                    "weight": [1.0] * 5,
+                }
+            ),
+        )
+        bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
+        adjusted = bf.adjust(method="null")
 
         mean_df = adjusted.covars().mean()
         self.assertEqual(mean_df.index.name, "source")
@@ -1411,31 +1495,46 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
 
     def test_immutability_across_methods(self) -> None:
         """Verify adjust() does not mutate the original BalanceFrame."""
-        target_df, sample_df = load_data()
-        assert target_df is not None and sample_df is not None
-
-        resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
-        tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        bf = BalanceFrame(responders=resp, target=tgt)
+        resp = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [str(i) for i in range(5)],
+                    "x": [1.0, 2, 3, 4, 5],
+                    "weight": [1.0] * 5,
+                }
+            ),
+        )
+        tgt = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [str(i) for i in range(5, 10)],
+                    "x": [2.0, 3, 4, 5, 6],
+                    "weight": [1.0] * 5,
+                }
+            ),
+        )
+        bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
 
         original_weights = bf.responders.df_weights.copy()
 
-        adjusted_ipw = bf.adjust(method="ipw")
-        adjusted_cbps = bf.adjust(method="cbps")
+        adjusted_null1 = bf.adjust(method="null")
+        adjusted_null2 = bf.adjust(method="null")
 
         # Original is unchanged
         self.assertFalse(bf.is_adjusted)
         pd.testing.assert_frame_equal(bf.responders.df_weights, original_weights)
 
         # Each adjusted BF is independent
-        self.assertTrue(adjusted_ipw.is_adjusted)
-        self.assertTrue(adjusted_cbps.is_adjusted)
-        self.assertIsNot(adjusted_ipw, adjusted_cbps)
+        self.assertTrue(adjusted_null1.is_adjusted)
+        self.assertTrue(adjusted_null2.is_adjusted)
+        self.assertIsNot(adjusted_null1, adjusted_null2)
 
     def test_diagnostics_equivalence(self) -> None:
         """Verify diagnostics() produces consistent output between APIs."""
         target_df, sample_df = load_data()
         assert target_df is not None and sample_df is not None
+        sample_df = sample_df.head(50)
+        target_df = target_df.head(100)
 
         old_sample = Sample.from_frame(sample_df, outcome_columns=["happiness"])
         old_target = Sample.from_frame(target_df, outcome_columns=["happiness"])
@@ -1443,7 +1542,9 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
 
         resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        new_adjusted = BalanceFrame(responders=resp, target=tgt).adjust(method="ipw")
+        new_adjusted = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt).adjust(
+            method="ipw"
+        )
 
         old_diag = old_adjusted.diagnostics()
         new_diag = new_adjusted.diagnostics()
@@ -1455,6 +1556,8 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
         """Verify covars().mean() matches between old and new APIs."""
         target_df, sample_df = load_data()
         assert target_df is not None and sample_df is not None
+        sample_df = sample_df.head(50)
+        target_df = target_df.head(100)
 
         old_sample = Sample.from_frame(sample_df, outcome_columns=["happiness"])
         old_target = Sample.from_frame(target_df, outcome_columns=["happiness"])
@@ -1462,7 +1565,9 @@ class TestBalanceFrameEndToEnd(BalanceTestCase):
 
         resp = SampleFrame.from_frame(sample_df, outcome_columns=["happiness"])
         tgt = SampleFrame.from_frame(target_df, outcome_columns=["happiness"])
-        new_adjusted = BalanceFrame(responders=resp, target=tgt).adjust(method="ipw")
+        new_adjusted = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt).adjust(
+            method="ipw"
+        )
 
         old_means = old_adjusted.covars().mean()
         new_means = new_adjusted.covars().mean()
@@ -1549,6 +1654,8 @@ class TestBalanceFrameFromSample(BalanceTestCase):
         """Verify that converting Sample->BalanceFrame produces equivalent results."""
         target_df, sample_df = load_data()
         assert target_df is not None and sample_df is not None
+        sample_df = sample_df.head(50)
+        target_df = target_df.head(100)
 
         old_sample = Sample.from_frame(sample_df, outcome_columns=["happiness"])
         old_target = Sample.from_frame(target_df, outcome_columns=["happiness"])
@@ -1591,7 +1698,7 @@ class TestBalanceFrameToSample(BalanceTestCase):
         )
         self.resp_sf = SampleFrame.from_frame(self.resp_df)
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
-        self.bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
+        self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
 
     def test_to_sample_has_target(self) -> None:
         s = self.bf.to_sample()
@@ -1641,7 +1748,7 @@ class TestBalanceFrameToSample(BalanceTestCase):
             }
         )
         resp_sf = SampleFrame.from_frame(resp_df, outcome_columns=["y"])
-        bf = BalanceFrame(responders=resp_sf, target=self.tgt_sf)
+        bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=self.tgt_sf)
         s = bf.to_sample()
         self.assertIsNotNone(s._outcome_columns)
         assert s._outcome_columns is not None
@@ -1663,7 +1770,8 @@ class TestBalanceFrameToSample(BalanceTestCase):
             sorted(original._covar_columns_names()),
         )
         for o_val, r_val in zip(
-            original.weight_column.tolist(), roundtrip.weight_column.tolist()
+            _assert_type(original.weight_column).tolist(),
+            _assert_type(roundtrip.weight_column).tolist(),
         ):
             self.assertAlmostEqual(o_val, r_val, places=10)
 
@@ -1679,7 +1787,8 @@ class TestBalanceFrameToSample(BalanceTestCase):
         self.assertTrue(roundtrip.is_adjusted())
         self.assertTrue(roundtrip.has_target())
         for o_val, r_val in zip(
-            adjusted.weight_column.tolist(), roundtrip.weight_column.tolist()
+            _assert_type(adjusted.weight_column).tolist(),
+            _assert_type(roundtrip.weight_column).tolist(),
         ):
             self.assertAlmostEqual(o_val, r_val, places=10)
 
@@ -1687,6 +1796,8 @@ class TestBalanceFrameToSample(BalanceTestCase):
         """Round-trip with load_data ensures real-world equivalence."""
         target_df, sample_df = load_data()
         assert target_df is not None and sample_df is not None
+        sample_df = sample_df.head(50)
+        target_df = target_df.head(100)
 
         old_sample = Sample.from_frame(sample_df, outcome_columns=["happiness"])
         old_target = Sample.from_frame(target_df, outcome_columns=["happiness"])
@@ -1698,7 +1809,8 @@ class TestBalanceFrameToSample(BalanceTestCase):
         self.assertTrue(roundtrip.is_adjusted())
         self.assertTrue(roundtrip.has_target())
         for o_val, r_val in zip(
-            old_adjusted.weight_column.tolist(), roundtrip.weight_column.tolist()
+            _assert_type(old_adjusted.weight_column).tolist(),
+            _assert_type(roundtrip.weight_column).tolist(),
         ):
             self.assertAlmostEqual(o_val, r_val, places=5)
         self.assertEqual(

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -99,13 +99,13 @@ class TestBalanceFrameCovarOverlap(BalanceTestCase):
         resp_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [1], "a": [10.0], "w": [1.0]}),
             id_column="id",
-            covars_columns=["a"],
+            covar_columns=["a"],
             weight_columns=["w"],
         )
         tgt_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [2], "b": [20.0], "w": [1.0]}),
             id_column="id",
-            covars_columns=["b"],
+            covar_columns=["b"],
             weight_columns=["w"],
         )
         with self.assertRaises(ValueError) as ctx:
@@ -116,13 +116,13 @@ class TestBalanceFrameCovarOverlap(BalanceTestCase):
         resp_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [1], "x": [10.0], "a": [1.0], "w": [1.0]}),
             id_column="id",
-            covars_columns=["x", "a"],
+            covar_columns=["x", "a"],
             weight_columns=["w"],
         )
         tgt_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [2], "x": [20.0], "b": [2.0], "w": [1.0]}),
             id_column="id",
-            covars_columns=["x", "b"],
+            covar_columns=["x", "b"],
             weight_columns=["w"],
         )
         with self.assertLogs("balance", level="WARNING") as cm:
@@ -134,13 +134,13 @@ class TestBalanceFrameCovarOverlap(BalanceTestCase):
         resp_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [1], "x": [10.0], "w": [1.0]}),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
         )
         tgt_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [2], "x": [20.0], "w": [1.0]}),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
         )
         # Capture any balance logger warnings — there should be none
@@ -157,13 +157,13 @@ class TestBalanceFrameDeepCopy(BalanceTestCase):
         resp_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "w": [1.0, 1.0]}),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
         )
         tgt_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "w": [1.0, 1.0]}),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
         )
         bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
@@ -179,7 +179,7 @@ class TestBalanceFrameRepr(BalanceTestCase):
         resp_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "w": [1.0, 1.0]}),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
         )
         tgt_sf = SampleFrame._create(
@@ -187,7 +187,7 @@ class TestBalanceFrameRepr(BalanceTestCase):
                 {"id": [3, 4, 5], "x": [15.0, 25.0, 35.0], "w": [1.0, 1.0, 1.0]}
             ),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
         )
         bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
@@ -202,13 +202,13 @@ class TestBalanceFrameRepr(BalanceTestCase):
         resp_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [1], "x": [10.0], "w": [1.0]}),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
         )
         tgt_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [2], "x": [20.0], "w": [1.0]}),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
         )
         bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
@@ -222,13 +222,13 @@ class TestBalanceFrameCreateDirect(BalanceTestCase):
         resp_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [1], "x": [10.0], "w": [1.0]}),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
         )
         tgt_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [2], "x": [20.0], "w": [1.0]}),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
         )
         bf = BalanceFrame._create(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
@@ -242,14 +242,14 @@ class TestBalanceFrameCreateDirect(BalanceTestCase):
                 {"id": [1, 2], "x": [10.0, 20.0], "y": [1.0, 0.0], "w": [1.0, 2.0]}
             ),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
             outcome_columns=["y"],
         )
         tgt_sf = SampleFrame._create(
             df=pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "w": [1.0, 1.0]}),
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
         )
         bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)
@@ -507,7 +507,7 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         bad_tgt = SampleFrame._create(
             df=pd.DataFrame({"id": [1], "z": [10.0], "w": [1.0]}),
             id_column="id",
-            covars_columns=["z"],
+            covar_columns=["z"],
             weight_columns=["w"],
         )
         with self.assertRaises(ValueError) as ctx:
@@ -1168,13 +1168,13 @@ class TestBalanceFrameDfExportFilter(BalanceTestCase):
         resp_sf = SampleFrame._create(
             df=pd.DataFrame({"id": ["1", "2"], "x1": [10.0, 20.0]}),
             id_column="id",
-            covars_columns=["x1"],
+            covar_columns=["x1"],
             weight_columns=[],
         )
         tgt_sf = SampleFrame._create(
             df=pd.DataFrame({"id": ["3", "4"], "x1": [15.0, 25.0]}),
             id_column="id",
-            covars_columns=["x1"],
+            covar_columns=["x1"],
             weight_columns=[],
         )
         bf = BalanceFrame(sf_with_outcomes=resp_sf, sf_target=tgt_sf)

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -987,7 +987,7 @@ class TestBalanceFrameParityHelpers(BalanceTestCase):
                 "weight": [1.0, 1.0, 1.0],
             }
         )
-        self.resp_sf = SampleFrame.from_frame(self.resp_df, misc_columns=["region"])
+        self.resp_sf = SampleFrame.from_frame(self.resp_df, ignore_columns=["region"])
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
         self.bf = BalanceFrame(responders=self.resp_sf, target=self.tgt_sf)
 

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -60,7 +60,7 @@ class TestBalanceFrameConstruction(BalanceTestCase):
 
     def test_model_none_on_creation(self) -> None:
         bf = BalanceFrame(sample=self.resp_sf, sf_target=self.tgt_sf)
-        self.assertIsNone(bf.model())
+        self.assertIsNone(bf.model)
 
     def test_missing_responders_raises(self) -> None:
         with self.assertRaises(TypeError):
@@ -258,7 +258,7 @@ class TestBalanceFrameCreateDirect(BalanceTestCase):
         self.assertIsNotNone(bf.target)
         self.assertIsNone(bf.unadjusted)
         self.assertFalse(bf.is_adjusted)
-        self.assertIsNone(bf.model())
+        self.assertIsNone(bf.model)
         # Responder data is correct
         self.assertEqual(len(bf.responders.df_covars), 2)
         self.assertListEqual(list(bf.responders.df_weights.columns), ["w"])
@@ -290,7 +290,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
     def test_adjust_ipw(self) -> None:
         adjusted = self.bf.adjust(method="ipw")
         self.assertTrue(adjusted.is_adjusted)
-        model = adjusted.model()
+        model = adjusted.model
         self.assertIsNotNone(model)
         assert model is not None  # for Pyre narrowing
         self.assertIn("method", model)
@@ -312,7 +312,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
         adjusted = self.bf.adjust(method="ipw")
         # Original BalanceFrame is unchanged
         self.assertFalse(self.bf.is_adjusted)
-        self.assertIsNone(self.bf.model())
+        self.assertIsNone(self.bf.model)
         self.assertIsNone(self.bf.unadjusted)
         # Original weights unchanged
         after_weight_vals = self.bf.responders.df_weights.iloc[:, 0].tolist()
@@ -340,7 +340,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
         # All adjusted weights should be 42.0
         for w in adjusted.responders.df_weights.iloc[:, 0].tolist():
             self.assertAlmostEqual(w, 42.0, places=5)
-        model = adjusted.model()
+        model = adjusted.model
         assert model is not None
         self.assertEqual(model["method"], "dummy")
 
@@ -373,7 +373,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
     def test_adjust_stores_method_name_in_model(self) -> None:
         """adjust() stores the method name in the adjustment model dict."""
         adjusted = self.bf.adjust(method="null")
-        model = adjusted.model()
+        model = adjusted.model
         self.assertIsInstance(model, dict)
         assert model is not None
         self.assertEqual(model["method"], "null_adjustment")
@@ -390,7 +390,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
             return {"weight": sample_weights, "model": {"info": "test"}}
 
         adjusted = self.bf.adjust(method=custom_method)
-        model = adjusted.model()
+        model = adjusted.model
         self.assertIsInstance(model, dict)
         assert model is not None
         self.assertEqual(model["method"], "custom_method")
@@ -412,7 +412,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
         adjusted_copy = copy.deepcopy(adjusted)
         self.assertTrue(adjusted_copy.is_adjusted)
         self.assertIsNotNone(adjusted_copy.unadjusted)
-        self.assertIsNotNone(adjusted_copy.model())
+        self.assertIsNotNone(adjusted_copy.model)
         # The copy's weights should match
         pd.testing.assert_series_equal(
             adjusted_copy.responders.df_weights.iloc[:, 0],
@@ -495,7 +495,7 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         # set_target returns a NEW BalanceFrame; the original stays adjusted.
         retargeted = adjusted.set_target(tgt2_sf)
         self.assertFalse(retargeted.is_adjusted)
-        self.assertIsNone(retargeted.model())
+        self.assertIsNone(retargeted.model)
 
     def test_set_target_non_sampleframe_raises(self) -> None:
         bf = BalanceFrame(sample=self.resp_sf)
@@ -1263,7 +1263,7 @@ class TestBalanceFrameMissingIntegration(BalanceTestCase):
         adjusted = self.bf.adjust(method="null")
 
         self.assertTrue(adjusted.is_adjusted)
-        model = adjusted.model()
+        model = adjusted.model
         self.assertIsNotNone(model)
         assert model is not None
         self.assertEqual(model["method"], "null_adjustment")
@@ -1602,7 +1602,7 @@ class TestBalanceFrameFromSample(BalanceTestCase):
         bf = BalanceFrame.from_sample(adjusted)
         self.assertTrue(bf.is_adjusted)
         self.assertIsNotNone(bf.unadjusted)
-        self.assertIsNotNone(bf.model())
+        self.assertIsNotNone(bf.model)
 
     def test_from_sample_covars_preserved(self) -> None:
         sample_with_target = self.sample.set_target(self.target)
@@ -1722,7 +1722,7 @@ class TestBalanceFrameToSample(BalanceTestCase):
         s = adjusted_bf.to_sample()
         self.assertTrue(s.is_adjusted())
         self.assertTrue(s.has_target())
-        self.assertIsNotNone(s.model())
+        self.assertIsNotNone(s.model)
 
     def test_to_sample_adjusted_weight_column(self) -> None:
         adjusted_bf = self.bf.adjust(method="null")

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -299,7 +299,7 @@ class TestBalanceFrameAdjust(BalanceTestCase):
     def test_adjust_preserves_original_weights(self) -> None:
         adjusted = self.bf.adjust(method="null")
         # Original weight column still present alongside adjusted
-        all_w_cols = adjusted.responders.weight_columns
+        all_w_cols = adjusted.responders.weight_columns_all
         self.assertIn("weight", all_w_cols)
         self.assertIn("weight_adjusted", all_w_cols)
         # Active weight is the adjusted one
@@ -1176,7 +1176,7 @@ class TestBalanceFrameDfExportFilter(BalanceTestCase):
         filtered = bf.keep_only_some_rows_columns(columns_to_keep=["x1"])
         self.assertIn("x1", filtered.responders._df.columns)
         self.assertIn("id", filtered.responders._df.columns)
-        self.assertIsNone(filtered.responders._active_weight_column)
+        self.assertIsNone(filtered.responders._weight_column_name)
 
     # --- to_csv ---
 
@@ -1709,7 +1709,7 @@ class TestBalanceFrameToSample(BalanceTestCase):
 
     def test_to_sample_weight_values(self) -> None:
         s = self.bf.to_sample()
-        self.assertEqual(s.weight_column.tolist(), [1.0, 1.0, 1.0])
+        self.assertEqual(s.weight_series.tolist(), [1.0, 1.0, 1.0])
 
     def test_to_sample_id_values(self) -> None:
         s = self.bf.to_sample()
@@ -1731,7 +1731,7 @@ class TestBalanceFrameToSample(BalanceTestCase):
     def test_to_sample_adjusted_weight_column(self) -> None:
         adjusted_bf = self.bf.adjust(method="null")
         s = adjusted_bf.to_sample()
-        self.assertEqual(s.weight_column.name, "weight_adjusted")
+        self.assertEqual(s.weight_series.name, "weight_adjusted")
 
     def test_to_sample_with_outcomes(self) -> None:
         resp_df = pd.DataFrame(
@@ -1765,8 +1765,8 @@ class TestBalanceFrameToSample(BalanceTestCase):
             sorted(original._covar_columns_names()),
         )
         for o_val, r_val in zip(
-            _assert_type(original.weight_column).tolist(),
-            _assert_type(roundtrip.weight_column).tolist(),
+            _assert_type(original.weight_series).tolist(),
+            _assert_type(roundtrip.weight_series).tolist(),
         ):
             self.assertAlmostEqual(o_val, r_val, places=10)
 
@@ -1782,8 +1782,8 @@ class TestBalanceFrameToSample(BalanceTestCase):
         self.assertTrue(roundtrip.is_adjusted())
         self.assertTrue(roundtrip.has_target())
         for o_val, r_val in zip(
-            _assert_type(adjusted.weight_column).tolist(),
-            _assert_type(roundtrip.weight_column).tolist(),
+            _assert_type(adjusted.weight_series).tolist(),
+            _assert_type(roundtrip.weight_series).tolist(),
         ):
             self.assertAlmostEqual(o_val, r_val, places=10)
 
@@ -1804,8 +1804,8 @@ class TestBalanceFrameToSample(BalanceTestCase):
         self.assertTrue(roundtrip.is_adjusted())
         self.assertTrue(roundtrip.has_target())
         for o_val, r_val in zip(
-            _assert_type(old_adjusted.weight_column).tolist(),
-            _assert_type(roundtrip.weight_column).tolist(),
+            _assert_type(old_adjusted.weight_series).tolist(),
+            _assert_type(roundtrip.weight_series).tolist(),
         ):
             self.assertAlmostEqual(o_val, r_val, places=5)
         self.assertEqual(

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -1007,7 +1007,7 @@ class TestBalanceFrameSummaryDiagnostics(BalanceTestCase):
 
 
 class TestBalanceFrameParityHelpers(BalanceTestCase):
-    """Tests for ignored_columns() and id_column parity methods."""
+    """Tests for df_ignored access and id_column parity methods."""
 
     def setUp(self) -> None:
         super().setUp()
@@ -1026,17 +1026,17 @@ class TestBalanceFrameParityHelpers(BalanceTestCase):
                 "weight": [1.0, 1.0, 1.0],
             }
         )
-        self.resp_sf = SampleFrame.from_frame(self.resp_df, ignore_columns=["region"])
+        self.resp_sf = SampleFrame.from_frame(self.resp_df, ignored_columns=["region"])
         self.tgt_sf = SampleFrame.from_frame(self.tgt_df)
         self.bf = BalanceFrame(sf_with_outcomes=self.resp_sf, sf_target=self.tgt_sf)
 
-    def test_ignored_columns_present(self) -> None:
-        result = self.bf.ignored_columns()
+    def test_df_ignored_present(self) -> None:
+        result = self.bf.responders.df_ignored
         self.assertIsNotNone(result)
         self.assertListEqual(list(result.columns), ["region"])
         self.assertListEqual(list(result["region"]), ["US", "UK", "CA"])
 
-    def test_ignored_columns_none(self) -> None:
+    def test_df_ignored_none(self) -> None:
         resp = SampleFrame.from_frame(
             pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]})
         )
@@ -1044,12 +1044,7 @@ class TestBalanceFrameParityHelpers(BalanceTestCase):
             pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]})
         )
         bf = BalanceFrame(sf_with_outcomes=resp, sf_target=tgt)
-        self.assertIsNone(bf.ignored_columns())
-
-    def test_ignored_columns_delegates_to_responders(self) -> None:
-        pd.testing.assert_frame_equal(
-            self.bf.ignored_columns(), self.bf.responders.ignored_columns()
-        )
+        self.assertIsNone(bf.responders.df_ignored)
 
     def test_id_column_returns_series(self) -> None:
         result = self.bf.id_column

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -621,14 +621,14 @@ class TestBalanceFrameCovarsWeightsOutcomes(BalanceTestCase):
 
     def test_covars_links_unadjusted(self) -> None:
         adjusted = self.bf.adjust(method="null")
-        linked = adjusted.covars()._BalanceDF_child_from_linked_samples()
+        linked = adjusted.covars()._balancedf_child_from_linked_samples()
         self.assertIn("self", linked)
         self.assertIn("target", linked)
         self.assertIn("unadjusted", linked)
         self.assertEqual(len(linked), 3)
 
     def test_covars_links_no_unadjusted(self) -> None:
-        linked = self.bf.covars()._BalanceDF_child_from_linked_samples()
+        linked = self.bf.covars()._balancedf_child_from_linked_samples()
         self.assertIn("self", linked)
         self.assertIn("target", linked)
         self.assertNotIn("unadjusted", linked)

--- a/tests/test_balancedf.py
+++ b/tests/test_balancedf.py
@@ -5,7 +5,13 @@
 
 # pyre-strict
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    annotations,
+    division,
+    print_function,
+    unicode_literals,
+)
 
 import tempfile
 from copy import deepcopy
@@ -3390,7 +3396,9 @@ class TestBalanceDFSourceProtocol(BalanceTestCase):
 
     def test_protocol_is_runtime_checkable(self) -> None:
         """Verify that BalanceDFSource is runtime_checkable."""
-        self.assertTrue(hasattr(BalanceDFSource, "__protocol_attrs__"))
+        # _is_runtime_protocol is set by @runtime_checkable on all Python
+        # versions (3.8+).  __protocol_attrs__ only exists from 3.12+.
+        self.assertTrue(getattr(BalanceDFSource, "_is_runtime_protocol", False))
 
     def test_non_conforming_object_fails_isinstance(self) -> None:
         """Verify that an arbitrary object does NOT satisfy the protocol."""

--- a/tests/test_balancedf.py
+++ b/tests/test_balancedf.py
@@ -848,46 +848,46 @@ class TestBalanceDFWeights(BalanceTestCase):
         self.assertEqual(w.summary().round(2).to_dict(), exp)
 
 
-class TestBalanceDF__BalanceDF_child_from_linked_samples(BalanceTestCase):
-    def test__BalanceDF_child_from_linked_samples_keys(self) -> None:
+class TestBalanceDF__balancedf_child_from_linked_samples(BalanceTestCase):
+    def test__balancedf_child_from_linked_samples_keys(self) -> None:
         self.assertEqual(
-            list(s1.covars()._BalanceDF_child_from_linked_samples().keys()), ["self"]
+            list(s1.covars()._balancedf_child_from_linked_samples().keys()), ["self"]
         )
         self.assertEqual(
-            list(s3.covars()._BalanceDF_child_from_linked_samples().keys()),
+            list(s3.covars()._balancedf_child_from_linked_samples().keys()),
             ["self", "target"],
         )
         self.assertEqual(
-            list(s3_null.covars()._BalanceDF_child_from_linked_samples().keys()),
+            list(s3_null.covars()._balancedf_child_from_linked_samples().keys()),
             ["self", "target", "unadjusted"],
         )
 
         self.assertEqual(
-            list(s1.weights()._BalanceDF_child_from_linked_samples().keys()), ["self"]
+            list(s1.weights()._balancedf_child_from_linked_samples().keys()), ["self"]
         )
         self.assertEqual(
-            list(s3.weights()._BalanceDF_child_from_linked_samples().keys()),
+            list(s3.weights()._balancedf_child_from_linked_samples().keys()),
             ["self", "target"],
         )
         self.assertEqual(
-            list(s3_null.weights()._BalanceDF_child_from_linked_samples().keys()),
+            list(s3_null.weights()._balancedf_child_from_linked_samples().keys()),
             ["self", "target", "unadjusted"],
         )
 
         self.assertEqual(
-            list(s1.outcomes()._BalanceDF_child_from_linked_samples().keys()), ["self"]
+            list(s1.outcomes()._balancedf_child_from_linked_samples().keys()), ["self"]
         )
         self.assertEqual(
-            list(s3.outcomes()._BalanceDF_child_from_linked_samples().keys()),
+            list(s3.outcomes()._balancedf_child_from_linked_samples().keys()),
             ["self", "target"],
         )
         self.assertEqual(
-            list(s3_null.outcomes()._BalanceDF_child_from_linked_samples().keys()),
+            list(s3_null.outcomes()._balancedf_child_from_linked_samples().keys()),
             ["self", "target", "unadjusted"],
         )
 
-    def test__BalanceDF_child_from_linked_samples_class_types(self) -> None:
-        """Test that _BalanceDF_child_from_linked_samples returns correct class types.
+    def test__balancedf_child_from_linked_samples_class_types(self) -> None:
+        """Test that _balancedf_child_from_linked_samples returns correct class types.
 
         Verifies that the method returns appropriate BalanceDF subclasses
         based on the type and number of linked samples.
@@ -896,29 +896,29 @@ class TestBalanceDF__BalanceDF_child_from_linked_samples(BalanceTestCase):
         self.assertEqual(s1.covars().__class__, BalanceDFCovars)
 
         # We get a different number of classes based on the number of linked items:
-        the_dict = s1.covars()._BalanceDF_child_from_linked_samples()
+        the_dict = s1.covars()._balancedf_child_from_linked_samples()
         exp = [BalanceDFCovars]
         self.assertEqual([v.__class__ for (k, v) in the_dict.items()], exp)
 
-        the_dict = s3.covars()._BalanceDF_child_from_linked_samples()
+        the_dict = s3.covars()._balancedf_child_from_linked_samples()
         exp = 2 * [BalanceDFCovars]
         self.assertEqual([v.__class__ for (k, v) in the_dict.items()], exp)
 
-        the_dict = s3_null.covars()._BalanceDF_child_from_linked_samples()
+        the_dict = s3_null.covars()._balancedf_child_from_linked_samples()
         exp = 3 * [BalanceDFCovars]
         self.assertEqual([v.__class__ for (k, v) in the_dict.items()], exp)
 
-    def test__BalanceDF_child_from_linked_samples_weights_class(self) -> None:
-        """Test that _BalanceDF_child_from_linked_samples works for BalanceDFWeights."""
+    def test__balancedf_child_from_linked_samples_weights_class(self) -> None:
+        """Test that _balancedf_child_from_linked_samples works for BalanceDFWeights."""
         # This also works for things other than BalanceDFCovars:
-        the_dict = s3_null.weights()._BalanceDF_child_from_linked_samples()
+        the_dict = s3_null.weights()._balancedf_child_from_linked_samples()
         exp = 3 * [BalanceDFWeights]
         self.assertEqual([v.__class__ for (k, v) in the_dict.items()], exp)
 
-    def test__BalanceDF_child_from_linked_samples_outcomes_with_none(self) -> None:
-        """Test that _BalanceDF_child_from_linked_samples handles None outcomes correctly."""
+    def test__balancedf_child_from_linked_samples_outcomes_with_none(self) -> None:
+        """Test that _balancedf_child_from_linked_samples handles None outcomes correctly."""
         # Notice that with something like outcomes, we might get a None in return!
-        the_dict = s3_null.outcomes()._BalanceDF_child_from_linked_samples()
+        the_dict = s3_null.outcomes()._balancedf_child_from_linked_samples()
         exp = [
             BalanceDFOutcomes,
             type(None),
@@ -926,11 +926,11 @@ class TestBalanceDF__BalanceDF_child_from_linked_samples(BalanceTestCase):
         ]
         self.assertEqual([v.__class__ for (k, v) in the_dict.items()], exp)
 
-    def test__BalanceDF_child_from_linked_samples_covars_values(self) -> None:
+    def test__balancedf_child_from_linked_samples_covars_values(self) -> None:
         """Test that covariates DataFrame values are correctly preserved in linked samples."""
         # Verify DataFrame values makes sense:
         # for covars
-        the_dict = s3_null.covars()._BalanceDF_child_from_linked_samples()
+        the_dict = s3_null.covars()._balancedf_child_from_linked_samples()
         exp = [
             {
                 "a": {0: 1, 1: 2, 2: 3, 3: 1},
@@ -950,20 +950,20 @@ class TestBalanceDF__BalanceDF_child_from_linked_samples(BalanceTestCase):
         ]
         self.assertEqual([v.df.to_dict() for (k, v) in the_dict.items()], exp)
 
-    def test__BalanceDF_child_from_linked_samples_outcomes_values(self) -> None:
+    def test__balancedf_child_from_linked_samples_outcomes_values(self) -> None:
         """Test that outcomes DataFrame values are correctly preserved, excluding None values."""
         # for outcomes
-        the_dict = s3_null.outcomes()._BalanceDF_child_from_linked_samples()
+        the_dict = s3_null.outcomes()._balancedf_child_from_linked_samples()
         exp = [{"o": {0: 7, 1: 8, 2: 9, 3: 10}}, {"o": {0: 7, 1: 8, 2: 9, 3: 10}}]
         # need to exclude None v:
         self.assertEqual(
             [v.df.to_dict() for (k, v) in the_dict.items() if v is not None], exp
         )
 
-    def test__BalanceDF_child_from_linked_samples_weights_values(self) -> None:
+    def test__balancedf_child_from_linked_samples_weights_values(self) -> None:
         """Test that weights DataFrame values are correctly preserved in linked samples."""
         # for weights
-        the_dict = s3_null.weights()._BalanceDF_child_from_linked_samples()
+        the_dict = s3_null.weights()._balancedf_child_from_linked_samples()
         exp = [
             {"w": {0: 0.5, 1: 2.0, 2: 1.0, 3: 1.0}},
             {"w": {0: 0.5, 1: 1.0, 2: 2.0}},
@@ -1533,7 +1533,7 @@ class TestBalanceDF_asmd(BalanceTestCase):
         covars = adjusted.covars(formula="age_group * gender")
         output = covars.kld(on_linked_samples=True)
 
-        links = covars._BalanceDF_child_from_linked_samples()
+        links = covars._balancedf_child_from_linked_samples()
         self_df = links["self"].df
         target_df = links["target"].df
         unadj_df = links["unadjusted"].df
@@ -1758,7 +1758,7 @@ class TestBalanceDF_asmd(BalanceTestCase):
         covars = adjusted.covars(formula="age_group * gender")
         output = covars.kld(on_linked_samples=True)
 
-        links = covars._BalanceDF_child_from_linked_samples()
+        links = covars._balancedf_child_from_linked_samples()
         self_df = links["self"].df
         target_df = links["target"].df
         unadj_df = links["unadjusted"].df
@@ -1937,7 +1937,7 @@ class TestBalanceDF_asmd(BalanceTestCase):
 
     def test_BalanceDF_kld_on_linked_samples(self) -> None:
         covars = s3_null_madeup_weights.covars()
-        links = covars._BalanceDF_child_from_linked_samples()
+        links = covars._balancedf_child_from_linked_samples()
 
         self.assertIn("unadjusted", links)
         self.assertIn("target", links)
@@ -2030,7 +2030,7 @@ class TestBalanceDF_asmd(BalanceTestCase):
         pd.testing.assert_frame_equal(covars.df, original_df)
 
         # Build expected values using the same NA-indicator logic
-        links = covars._BalanceDF_child_from_linked_samples()
+        links = covars._balancedf_child_from_linked_samples()
         self_df, self_w = links["self"]._get_df_and_weights(use_model_matrix=False)
         target_df, target_w = links["target"]._get_df_and_weights(
             use_model_matrix=False
@@ -2545,13 +2545,13 @@ class TestBalanceDF(BalanceTestCase):
         with self.assertRaises(PatsyError):
             covars.model_matrix(formula="missing_column + a")
 
-    def test_check_if_not_BalanceDF(self) -> None:
+    def test_check_if_not_balancedf(self) -> None:
         with self.assertRaisesRegex(ValueError, "number must be balancedf_class"):
-            BalanceDF._check_if_not_BalanceDF(
+            BalanceDF._check_if_not_balancedf(
                 5,  # pyre-ignore[6]: Testing error handling with wrong type
                 "number",
             )
-        self.assertTrue(BalanceDF._check_if_not_BalanceDF(s3.covars()) is None)
+        self.assertTrue(BalanceDF._check_if_not_balancedf(s3.covars()) is None)
 
 
 class TestBalanceDFCovars_from_frame(BalanceTestCase):
@@ -3609,7 +3609,7 @@ class TestBalanceDFSourceProtocol(BalanceTestCase):
         covars = s3_null.covars()
         self.assertIsNotNone(covars.df)
         self.assertIsNotNone(covars.mean())
-        linked = covars._BalanceDF_child_from_linked_samples()
+        linked = covars._balancedf_child_from_linked_samples()
         self.assertIn("self", linked)
         self.assertIn("target", linked)
         self.assertIn("unadjusted", linked)

--- a/tests/test_balancedf.py
+++ b/tests/test_balancedf.py
@@ -3420,7 +3420,7 @@ class TestBalanceDFSourceProtocol(BalanceTestCase):
                 self._data = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
 
             @property
-            def weight_column(self) -> pd.Series:
+            def weight_series(self) -> pd.Series:
                 return pd.Series([1.0, 1.0, 1.0], name="w")
 
             @property
@@ -3463,7 +3463,7 @@ class TestBalanceDFSourceProtocol(BalanceTestCase):
                 self._data = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4.0, 5.0, 6.0]})
 
             @property
-            def weight_column(self) -> pd.Series:
+            def weight_series(self) -> pd.Series:
                 return pd.Series([1.0, 1.0, 1.0], name="w")
 
             @property
@@ -3494,7 +3494,7 @@ class TestBalanceDFSourceProtocol(BalanceTestCase):
         self.assertIn("id", df_with_ids.columns)
         self.assertEqual(list(df_with_ids["id"]), [10, 20, 30])
 
-        # Verify _weights works (accesses _sample.weight_column)
+        # Verify _weights works (accesses _sample.weight_series)
         weights = covars._weights
         self.assertIsNotNone(weights)
         self.assertEqual(len(weights), 3)
@@ -3506,7 +3506,7 @@ class TestBalanceDFSourceProtocol(BalanceTestCase):
             """Mock source for BalanceDFWeights testing."""
 
             @property
-            def weight_column(self) -> pd.Series:
+            def weight_series(self) -> pd.Series:
                 return pd.Series([1.0, 2.0, 3.0], name="w")
 
             @property
@@ -3540,7 +3540,7 @@ class TestBalanceDFSourceProtocol(BalanceTestCase):
             """Mock source with outcomes for BalanceDFOutcomes testing."""
 
             @property
-            def weight_column(self) -> pd.Series:
+            def weight_series(self) -> pd.Series:
                 return pd.Series([1.0, 1.0, 1.0], name="w")
 
             @property

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,11 +163,11 @@ class TestCli(
                 id_column: str | None = None,
                 weight_column: str | None = None,
                 outcome_columns: tuple[str, ...] | None = None,
-                ignore_columns: list[str] | None = None,
+                ignored_columns: list[str] | None = None,
                 **kwargs: object,
             ) -> "RecordingSample":
                 cls.calls.append(outcome_columns)
-                cls.ignore_calls.append(ignore_columns)
+                cls.ignore_calls.append(ignored_columns)
                 return cls(df)
 
             def set_target(self, target: "RecordingSample") -> "RecordingSample":
@@ -1584,10 +1584,10 @@ class TestBalanceCLI_csv_column_parsing(balance.testutil.BalanceTestCase):
         self.assertEqual(cli.covariate_columns_for_diagnostics(), ["x", "y"])
 
     def test_keep_columns_preserved_in_adjusted_output(self) -> None:
-        """Test that --keep_columns columns survive adjustment via ignore_columns.
+        """Test that --keep_columns columns survive adjustment via ignored_columns.
 
         A keep column that is not id, weight, covariate, or outcome should be
-        routed to ignore_columns by process_batch, carried through the Sample,
+        routed to ignored_columns by process_batch, carried through the Sample,
         and available for adapt_output to subset without KeyError.
         """
         with (

--- a/tests/test_e2e_from_tutorials.py
+++ b/tests/test_e2e_from_tutorials.py
@@ -1,0 +1,905 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""End-to-end tests that reproduce the balance_quickstart tutorial.
+
+Each test mirrors a section of the tutorial notebook and compares output
+against known-good expected values captured from a healthy codebase run.
+
+IPW adjustments use a fixed lambda (``num_lambdas=1``) to skip the
+cross-validation grid search and keep runtime under a few seconds.
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import sys
+import unittest
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from balance import load_data, Sample
+
+
+def _has_sklearn_1_4() -> bool:
+    """Return True if scikit-learn >= 1.4 is available."""
+    try:
+        import sklearn
+
+        return tuple(int(x) for x in sklearn.__version__.split(".")[:2]) >= (1, 4)
+    except Exception:
+        return False
+
+
+_SKLEARN_1_4_AVAILABLE: bool = _has_sklearn_1_4()
+
+
+# ---------------------------------------------------------------------------
+# Fixed lambda from the tutorial run — avoids the slow CV search.
+# ---------------------------------------------------------------------------
+
+_FIXED_LAMBDA: float = 0.041158338186664825
+_IPW_FAST_KWARGS: dict[str, Any] = {
+    "num_lambdas": 1,
+    "lambda_min": _FIXED_LAMBDA,
+    "lambda_max": _FIXED_LAMBDA,
+}
+
+
+class E2ETutorialQuickstartTest(unittest.TestCase):
+    """Reproduce balance_quickstart.ipynb and verify outputs."""
+
+    # shared across all tests — created once
+    target_df: pd.DataFrame
+    sample_df: pd.DataFrame
+    sample: Sample
+    target: Sample
+    sample_with_target: Sample
+    adjusted: Sample
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        target_df, sample_df = load_data()
+        assert target_df is not None and sample_df is not None
+        cls.target_df = target_df
+        cls.sample_df = sample_df
+        cls.sample = Sample.from_frame(cls.sample_df, outcome_columns=["happiness"])
+        cls.target = Sample.from_frame(cls.target_df, outcome_columns=["happiness"])
+        cls.sample_with_target = cls.sample.set_target(cls.target)
+        cls.adjusted = cls.sample_with_target.adjust(**_IPW_FAST_KWARGS)
+
+    # -----------------------------------------------------------------------
+    # 1. Load data
+    # -----------------------------------------------------------------------
+    def test_load_data_shapes(self) -> None:
+        self.assertEqual(self.sample_df.shape, (1000, 5))
+        self.assertEqual(self.target_df.shape, (10000, 5))
+
+    def test_target_df_head(self) -> None:
+        expected = {
+            "id": {0: "100000", 1: "100001", 2: "100002", 3: "100003", 4: "100004"},
+            "gender": {0: "Male", 1: "Male", 2: "Male", 3: np.nan, 4: np.nan},
+            "age_group": {0: "45+", 1: "45+", 2: "35-44", 3: "45+", 4: "25-34"},
+            "income": {0: 10.18, 1: 6.04, 2: 5.23, 3: 5.75, 4: 4.84},
+            "happiness": {0: 61.71, 1: 79.12, 2: 44.21, 3: 83.99, 4: 49.34},
+        }
+        result = self.target_df.head().round(2).to_dict()
+
+        # Compare non-NaN values; NaN == NaN is False, so handle gender separately
+        for col in ["id", "age_group", "income", "happiness"]:
+            self.assertEqual(result[col], expected[col], f"Mismatch in column {col}")
+
+        gender = result["gender"]
+        self.assertEqual(gender[0], "Male")
+        self.assertEqual(gender[1], "Male")
+        self.assertEqual(gender[2], "Male")
+        self.assertTrue(pd.isna(gender[3]))
+        self.assertTrue(pd.isna(gender[4]))
+
+    def test_sample_df_head(self) -> None:
+        head = self.sample_df.head().round(2)
+        self.assertEqual(head["id"].tolist(), ["0", "1", "2", "3", "4"])
+
+        # Compare non-NaN values; NaN == NaN is False, so handle gender separately
+        gender = head["gender"].tolist()
+        self.assertEqual(gender[0], "Male")
+        self.assertEqual(gender[1], "Female")
+        self.assertEqual(gender[2], "Male")
+        self.assertTrue(pd.isna(gender[3]))
+        self.assertTrue(pd.isna(gender[4]))
+
+        self.assertEqual(
+            head["age_group"].tolist(),
+            ["25-34", "18-24", "18-24", "18-24", "18-24"],
+        )
+        self.assertEqual(head["income"].tolist(), [6.43, 9.94, 2.67, 10.55, 2.69])
+        self.assertEqual(
+            head["happiness"].tolist(), [26.04, 66.89, 37.09, 49.39, 72.30]
+        )
+
+    # -----------------------------------------------------------------------
+    # 2. Sample object creation
+    # -----------------------------------------------------------------------
+    def test_sample_df_shape_and_columns(self) -> None:
+        """sample.df has 1000 rows x 6 columns (id, gender, age_group, income, happiness, weight)."""
+        self.assertEqual(self.sample.df.shape, (1000, 6))
+        self.assertCountEqual(
+            self.sample.df.columns.tolist(),
+            ["id", "gender", "age_group", "income", "happiness", "weight"],
+        )
+
+    def test_sample_repr(self) -> None:
+        r = repr(self.sample)
+        self.assertIn("balance Sample object", r)
+        self.assertIn("1000 observations x 3 variables", r)
+        self.assertIn("gender,age_group,income", r)
+        self.assertIn("outcome_columns: happiness", r)
+
+    def test_target_repr(self) -> None:
+        r = repr(self.target)
+        self.assertIn("balance Sample object", r)
+        self.assertIn("10000 observations x 3 variables", r)
+
+    def test_sample_with_target_repr(self) -> None:
+        r = repr(self.sample_with_target)
+        self.assertIn("balance Sample object with target set", r)
+        self.assertIn("3 common variables", r)
+
+    # -----------------------------------------------------------------------
+    # 3. Pre-adjustment diagnostics: covars().mean()
+    # -----------------------------------------------------------------------
+    def test_covars_mean_before_adjustment(self) -> None:
+        mean_df = self.sample_with_target.covars().mean().T
+        _expected_str = """  # noqa: F841
+source                     self     target
+_is_na_gender[T.True]  0.088000   0.089800
+age_group[T.25-34]     0.300000   0.297400
+age_group[T.35-44]     0.156000   0.299200
+age_group[T.45+]       0.053000   0.206300
+gender[Female]         0.268000   0.455100
+gender[Male]           0.644000   0.455100
+gender[_NA]            0.088000   0.089800
+income                 6.297302  12.737608
+"""
+        # Verify key values with rounding
+        self.assertAlmostEqual(mean_df.loc["income", "self"], 6.297302, places=2)
+        self.assertAlmostEqual(mean_df.loc["income", "target"], 12.737608, places=2)
+        self.assertAlmostEqual(mean_df.loc["gender[Female]", "self"], 0.268, places=3)
+        self.assertAlmostEqual(
+            mean_df.loc["gender[Female]", "target"], 0.4551, places=3
+        )
+        self.assertAlmostEqual(mean_df.loc["age_group[T.45+]", "self"], 0.053, places=3)
+        self.assertAlmostEqual(
+            mean_df.loc["age_group[T.45+]", "target"], 0.2063, places=3
+        )
+        self.assertAlmostEqual(
+            mean_df.loc["_is_na_gender[T.True]", "self"], 0.088, places=3
+        )
+
+    # -----------------------------------------------------------------------
+    # 4. Pre-adjustment diagnostics: covars().asmd()
+    # -----------------------------------------------------------------------
+    def test_covars_asmd_before_adjustment(self) -> None:
+        asmd_df = self.sample_with_target.covars().asmd().T
+        _expected_str = """  # noqa: F841
+source                  self
+age_group[T.25-34]  0.005688
+age_group[T.35-44]  0.312711
+age_group[T.45+]    0.378828
+gender[Female]      0.375699
+gender[Male]        0.379314
+gender[_NA]         0.006296
+income              0.494217
+mean(asmd)          0.326799
+"""
+        self.assertAlmostEqual(asmd_df.loc["mean(asmd)", "self"], 0.326799, places=3)
+        self.assertAlmostEqual(asmd_df.loc["income", "self"], 0.494217, places=3)
+        self.assertAlmostEqual(
+            asmd_df.loc["gender[Female]", "self"], 0.375699, places=3
+        )
+
+    def test_covars_asmd_aggregated_before_adjustment(self) -> None:
+        asmd_agg = self.sample_with_target.covars().asmd(aggregate_by_main_covar=True).T
+        _expected_str = """  # noqa: F841
+source          self
+age_group   0.232409
+gender      0.253769
+income      0.494217
+mean(asmd)  0.326799
+"""
+        self.assertAlmostEqual(asmd_agg.loc["age_group", "self"], 0.232409, places=3)
+        self.assertAlmostEqual(asmd_agg.loc["gender", "self"], 0.253769, places=3)
+        self.assertAlmostEqual(asmd_agg.loc["income", "self"], 0.494217, places=3)
+        self.assertAlmostEqual(asmd_agg.loc["mean(asmd)", "self"], 0.326799, places=3)
+
+    # -----------------------------------------------------------------------
+    # 5. Distribution diagnostics (KLD, EMD, CVMD, KS)
+    # -----------------------------------------------------------------------
+    def test_covars_kld_before_adjustment(self) -> None:
+        kld = self.sample_with_target.covars().kld().T
+        _expected_str = """  # noqa: F841
+source         self
+gender     0.079889
+age_group  0.277138
+income     0.114895
+mean(kld)  0.157307
+"""
+        self.assertAlmostEqual(kld.loc["mean(kld)", "self"], 0.157307, places=3)
+        self.assertAlmostEqual(kld.loc["gender", "self"], 0.079889, places=3)
+        self.assertAlmostEqual(kld.loc["age_group", "self"], 0.277138, places=3)
+        self.assertAlmostEqual(kld.loc["income", "self"], 0.114895, places=3)
+
+    def test_covars_emd_before_adjustment(self) -> None:
+        emd = self.sample_with_target.covars().emd().T
+        _expected_str = """  # noqa: F841
+source         self
+gender     0.188900
+age_group  0.743700
+income     6.440306
+mean(emd)  2.457635
+"""
+        self.assertAlmostEqual(emd.loc["mean(emd)", "self"], 2.457635, places=2)
+        self.assertAlmostEqual(emd.loc["income", "self"], 6.440306, places=2)
+
+    def test_covars_cvmd_before_adjustment(self) -> None:
+        cvmd = self.sample_with_target.covars().cvmd().T
+        _expected_str = """  # noqa: F841
+source          self
+gender      0.012658
+age_group   0.061326
+income      0.029834
+mean(cvmd)  0.034606
+"""
+        self.assertAlmostEqual(cvmd.loc["mean(cvmd)", "self"], 0.034606, places=3)
+
+    def test_covars_ks_before_adjustment(self) -> None:
+        ks = self.sample_with_target.covars().ks().T
+        _expected_str = """  # noqa: F841
+source         self
+gender     0.187100
+age_group  0.296500
+income     0.246400
+mean(ks)   0.243333
+"""
+        self.assertAlmostEqual(ks.loc["mean(ks)", "self"], 0.243333, places=3)
+
+    # -----------------------------------------------------------------------
+    # 6. Pre-adjustment plots (no-crash)
+    # -----------------------------------------------------------------------
+    def test_covars_plot_plotly_no_crash(self) -> None:
+        """covars().plot() should not crash (plotly, default)."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+        # Default library is plotly; this should not raise
+        self.sample_with_target.covars().plot()
+
+    def test_covars_plot_seaborn_kde_no_crash(self) -> None:
+        """covars().plot(library='seaborn', dist_type='kde') should not crash."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+        self.sample_with_target.covars().plot(library="seaborn", dist_type="kde")
+
+    # -----------------------------------------------------------------------
+    # 7. Adjustment
+    # -----------------------------------------------------------------------
+    def test_adjusted_repr(self) -> None:
+        r = str(self.adjusted)
+        _expected_str = """  # noqa: F841
+        Adjusted balance Sample object with target set using ipw
+        1000 observations x 3 variables: gender,age_group,income
+        id_column: id, weight_column: weight,
+        outcome_columns: happiness
+"""
+        self.assertIn("Adjusted balance Sample object", r)
+        self.assertIn("ipw", r)
+        self.assertIn("1000 observations x 3 variables", r)
+        self.assertIn("outcome_columns: happiness", r)
+
+    def test_adjusted_is_adjusted(self) -> None:
+        self.assertTrue(self.adjusted.is_adjusted())
+        self.assertFalse(self.sample_with_target.is_adjusted())
+
+    # -----------------------------------------------------------------------
+    # 8. Post-adjustment diagnostics: summary
+    # -----------------------------------------------------------------------
+    def test_adjusted_summary_key_metrics(self) -> None:
+        summary = self.adjusted.summary()
+        _expected_str = """  # noqa: F841
+Adjustment details:
+    method: ipw
+    weight trimming mean ratio: 20
+Covariate diagnostics:
+    Covar ASMD reduction: 63.4%
+    Covar ASMD (7 variables): 0.327 -> 0.120
+    Covar mean KLD reduction: 92.3%
+    Covar mean KLD (3 variables): 0.157 -> 0.012
+Weight diagnostics:
+    design effect (Deff): 1.880
+    effective sample size proportion (ESSP): 0.532
+    effective sample size (ESS): 531.9
+Outcome weighted means:
+            happiness
+source
+self           53.295
+target         56.278
+unadjusted     48.559
+Model performance: Model proportion deviance explained: 0.173
+"""
+        self.assertIn("method: ipw", summary)
+        self.assertIn("weight trimming mean ratio: 20", summary)
+
+        # ASMD reduction
+        asmd_match = re.search(
+            r"Covar ASMD \(7 variables\): ([\d.]+) -> ([\d.]+)", summary
+        )
+        self.assertIsNotNone(asmd_match)
+        assert asmd_match is not None
+        self.assertAlmostEqual(float(asmd_match.group(1)), 0.327, places=2)
+        self.assertAlmostEqual(float(asmd_match.group(2)), 0.120, places=1)
+
+        # Design effect
+        deff_match = re.search(r"design effect \(Deff\): ([\d.]+)", summary)
+        self.assertIsNotNone(deff_match)
+        assert deff_match is not None
+        self.assertAlmostEqual(float(deff_match.group(1)), 1.880, places=1)
+
+        # ESS
+        ess_match = re.search(r"effective sample size \(ESS\): ([\d.]+)", summary)
+        self.assertIsNotNone(ess_match)
+        assert ess_match is not None
+        self.assertAlmostEqual(float(ess_match.group(1)), 531.9, places=0)
+
+        # Outcome means
+        self.assertIn("happiness", summary)
+        self.assertIn("unadjusted", summary)
+
+    # -----------------------------------------------------------------------
+    # 9. Post-adjustment diagnostics: covars().mean()
+    # -----------------------------------------------------------------------
+    def test_adjusted_covars_mean(self) -> None:
+        mean_df = self.adjusted.covars().mean().T
+        _expected_str = """  # noqa: F841
+source                      self     target  unadjusted
+_is_na_gender[T.True]   0.086776   0.089800    0.088000
+age_group[T.25-34]      0.307355   0.297400    0.300000
+age_group[T.35-44]      0.273609   0.299200    0.156000
+age_group[T.45+]        0.137581   0.206300    0.053000
+gender[Female]          0.406337   0.455100    0.268000
+gender[Male]            0.506887   0.455100    0.644000
+gender[_NA]             0.086776   0.089800    0.088000
+income                 10.060068  12.737608    6.297302
+"""
+        # Check that "unadjusted" column now appears
+        self.assertIn("unadjusted", mean_df.columns)
+        self.assertIn("self", mean_df.columns)
+        self.assertIn("target", mean_df.columns)
+
+        # Verify key values
+        self.assertAlmostEqual(mean_df.loc["income", "self"], 10.060, places=1)
+        self.assertAlmostEqual(mean_df.loc["income", "target"], 12.738, places=1)
+        self.assertAlmostEqual(mean_df.loc["income", "unadjusted"], 6.297, places=1)
+        self.assertAlmostEqual(mean_df.loc["gender[Female]", "self"], 0.406, places=2)
+        self.assertAlmostEqual(
+            mean_df.loc["age_group[T.35-44]", "self"], 0.274, places=2
+        )
+        self.assertAlmostEqual(
+            mean_df.loc["age_group[T.35-44]", "unadjusted"], 0.156, places=3
+        )
+
+    # -----------------------------------------------------------------------
+    # 10. Post-adjustment diagnostics: covars().asmd()
+    # -----------------------------------------------------------------------
+    def test_adjusted_covars_asmd(self) -> None:
+        asmd_df = self.adjusted.covars().asmd().T
+        _expected_str = """  # noqa: F841
+source                  self  unadjusted  unadjusted - self
+age_group[T.25-34]  0.021777    0.005688          -0.016090
+age_group[T.35-44]  0.055884    0.312711           0.256827
+age_group[T.45+]    0.169816    0.378828           0.209013
+gender[Female]      0.097916    0.375699           0.277783
+gender[Male]        0.103989    0.379314           0.275324
+gender[_NA]         0.010578    0.006296          -0.004282
+income              0.205469    0.494217           0.288748
+mean(asmd)          0.119597    0.326799           0.207202
+"""
+        # mean(asmd) should decrease from unadjusted to adjusted
+        mean_adjusted = asmd_df.loc["mean(asmd)", "self"]
+        mean_unadjusted = asmd_df.loc["mean(asmd)", "unadjusted"]
+        self.assertAlmostEqual(mean_adjusted, 0.1196, places=2)
+        self.assertAlmostEqual(mean_unadjusted, 0.3268, places=2)
+        self.assertGreater(mean_unadjusted, mean_adjusted)
+
+        # income ASMD should shrink
+        self.assertAlmostEqual(asmd_df.loc["income", "self"], 0.2055, places=2)
+        self.assertAlmostEqual(asmd_df.loc["income", "unadjusted"], 0.4942, places=2)
+
+    # -----------------------------------------------------------------------
+    # 11. Post-adjustment diagnostics: covars().kld()
+    # -----------------------------------------------------------------------
+    def test_adjusted_covars_kld(self) -> None:
+        kld = self.adjusted.covars().kld().T
+        _expected_str = """  # noqa: F841
+source         self  unadjusted  unadjusted - self
+gender     0.005603    0.079889           0.074286
+age_group  0.030191    0.277138           0.246947
+income     0.000768    0.114895           0.114127
+mean(kld)  0.012187    0.157307           0.145120
+"""
+        self.assertAlmostEqual(kld.loc["mean(kld)", "self"], 0.0122, places=2)
+        self.assertAlmostEqual(kld.loc["mean(kld)", "unadjusted"], 0.1573, places=2)
+        self.assertGreater(
+            kld.loc["mean(kld)", "unadjusted"], kld.loc["mean(kld)", "self"]
+        )
+
+    # -----------------------------------------------------------------------
+    # 12. Post-adjustment plots (no-crash)
+    # -----------------------------------------------------------------------
+    def test_adjusted_covars_plot_plotly_no_crash(self) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        self.adjusted.covars().plot()
+
+    def test_adjusted_covars_plot_seaborn_kde_no_crash(self) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        self.adjusted.covars().plot(library="seaborn", dist_type="kde")
+
+    def test_adjusted_covars_plot_ascii(self) -> None:
+        """ASCII plot should produce readable text output."""
+        import matplotlib
+
+        matplotlib.use("Agg")
+
+        buf = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = buf
+        try:
+            self.adjusted.covars().plot(library="balance", bar_width=30)
+        finally:
+            sys.stdout = old_stdout
+
+        output = buf.getvalue()
+
+        _expected_str = """  # noqa: F841
+=== gender (categorical) ===
+
+Category | population  adjusted  sample
+         |
+Female   | █████████████████████ (50.0%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (44.5%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐ (29.4%)
+
+Male     | █████████████████████ (50.0%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (55.5%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (70.6%)
+
+Legend: █ population  ▒ adjusted  ▐ sample
+Bar lengths are proportional to weighted frequency within each dataset.
+
+=== age_group (categorical) ===
+
+Category | population  adjusted  sample
+         |
+18-24    | ████████████ (19.7%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (28.1%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (49.1%)
+
+25-34    | ██████████████████ (29.7%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (30.7%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (30.0%)
+
+35-44    | ██████████████████ (29.9%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (27.4%)
+         | ▐▐▐▐▐▐▐▐▐▐ (15.6%)
+
+45+      | █████████████ (20.6%)
+         | ▒▒▒▒▒▒▒▒ (13.8%)
+         | ▐▐▐ (5.3%)
+
+Legend: █ population  ▒ adjusted  ▐ sample
+Bar lengths are proportional to weighted frequency within each dataset.
+"""
+        # Verify key structural elements of ASCII plot
+        self.assertIn("=== gender (categorical) ===", output)
+        self.assertIn("=== age_group (categorical) ===", output)
+        self.assertIn("=== income (numeric, comparative) ===", output)
+        self.assertIn("Female", output)
+        self.assertIn("Male", output)
+        self.assertIn("18-24", output)
+        self.assertIn("25-34", output)
+        self.assertIn("35-44", output)
+        self.assertIn("45+", output)
+        self.assertIn("population", output)
+        self.assertIn("adjusted", output)
+        self.assertIn("sample", output)
+
+        # Verify percentages appear (with some tolerance for rounding)
+        self.assertIn("50.0%", output)  # gender population split
+        self.assertIn("49.1%", output)  # 18-24 sample proportion
+
+    # -----------------------------------------------------------------------
+    # 13. Weights diagnostics
+    # -----------------------------------------------------------------------
+    def test_weights_plot_no_crash(self) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        self.adjusted.weights().plot()
+
+    def test_weights_summary(self) -> None:
+        ws = self.adjusted.weights().summary().round(2)
+        _expected_str = """  # noqa: F841
+                                var       val
+0                     design_effect      1.88
+1       effective_sample_proportion      0.53
+2             effective_sample_size    531.92
+3                               sum  10000.00
+4                    describe_count   1000.00
+5                     describe_mean      1.00
+6                      describe_std      0.94
+7                      describe_min      0.30
+8                      describe_25%      0.45
+9                      describe_50%      0.65
+10                     describe_75%      1.17
+11                     describe_max     11.36
+12                    prop(w < 0.1)      0.00
+13                    prop(w < 0.2)      0.00
+14                  prop(w < 0.333)      0.11
+15                    prop(w < 0.5)      0.32
+16                      prop(w < 1)      0.67
+17                     prop(w >= 1)      0.33
+18                     prop(w >= 2)      0.10
+19                     prop(w >= 3)      0.03
+20                     prop(w >= 5)      0.01
+21                    prop(w >= 10)      0.00
+22               nonparametric_skew      0.37
+23  weighted_median_breakdown_point      0.21
+"""
+        # Build a lookup dict from var -> val
+        lookup = dict(zip(ws["var"].tolist(), ws["val"].tolist()))
+        self.assertAlmostEqual(lookup["design_effect"], 1.88, places=1)
+        self.assertAlmostEqual(lookup["effective_sample_proportion"], 0.53, places=1)
+        self.assertAlmostEqual(lookup["effective_sample_size"], 531.92, places=0)
+        self.assertAlmostEqual(lookup["sum"], 10000.0, places=0)
+        self.assertAlmostEqual(lookup["describe_count"], 1000.0, places=0)
+        self.assertAlmostEqual(lookup["describe_mean"], 1.0, places=1)
+        self.assertAlmostEqual(lookup["describe_min"], 0.30, places=1)
+        self.assertAlmostEqual(lookup["describe_max"], 11.36, places=0)
+        self.assertAlmostEqual(lookup["nonparametric_skew"], 0.37, places=1)
+
+    # -----------------------------------------------------------------------
+    # 14. Outcomes
+    # -----------------------------------------------------------------------
+    def test_outcomes_summary(self) -> None:
+        summary = self.adjusted.outcomes().summary()
+        _expected_str = """  # noqa: F841
+1 outcomes: ['happiness']
+Mean outcomes (with 95% confidence intervals):
+source       self  target  unadjusted           self_ci         target_ci     unadjusted_ci
+happiness  53.295  56.278      48.559  (52.096, 54.495)  (55.961, 56.595)  (47.669, 49.449)
+"""
+        self.assertIn("1 outcomes: ['happiness']", summary)
+        self.assertIn("happiness", summary)
+        self.assertIn("Mean outcomes", summary)
+
+        # Extract numeric values from the mean outcomes line
+        # happiness  53.295  56.278      48.559
+        happiness_match = re.search(
+            r"happiness\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)", summary
+        )
+        self.assertIsNotNone(happiness_match)
+        assert happiness_match is not None
+        adjusted_mean = float(happiness_match.group(1))
+        target_mean = float(happiness_match.group(2))
+        unadjusted_mean = float(happiness_match.group(3))
+
+        self.assertAlmostEqual(adjusted_mean, 53.295, places=0)
+        self.assertAlmostEqual(target_mean, 56.278, places=0)
+        self.assertAlmostEqual(unadjusted_mean, 48.559, places=0)
+
+        # Adjusted should be closer to target than unadjusted
+        self.assertLess(
+            abs(adjusted_mean - target_mean),
+            abs(unadjusted_mean - target_mean),
+        )
+
+    def test_outcomes_plot_no_crash(self) -> None:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        self.adjusted.outcomes().plot()
+
+    # -----------------------------------------------------------------------
+    # 15. Comparing adjustment methods: HGB
+    # -----------------------------------------------------------------------
+    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    @unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires sklearn >= 1.4")
+    def test_adjust_hgb_native_categorical(self) -> None:
+        from sklearn.ensemble import HistGradientBoostingClassifier
+
+        hgb = HistGradientBoostingClassifier(
+            random_state=0, categorical_features="from_dtype"
+        )
+        adjusted_hgb = self.sample_with_target.adjust(model=hgb, use_model_matrix=False)
+        summary = adjusted_hgb.summary()
+        _expected_str = """  # noqa: F841
+Adjustment details:
+    method: ipw
+    weight trimming mean ratio: 20
+Covariate diagnostics:
+    Covar ASMD reduction: 67.7%
+    Covar ASMD (7 variables): 0.327 -> 0.106
+    Covar mean KLD reduction: 95.7%
+    Covar mean KLD (3 variables): 0.157 -> 0.007
+Weight diagnostics:
+    design effect (Deff): 2.539
+    effective sample size proportion (ESSP): 0.394
+    effective sample size (ESS): 393.8
+Outcome weighted means:
+            happiness
+source
+self           54.326
+target         56.278
+unadjusted     48.559
+Model performance: Model proportion deviance explained: 0.204
+"""
+        self.assertIn("method: ipw", summary)
+
+        deff_match = re.search(r"design effect \(Deff\): ([\d.]+)", summary)
+        self.assertIsNotNone(deff_match)
+        assert deff_match is not None
+        self.assertAlmostEqual(float(deff_match.group(1)), 2.539, places=1)
+
+        ess_match = re.search(r"effective sample size \(ESS\): ([\d.]+)", summary)
+        self.assertIsNotNone(ess_match)
+        assert ess_match is not None
+        self.assertAlmostEqual(float(ess_match.group(1)), 393.8, places=0)
+
+    def test_adjust_hgb_with_model_matrix(self) -> None:
+        from sklearn.ensemble import HistGradientBoostingClassifier
+
+        hgb_mm = HistGradientBoostingClassifier(random_state=0)
+        adjusted_hgb_mm = self.sample_with_target.adjust(
+            model=hgb_mm, use_model_matrix=True
+        )
+        summary = adjusted_hgb_mm.summary()
+        _expected_str = """  # noqa: F841
+Adjustment details:
+    method: ipw
+    weight trimming mean ratio: 20
+Covariate diagnostics:
+    Covar ASMD reduction: 68.8%
+    Covar ASMD (7 variables): 0.327 -> 0.102
+    Covar mean KLD reduction: 95.7%
+    Covar mean KLD (3 variables): 0.157 -> 0.007
+Weight diagnostics:
+    design effect (Deff): 2.699
+    effective sample size proportion (ESSP): 0.370
+    effective sample size (ESS): 370.5
+Outcome weighted means:
+            happiness
+source
+self           54.460
+target         56.278
+unadjusted     48.559
+Model performance: Model proportion deviance explained: 0.206
+"""
+        self.assertIn("method: ipw", summary)
+
+        deff_match = re.search(r"design effect \(Deff\): ([\d.]+)", summary)
+        self.assertIsNotNone(deff_match)
+        assert deff_match is not None
+        self.assertAlmostEqual(float(deff_match.group(1)), 2.699, places=1)
+
+        ess_match = re.search(r"effective sample size \(ESS\): ([\d.]+)", summary)
+        self.assertIsNotNone(ess_match)
+        assert ess_match is not None
+        self.assertAlmostEqual(float(ess_match.group(1)), 370.5, places=0)
+
+
+class E2ETutorialRakeTest(unittest.TestCase):
+    """Reproduce key sections of balance_quickstart_rake.ipynb."""
+
+    sample_with_target: Sample
+    adjusted_rake: Sample
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        target_df, sample_df = load_data()
+        assert target_df is not None and sample_df is not None
+        # Tutorial uses only gender + age_group (categorical covariates)
+        sample = Sample.from_frame(
+            sample_df[["id", "gender", "age_group", "happiness"]],
+            outcome_columns=["happiness"],
+        )
+        target = Sample.from_frame(
+            target_df[["id", "gender", "age_group", "happiness"]],
+            outcome_columns=["happiness"],
+        )
+        cls.sample_with_target = sample.set_target(target)
+        cls.adjusted_rake = cls.sample_with_target.adjust(method="rake")
+
+    def test_rake_summary(self) -> None:
+        summary = self.adjusted_rake.summary()
+        _expected_str = """  # noqa: F841
+Adjustment details:
+    method: rake
+Covariate diagnostics:
+    Covar ASMD reduction: 100.0%
+    Covar ASMD (6 variables): 0.243 -> 0.000
+    Covar mean KLD reduction: 100.0%
+    Covar mean KLD (2 variables): 0.179 -> 0.000
+Weight diagnostics:
+    design effect (Deff): 2.103
+    effective sample size proportion (ESSP): 0.476
+    effective sample size (ESS): 475.6
+Outcome weighted means:
+            happiness
+source
+self           55.484
+target         56.278
+unadjusted     48.559
+"""
+        self.assertIn("method: rake", summary)
+        self.assertIn("Covar ASMD reduction: 100.0%", summary)
+
+        deff_match = re.search(r"design effect \(Deff\): ([\d.]+)", summary)
+        self.assertIsNotNone(deff_match)
+        assert deff_match is not None
+        self.assertAlmostEqual(float(deff_match.group(1)), 2.103, places=1)
+
+        ess_match = re.search(r"effective sample size \(ESS\): ([\d.]+)", summary)
+        self.assertIsNotNone(ess_match)
+        assert ess_match is not None
+        self.assertAlmostEqual(float(ess_match.group(1)), 475.6, places=0)
+
+    def test_rake_asmd_near_zero(self) -> None:
+        """Rake should achieve near-perfect balance on categorical covariates."""
+        asmd_df = self.adjusted_rake.covars().asmd().T
+        _expected_str = """  # noqa: F841
+source                      self  unadjusted  unadjusted - self
+age_group[T.25-34]  9.805611e-06    0.005688           0.005678
+age_group[T.35-44]  1.769428e-05    0.312711           0.312694
+age_group[T.45+]    3.015863e-05    0.378828           0.378798
+gender[Female]      1.114671e-16    0.375699           0.375699
+gender[Male]        3.344013e-16    0.379314           0.379314
+gender[_NA]         4.853912e-17    0.006296           0.006296
+mean(asmd)          9.609754e-06    0.243089           0.243080
+"""
+        mean_asmd = asmd_df.loc["mean(asmd)", "self"]
+        # Rake achieves near-zero ASMD on categorical marginals
+        self.assertLess(mean_asmd, 0.001)
+        # Unadjusted should be much higher
+        self.assertAlmostEqual(
+            asmd_df.loc["mean(asmd)", "unadjusted"], 0.243089, places=3
+        )
+
+    def test_rake_covars_mean(self) -> None:
+        """Rake covars().mean() should match target exactly."""
+        mean_df = self.adjusted_rake.covars().mean().T
+        _expected_str = """  # noqa: F841
+source                     self  target  unadjusted
+_is_na_gender[T.True]  0.089800  0.0898       0.088
+age_group[T.25-34]     0.297404  0.2974       0.300
+age_group[T.35-44]     0.299208  0.2992       0.156
+age_group[T.45+]       0.206288  0.2063       0.053
+gender[Female]         0.455100  0.4551       0.268
+gender[Male]           0.455100  0.4551       0.644
+gender[_NA]            0.089800  0.0898       0.088
+"""
+        # Gender proportions should match target exactly after raking
+        self.assertAlmostEqual(
+            mean_df.loc["gender[Female]", "self"],
+            mean_df.loc["gender[Female]", "target"],
+            places=4,
+        )
+        self.assertAlmostEqual(
+            mean_df.loc["gender[Male]", "self"],
+            mean_df.loc["gender[Male]", "target"],
+            places=4,
+        )
+        # Age group proportions should also match target closely
+        self.assertAlmostEqual(
+            mean_df.loc["age_group[T.45+]", "self"],
+            mean_df.loc["age_group[T.45+]", "target"],
+            places=3,
+        )
+
+
+class E2ETutorialPoststratifyTest(unittest.TestCase):
+    """Reproduce key sections of balance_quickstart_poststratify.ipynb."""
+
+    def test_poststratify_single_variable(self) -> None:
+        """Post-stratify on gender matches target counts exactly."""
+        from balance.weighting_methods.poststratify import poststratify
+
+        target_df, sample_df = load_data()
+        assert target_df is not None and sample_df is not None
+
+        sample_gender = sample_df.dropna(subset=["gender"])
+        target_gender = target_df.dropna(subset=["gender"])
+
+        result = poststratify(
+            sample_df=sample_gender[["gender"]],
+            sample_weights=pd.Series(1, index=sample_gender.index),
+            target_df=target_gender[["gender"]],
+            target_weights=pd.Series(1, index=target_gender.index),
+        )
+
+        weighted = sample_gender.assign(weight=result["weight"])
+        weighted_counts = weighted.groupby("gender")["weight"].sum()
+        target_counts = target_gender.groupby("gender").size()
+
+        _expected_str = """  # noqa: F841
+        weighted_sample  target_population
+gender
+Female           4551.0               4551
+Male             4551.0               4551
+"""
+        # Weighted sample counts should exactly match target population counts
+        self.assertAlmostEqual(weighted_counts["Female"], 4551.0, places=0)
+        self.assertAlmostEqual(weighted_counts["Male"], 4551.0, places=0)
+        self.assertAlmostEqual(
+            weighted_counts["Female"], float(target_counts["Female"]), places=0
+        )
+        self.assertAlmostEqual(
+            weighted_counts["Male"], float(target_counts["Male"]), places=0
+        )
+
+    def test_poststratify_joint_distribution(self) -> None:
+        """Post-stratify on gender x age_group matches joint target counts."""
+        from balance.weighting_methods.poststratify import poststratify
+
+        target_df, sample_df = load_data()
+        assert target_df is not None and sample_df is not None
+
+        covariates = ["gender", "age_group"]
+        sample_cells = sample_df.dropna(subset=covariates)
+        target_cells = target_df.dropna(subset=covariates)
+
+        result = poststratify(
+            sample_df=sample_cells[covariates],
+            sample_weights=pd.Series(1, index=sample_cells.index),
+            target_df=target_cells[covariates],
+            target_weights=pd.Series(1, index=target_cells.index),
+        )
+
+        weighted = sample_cells.assign(weight=result["weight"])
+        weighted_counts = weighted.groupby(covariates)["weight"].sum()
+        target_counts = target_cells.groupby(covariates).size()
+
+        _expected_str = """  # noqa: F841
+                  weighted_sample  target_population
+gender age_group
+Female 18-24                876.0                876
+       25-34               1360.0               1360
+       35-44               1370.0               1370
+       45+                  945.0                945
+Male   18-24                905.0                905
+       25-34               1355.0               1355
+       35-44               1347.0               1347
+       45+                  944.0                944
+"""
+        # Each cell's weighted count should match target exactly
+        for cell, count in target_counts.items():
+            self.assertAlmostEqual(
+                weighted_counts[cell],
+                float(count),
+                places=0,
+                msg=f"Cell {cell} mismatch",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ipw.py
+++ b/tests/test_ipw.py
@@ -13,15 +13,12 @@ from __future__ import (
     unicode_literals,
 )
 
-import unittest
-
 import balance.testutil
 import numpy as np
 import pandas as pd
-import sklearn
+import pytest
 from balance.sample_class import Sample
 from balance.weighting_methods import ipw as balance_ipw
-from packaging.version import Version
 from scipy.sparse import csr_matrix
 from sklearn.ensemble import HistGradientBoostingClassifier, RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
@@ -29,8 +26,6 @@ from sklearn.metrics import log_loss
 from sklearn.naive_bayes import GaussianNB
 from sklearn.svm import LinearSVC
 from sklearn.tree import DecisionTreeClassifier
-
-_SKLEARN_LT_1_4: bool = Version(sklearn.__version__) < Version("1.4")
 
 
 class TestIPW(
@@ -339,10 +334,7 @@ class TestIPW(
                 use_model_matrix=False,
             )
 
-    @unittest.skipIf(
-        _SKLEARN_LT_1_4,
-        "categorical_features='from_dtype' requires scikit-learn >= 1.4",
-    )
+    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
     def test_ipw_use_model_matrix_false_preserves_categoricals(self) -> None:
         """Raw-covariate IPW preserves categorical dtype for native sklearn categorical support."""
 
@@ -404,10 +396,8 @@ class TestIPW(
         )
         self.assertEqual(len(result_no_indicator["weight"]), len(sample))
 
-    @unittest.skipIf(
-        _SKLEARN_LT_1_4,
-        "categorical_features='from_dtype' requires scikit-learn >= 1.4",
-    )
+    # pyre-ignore[56]: Pyre cannot infer type of custom pytest mark
+    @pytest.mark.requires_sklearn_1_4
     def test_ipw_use_model_matrix_false_raises_on_old_sklearn(self) -> None:
         """ValueError is raised when sklearn < 1.4 and categorical columns are present."""
         from unittest.mock import patch
@@ -445,10 +435,8 @@ class TestIPW(
             self.assertIn("scikit-learn >= 1.4", str(ctx.exception))
             self.assertIn("1.3.2", str(ctx.exception))
 
-    @unittest.skipIf(
-        _SKLEARN_LT_1_4,
-        "categorical_features='from_dtype' requires scikit-learn >= 1.4",
-    )
+    # pyre-ignore[56]: Pyre cannot infer type of custom pytest mark
+    @pytest.mark.requires_sklearn_1_4
     def test_ipw_use_model_matrix_false_no_error_on_new_sklearn(self) -> None:
         """No version error when sklearn >= 1.4 and categorical columns are present."""
         from unittest.mock import patch

--- a/tests/test_rake.py
+++ b/tests/test_rake.py
@@ -261,9 +261,9 @@ class Testrake(
 
         adjusted = rake(
             sample.covars().df,
-            _assert_type(sample.weight_column),
+            _assert_type(sample.weight_series),
             target.covars().df,
-            _assert_type(target.weight_column),
+            _assert_type(target.weight_series),
         )
 
         self.assertEqual(
@@ -295,16 +295,16 @@ class Testrake(
 
         baseline = rake(
             sample.covars().df,
-            _assert_type(sample.weight_column),
+            _assert_type(sample.weight_series),
             target.covars().df,
-            _assert_type(target.weight_column),
+            _assert_type(target.weight_series),
         )
 
         trimmed = rake(
             sample.covars().df,
-            _assert_type(sample.weight_column),
+            _assert_type(sample.weight_series),
             target.covars().df,
-            _assert_type(target.weight_column),
+            _assert_type(target.weight_series),
             weight_trimming_mean_ratio=1.0,
         )
 
@@ -340,16 +340,16 @@ class Testrake(
 
         baseline = rake(
             sample.covars().df,
-            _assert_type(sample.weight_column),
+            _assert_type(sample.weight_series),
             target.covars().df,
-            _assert_type(target.weight_column),
+            _assert_type(target.weight_series),
         )
 
         trimmed = rake(
             sample.covars().df,
-            _assert_type(sample.weight_column),
+            _assert_type(sample.weight_series),
             target.covars().df,
-            _assert_type(target.weight_column),
+            _assert_type(target.weight_series),
             weight_trimming_percentile=0.1,
         )
 
@@ -391,9 +391,9 @@ class Testrake(
 
         adjusted = rake(
             sample.covars().df,
-            _assert_type(sample.weight_column),
+            _assert_type(sample.weight_series),
             target.covars().df,
-            _assert_type(target.weight_column),
+            _assert_type(target.weight_series),
         )
 
         self.assertEqual(
@@ -430,9 +430,9 @@ class Testrake(
 
         adjusted = rake(
             sample.covars().df,
-            _assert_type(sample.weight_column),
+            _assert_type(sample.weight_series),
             target.covars().df,
-            _assert_type(target.weight_column),
+            _assert_type(target.weight_series),
         )
 
         self.assertEqual(round(sum(adjusted["weight"]), 2), 15.0)
@@ -477,7 +477,7 @@ class Testrake(
 
         adjusted = sample.adjust(method="rake", transformations=None, na_action="drop")
         self.assertEqual(
-            _assert_type(adjusted.weight_column).round(2),
+            _assert_type(adjusted.weight_series).round(2),
             pd.Series([1.67, 1.0, np.nan] * 6, name="weight"),
         )
 
@@ -492,7 +492,7 @@ class Testrake(
         )
 
         self.assertEqual(
-            _assert_type(adjusted.weight_column).round(2),
+            _assert_type(adjusted.weight_series).round(2),
             pd.Series([1.67, 1.0, 0.33] * 6, name="weight"),
         )
 
@@ -598,17 +598,17 @@ class Testrake(
 
         adjusted = rake(
             sample.covars().df,
-            _assert_type(sample.weight_column),
+            _assert_type(sample.weight_series),
             target.covars().df,
-            _assert_type(target.weight_column),
+            _assert_type(target.weight_series),
             variables=["a", "b"],
         )
 
         adjusted_two = rake(
             sample.covars().df,
-            _assert_type(sample.weight_column),
+            _assert_type(sample.weight_series),
             target.covars().df,
-            _assert_type(target.weight_column),
+            _assert_type(target.weight_series),
             variables=["b", "a"],
         )
 
@@ -666,17 +666,17 @@ class Testrake(
             "'b' in target is missing.*alpha",
             rake,
             sample_excess_levels.covars().df,
-            sample_excess_levels.weight_column,
+            sample_excess_levels.weight_series,
             target.covars().df,
-            _assert_type(target.weight_column),
+            _assert_type(target.weight_series),
         )
         self.assertWarnsRegexp(
             "'b' in sample is missing.*omega",
             rake,
             sample.covars().df,
-            _assert_type(sample.weight_column),
+            _assert_type(sample.weight_series),
             target_excess_levels.covars().df,
-            target_excess_levels.weight_column,
+            target_excess_levels.weight_series,
         )
 
     def test__proportional_array_from_dict(self) -> None:

--- a/tests/test_rake.py
+++ b/tests/test_rake.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 from balance import adjustment as balance_adjustment
 from balance.sample_class import Sample
+from balance.util import _assert_type
 from balance.weighting_methods.rake import (
     _find_lcm_of_array_lengths,
     _hare_niemeyer_allocation,
@@ -260,9 +261,9 @@ class Testrake(
 
         adjusted = rake(
             sample.covars().df,
-            sample.weight_column,
+            _assert_type(sample.weight_column),
             target.covars().df,
-            target.weight_column,
+            _assert_type(target.weight_column),
         )
 
         self.assertEqual(
@@ -294,16 +295,16 @@ class Testrake(
 
         baseline = rake(
             sample.covars().df,
-            sample.weight_column,
+            _assert_type(sample.weight_column),
             target.covars().df,
-            target.weight_column,
+            _assert_type(target.weight_column),
         )
 
         trimmed = rake(
             sample.covars().df,
-            sample.weight_column,
+            _assert_type(sample.weight_column),
             target.covars().df,
-            target.weight_column,
+            _assert_type(target.weight_column),
             weight_trimming_mean_ratio=1.0,
         )
 
@@ -339,16 +340,16 @@ class Testrake(
 
         baseline = rake(
             sample.covars().df,
-            sample.weight_column,
+            _assert_type(sample.weight_column),
             target.covars().df,
-            target.weight_column,
+            _assert_type(target.weight_column),
         )
 
         trimmed = rake(
             sample.covars().df,
-            sample.weight_column,
+            _assert_type(sample.weight_column),
             target.covars().df,
-            target.weight_column,
+            _assert_type(target.weight_column),
             weight_trimming_percentile=0.1,
         )
 
@@ -390,9 +391,9 @@ class Testrake(
 
         adjusted = rake(
             sample.covars().df,
-            sample.weight_column,
+            _assert_type(sample.weight_column),
             target.covars().df,
-            target.weight_column,
+            _assert_type(target.weight_column),
         )
 
         self.assertEqual(
@@ -429,9 +430,9 @@ class Testrake(
 
         adjusted = rake(
             sample.covars().df,
-            sample.weight_column,
+            _assert_type(sample.weight_column),
             target.covars().df,
-            target.weight_column,
+            _assert_type(target.weight_column),
         )
 
         self.assertEqual(round(sum(adjusted["weight"]), 2), 15.0)
@@ -476,7 +477,7 @@ class Testrake(
 
         adjusted = sample.adjust(method="rake", transformations=None, na_action="drop")
         self.assertEqual(
-            adjusted.weight_column.round(2),
+            _assert_type(adjusted.weight_column).round(2),
             pd.Series([1.67, 1.0, np.nan] * 6, name="weight"),
         )
 
@@ -491,7 +492,7 @@ class Testrake(
         )
 
         self.assertEqual(
-            adjusted.weight_column.round(2),
+            _assert_type(adjusted.weight_column).round(2),
             pd.Series([1.67, 1.0, 0.33] * 6, name="weight"),
         )
 
@@ -597,17 +598,17 @@ class Testrake(
 
         adjusted = rake(
             sample.covars().df,
-            sample.weight_column,
+            _assert_type(sample.weight_column),
             target.covars().df,
-            target.weight_column,
+            _assert_type(target.weight_column),
             variables=["a", "b"],
         )
 
         adjusted_two = rake(
             sample.covars().df,
-            sample.weight_column,
+            _assert_type(sample.weight_column),
             target.covars().df,
-            target.weight_column,
+            _assert_type(target.weight_column),
             variables=["b", "a"],
         )
 
@@ -667,13 +668,13 @@ class Testrake(
             sample_excess_levels.covars().df,
             sample_excess_levels.weight_column,
             target.covars().df,
-            target.weight_column,
+            _assert_type(target.weight_column),
         )
         self.assertWarnsRegexp(
             "'b' in sample is missing.*omega",
             rake,
             sample.covars().df,
-            sample.weight_column,
+            _assert_type(sample.weight_column),
             target_excess_levels.covars().df,
             target_excess_levels.weight_column,
         )

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -2708,8 +2708,8 @@ class TestSampleConversion(balance.testutil.BalanceTestCase):
         )
         sf = sample_with_ignored.to_sample_frame()
         self.assertIsInstance(sf, SampleFrame)
-        self.assertIsNotNone(sf.misc_columns)
-        self.assertIn("b", sf.misc_columns)
+        self.assertIsNotNone(sf.ignore_columns)
+        self.assertIn("b", sf.ignore_columns)
 
     def test_to_balance_frame_unadjusted(self) -> None:
         """to_balance_frame converts a Sample with target to a BalanceFrame."""

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -25,7 +25,6 @@ import logging
 from copy import deepcopy
 from textwrap import dedent
 from typing import Any, Callable
-from unittest.mock import MagicMock
 
 import balance.testutil
 import IPython.display
@@ -367,7 +366,7 @@ class TestSample(
         with self.assertRaisesRegex(ValueError, "cannot include id/weight"):
             Sample.from_frame(df, ignore_columns=["weight"])
 
-        with self.assertRaisesRegex(ValueError, "both ignored and outcomes"):
+        with self.assertRaisesRegex(ValueError, "'outcomes' and 'ignored'"):
             Sample.from_frame(
                 df,
                 outcome_columns=["out"],
@@ -375,7 +374,7 @@ class TestSample(
                 weight_column=None,
             )
 
-        with self.assertRaisesRegex(ValueError, "must be strings"):
+        with self.assertRaisesRegex(ValueError, "not in df columns"):
             # pyre-ignore[6]: Intentionally passing int to test validation
             Sample.from_frame(df, ignore_columns=["a", 3])
 
@@ -443,7 +442,7 @@ class TestSample(
 
         # Mock importlib.metadata.version to return pandas 2.x
         with patch(
-            "balance.sample_class.importlib_version",
+            "importlib.metadata.version",
             return_value="2.2.0",
         ):
             sample = Sample.from_frame(df)
@@ -501,7 +500,7 @@ class TestSample(
         # Test exception for invalid method
         with self.assertRaisesRegex(
             ValueError,
-            "Method should be one of existing weighting methods",
+            "'method' must be a string naming a weighting method or a callable",
         ):
             # pyre-ignore[6]: Intentionally passing None to test exception handling
             s1.set_target(s2).adjust(method=None)
@@ -737,7 +736,7 @@ class TestSample_base_and_adjust_methods(
         # test exceptions when there is no a second sample
         with self.assertRaisesRegex(
             TypeError,
-            "set_unadjusted must be called with second_sample argument of type Sample",
+            "set_unadjusted must be called with a BalanceFrame argument",
         ):
             # pyre-ignore[6]: Intentionally passing str to test exception handling
             s1.set_unadjusted("Not a Sample object")
@@ -747,12 +746,38 @@ class TestSample_base_and_adjust_methods(
         self.assertFalse(s3.is_adjusted())
         self.assertTrue(s3_adjusted_null.is_adjusted())
 
+    def test_Sample_is_adjusted_property_and_callable(self) -> None:
+        """Verify is_adjusted works both as a property and as a method call."""
+        # Property access (new style, consistent with BalanceFrame.is_adjusted)
+        self.assertFalse(s1.is_adjusted)
+        self.assertFalse(s3.is_adjusted)
+        self.assertTrue(s3_adjusted_null.is_adjusted)
+
+        # Method call (legacy style, backward compatible)
+        self.assertFalse(s1.is_adjusted())
+        self.assertFalse(s3.is_adjusted())
+        self.assertTrue(s3_adjusted_null.is_adjusted())
+
+        # Both styles agree
+        self.assertEqual(bool(s1.is_adjusted), s1.is_adjusted())
+        self.assertEqual(
+            bool(s3_adjusted_null.is_adjusted), s3_adjusted_null.is_adjusted()
+        )
+
+        # Works in boolean expressions
+        self.assertFalse(s1.is_adjusted and True)
+        self.assertTrue(s3_adjusted_null.is_adjusted and True)
+
+        # Equality with bool
+        self.assertEqual(s1.is_adjusted, False)
+        self.assertEqual(s3_adjusted_null.is_adjusted, True)
+
     def test_Sample_set_target(self) -> None:
         s5 = s1.set_target(s2)
         self.assertTrue(s5.has_target())
         # test exceptions when the provided object is not a second sample
         with self.assertRaisesRegex(
-            ValueError,
+            TypeError,
             "A target, a Sample object, must be specified",
         ):
             # pyre-ignore[6]: Intentionally passing str to test exception handling
@@ -976,11 +1001,11 @@ class TestSample_metrics_methods(
         expected_ratio = (
             weighted_var(
                 a_with_outcome_adjusted.outcomes().df,
-                a_with_outcome_adjusted.weights().df["weight"],
+                a_with_outcome_adjusted.weights().df.iloc[:, 0],
             )
             / weighted_var(
                 a_with_outcome_adjusted._links["unadjusted"].outcomes().df,
-                a_with_outcome_adjusted._links["unadjusted"].weights().df["weight"],
+                a_with_outcome_adjusted._links["unadjusted"].weights().df.iloc[:, 0],
             )
         ).iloc[0]
 
@@ -1115,12 +1140,17 @@ class TestSample_metrics_methods(
         self.assertTrue("design effect" in s3_summ)
 
     def test_Sample_summary_handles_nonfinite_design_effect(self) -> None:
-        adjusted = deepcopy(s3_adjusted_null)
-        mock_weights = MagicMock()
-        mock_weights.design_effect = MagicMock(return_value=np.nan)
-        adjusted.weights = MagicMock(return_value=mock_weights)
+        from unittest.mock import patch
 
-        summary = adjusted.summary()
+        adjusted = deepcopy(s3_adjusted_null)
+        # Mock _design_effect_diagnostics on the BalanceFrame to return None values
+        bf = adjusted._balance_frame
+        with patch.object(
+            type(bf),
+            "_design_effect_diagnostics",
+            return_value=(None, None, None),
+        ):
+            summary = adjusted.summary()
 
         self.assertIn("Weight diagnostics:", summary)
         self.assertIn("design effect (Deff): unavailable", summary)
@@ -1564,9 +1594,11 @@ class TestSample_metrics_methods(
             columns_to_keep=["g", "a"],
         )
 
-        # Test that existing columns are still kept
+        # Test that existing columns are still kept (outcome column "o" is always preserved)
         filtered_sample = s1.keep_only_some_rows_columns(columns_to_keep=["g", "a"])
-        self.assertEqual(filtered_sample._df.columns.tolist(), ["a"])
+        # Check via public API: covars should only have "a", outcomes "o" should be preserved
+        self.assertIn("a", filtered_sample.covars().df.columns.tolist())
+        self.assertIn("o", filtered_sample.outcomes().df.columns.tolist())
 
 
 class TestSample_to_download(balance.testutil.BalanceTestCase):
@@ -1692,7 +1724,8 @@ class TestSample_high_cardinality_warnings(balance.testutil.BalanceTestCase):
             )
 
         # Filter out NaN weights before comparing (dropped rows may have NaN weights)
-        valid_weights = result.weight_column[~pd.isna(result.weight_column)]
+        _wc = _assert_type(result.weight_column)
+        valid_weights = _wc[~pd.isna(_wc)]
         self.assertTrue(np.allclose(valid_weights, np.ones(len(sample_df) - 1)))
         self.assertTrue(
             any(
@@ -2214,7 +2247,7 @@ class TestSampleFromFrameGuessWeightColumn(balance.testutil.BalanceTestCase):
                     {"a": [1, 2, 3], "id": [1, 2, 3], "weights": [1.0, 2.0, 3.0]}
                 )
             )
-            self.assertEqual(sample.weight_column.name, "weights")
+            self.assertEqual(_assert_type(sample.weight_column).name, "weights")
             self.assertTrue(
                 any("Guessing weight column is 'weights'" in msg for msg in log.output)
             )
@@ -2241,7 +2274,7 @@ class TestSampleFromFrameGuessIdColumnCandidates(balance.testutil.BalanceTestCas
             pd.DataFrame({"user_id": [1, 2, 3], "a": [1, 2, 3]}),
             id_column_candidates=["user_id", "id"],
         )
-        self.assertEqual(sample.id_column.name, "user_id")
+        self.assertEqual(_assert_type(sample.id_column).name, "user_id")
 
     def test_from_frame_id_column_candidates_ambiguous(self) -> None:
         """Test from_frame raises when multiple candidate ids are present."""
@@ -2293,7 +2326,7 @@ class TestSampleSetWeightsNonFloat(balance.testutil.BalanceTestCase):
             standardize_types=False,
         )
         sample.set_weights(2.0)
-        self.assertEqual(sample._df[sample.weight_column.name].dtype.kind, "f")
+        self.assertEqual(_assert_type(sample.weight_column).dtype.kind, "f")
 
 
 class TestSampleSummaryIPWModel(balance.testutil.BalanceTestCase):
@@ -2727,3 +2760,77 @@ class TestSampleConversion(balance.testutil.BalanceTestCase):
         """to_balance_frame raises ValueError when Sample has no target."""
         with self.assertRaises(ValueError):
             s1.to_balance_frame()
+
+
+class TestCallableBool(balance.testutil.BalanceTestCase):
+    """Tests for the _CallableBool helper class."""
+
+    def test_bool_true(self) -> None:
+        from balance.sample_class import _CallableBool
+
+        cb = _CallableBool(True)
+        self.assertTrue(bool(cb))
+
+    def test_bool_false(self) -> None:
+        from balance.sample_class import _CallableBool
+
+        cb = _CallableBool(False)
+        self.assertFalse(bool(cb))
+
+    def test_call_true(self) -> None:
+        from balance.sample_class import _CallableBool
+
+        cb = _CallableBool(True)
+        self.assertTrue(cb())
+
+    def test_call_false(self) -> None:
+        from balance.sample_class import _CallableBool
+
+        cb = _CallableBool(False)
+        self.assertFalse(cb())
+
+    def test_repr(self) -> None:
+        from balance.sample_class import _CallableBool
+
+        self.assertEqual(repr(_CallableBool(True)), "True")
+        self.assertEqual(repr(_CallableBool(False)), "False")
+
+    def test_eq_with_bool(self) -> None:
+        from balance.sample_class import _CallableBool
+
+        self.assertEqual(_CallableBool(True), True)
+        self.assertEqual(_CallableBool(False), False)
+        self.assertNotEqual(_CallableBool(True), False)
+        self.assertNotEqual(_CallableBool(False), True)
+
+    def test_eq_with_callable_bool(self) -> None:
+        from balance.sample_class import _CallableBool
+
+        self.assertEqual(_CallableBool(True), _CallableBool(True))
+        self.assertEqual(_CallableBool(False), _CallableBool(False))
+        self.assertNotEqual(_CallableBool(True), _CallableBool(False))
+
+    def test_eq_not_implemented_for_other_types(self) -> None:
+        from balance.sample_class import _CallableBool
+
+        cb = _CallableBool(True)
+        result = cb.__eq__("not a bool")
+        self.assertIs(result, NotImplemented)
+
+    def test_hash(self) -> None:
+        from balance.sample_class import _CallableBool
+
+        self.assertEqual(hash(_CallableBool(True)), hash(True))
+        self.assertEqual(hash(_CallableBool(False)), hash(False))
+
+    def test_mul(self) -> None:
+        from balance.sample_class import _CallableBool
+
+        self.assertEqual(_CallableBool(True) * 5, 5)
+        self.assertEqual(_CallableBool(False) * 5, 0)
+
+    def test_rmul(self) -> None:
+        from balance.sample_class import _CallableBool
+
+        self.assertEqual(5 * _CallableBool(True), 5)
+        self.assertEqual(5 * _CallableBool(False), 0)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -250,14 +250,14 @@ class TestSample(
         df = pd.DataFrame({"id": (1, 2), "weight": (1, 2)})
         self.assertWarnsRegexp("Guessing weight", Sample.from_frame, df)
         self.assertEqual(
-            Sample.from_frame(df).weight_column, pd.Series((1.0, 2.0), name="weight")
+            Sample.from_frame(df).weight_series, pd.Series((1.0, 2.0), name="weight")
         )
 
         # Test default weights when none provided
         df = pd.DataFrame({"id": (1, 2)})
         self.assertWarnsRegexp("No weights passed", Sample.from_frame, df)
         self.assertEqual(
-            Sample.from_frame(df).weight_column, pd.Series((1.0, 1.0), name="weight")
+            Sample.from_frame(df).weight_series, pd.Series((1.0, 1.0), name="weight")
         )
 
         # Test error for null weight values
@@ -318,7 +318,7 @@ class TestSample(
         # Test that zero weights are acceptable
         df = pd.DataFrame({"id": (1, 2), "weight": (0, 2), "weight_column": "weight"})
         self.assertEqual(
-            Sample.from_frame(df).weight_column, pd.Series((0.0, 2.0), name="weight")
+            Sample.from_frame(df).weight_series, pd.Series((0.0, 2.0), name="weight")
         )
 
     def test_Sample_from_frame_ignored_columns(self) -> None:
@@ -710,10 +710,10 @@ class TestSample_base_and_adjust_methods(
             weight_column="w",
         )
         s.set_weights(pd.Series([1, 2, 3, 4]))
-        self.assertEqual(s.weight_column, pd.Series([1.0, 2.0, 3.0, 4.0], name="w"))
+        self.assertEqual(s.weight_series, pd.Series([1.0, 2.0, 3.0, 4.0], name="w"))
         s.set_weights(pd.Series([1, 2, 3, 4], index=(1, 2, 5, 6)))
         self.assertEqual(
-            s.weight_column, pd.Series([np.nan, 1.0, 2.0, np.nan], name="w")
+            s.weight_series, pd.Series([np.nan, 1.0, 2.0, np.nan], name="w")
         )
         # test warning
         self.assertWarnsRegexp(
@@ -1695,7 +1695,7 @@ class TestSample_high_cardinality_warnings(balance.testutil.BalanceTestCase):
         with self.assertLogs("balance", level="WARNING") as logs:
             result = sample.adjust(target, variables=["identifier"], num_lambdas=1)
 
-        self.assertTrue(np.allclose(result.weight_column, np.ones(len(sample_df))))
+        self.assertTrue(np.allclose(result.weight_series, np.ones(len(sample_df))))
         self.assertTrue(
             any(
                 "High-cardinality features detected" in log and "unique=10" in log
@@ -1724,7 +1724,7 @@ class TestSample_high_cardinality_warnings(balance.testutil.BalanceTestCase):
             )
 
         # Filter out NaN weights before comparing (dropped rows may have NaN weights)
-        _wc = _assert_type(result.weight_column)
+        _wc = _assert_type(result.weight_series)
         valid_weights = _wc[~pd.isna(_wc)]
         self.assertTrue(np.allclose(valid_weights, np.ones(len(sample_df) - 1)))
         self.assertTrue(
@@ -1752,7 +1752,7 @@ class TestSample_high_cardinality_warnings(balance.testutil.BalanceTestCase):
         with self.assertLogs("balance", level="WARNING") as logs:
             result = sample.adjust(target, variables=["identifier"], num_lambdas=1)
 
-        self.assertTrue(np.allclose(result.weight_column, np.ones(len(sample_df))))
+        self.assertTrue(np.allclose(result.weight_series, np.ones(len(sample_df))))
         self.assertTrue(
             any(
                 "High-cardinality features detected" in log and "unique=9" in log
@@ -1776,7 +1776,7 @@ class TestSample_high_cardinality_warnings(balance.testutil.BalanceTestCase):
         with self.assertLogs("balance", level="WARNING") as logs:
             result = sample.adjust(target, variables=["identifier"], num_lambdas=1)
 
-        self.assertTrue(np.allclose(result.weight_column, np.ones(len(sample_df))))
+        self.assertTrue(np.allclose(result.weight_series, np.ones(len(sample_df))))
         self.assertFalse(
             any("High-cardinality features detected" in log for log in logs.output)
         )
@@ -2247,7 +2247,7 @@ class TestSampleFromFrameGuessWeightColumn(balance.testutil.BalanceTestCase):
                     {"a": [1, 2, 3], "id": [1, 2, 3], "weights": [1.0, 2.0, 3.0]}
                 )
             )
-            self.assertEqual(_assert_type(sample.weight_column).name, "weights")
+            self.assertEqual(_assert_type(sample.weight_series).name, "weights")
             self.assertTrue(
                 any("Guessing weight column is 'weights'" in msg for msg in log.output)
             )
@@ -2262,7 +2262,7 @@ class TestSampleFromFrameGuessWeightColumn(balance.testutil.BalanceTestCase):
             standardize_types=False,
         )
         # Weight column should exist and be int type when no weight is given and standardize_types=False
-        self.assertIsNotNone(sample.weight_column)
+        self.assertIsNotNone(sample.weight_series)
 
 
 class TestSampleFromFrameGuessIdColumnCandidates(balance.testutil.BalanceTestCase):
@@ -2326,7 +2326,7 @@ class TestSampleSetWeightsNonFloat(balance.testutil.BalanceTestCase):
             standardize_types=False,
         )
         sample.set_weights(2.0)
-        self.assertEqual(_assert_type(sample.weight_column).dtype.kind, "f")
+        self.assertEqual(_assert_type(sample.weight_series).dtype.kind, "f")
 
 
 class TestSampleSummaryIPWModel(balance.testutil.BalanceTestCase):
@@ -2713,7 +2713,7 @@ class TestSampleConversion(balance.testutil.BalanceTestCase):
         sf = s1.to_sample_frame()
         self.assertIsInstance(sf, SampleFrame)
         self.assertEqual(sf.id_column_name, "id")
-        self.assertEqual(sf.active_weight_column, "w")
+        self.assertEqual(sf.weight_column, "w")
         self.assertIn("a", sf.covar_columns)
         self.assertIn("b", sf.covar_columns)
         self.assertIn("c", sf.covar_columns)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -321,7 +321,7 @@ class TestSample(
             Sample.from_frame(df).weight_column, pd.Series((0.0, 2.0), name="weight")
         )
 
-    def test_Sample_from_frame_ignore_columns(self) -> None:
+    def test_Sample_from_frame_ignored_columns(self) -> None:
         """Ensure ignored columns are preserved but excluded from outcomes/covars."""
 
         df = pd.DataFrame(
@@ -335,7 +335,7 @@ class TestSample(
         )
 
         sample = Sample.from_frame(
-            df, outcome_columns="out", ignore_columns="note", weight_column=None
+            df, outcome_columns="out", ignored_columns="note", weight_column=None
         )
 
         self.assertListEqual(sample.covars().names(), ["a", "b"])
@@ -343,7 +343,7 @@ class TestSample(
         self.assertListEqual(
             sample.df.columns.tolist(), ["id", "a", "b", "out", "weight", "note"]
         )
-        ignored = sample.ignored_columns()
+        ignored = sample.df_ignored
         assert ignored is not None
         self.assertListEqual(ignored.columns.tolist(), ["note"])
 
@@ -361,40 +361,40 @@ class TestSample(
         )
 
         with self.assertRaisesRegex(ValueError, "cannot include id/weight"):
-            Sample.from_frame(df, weight_column="weight", ignore_columns=["id"])
+            Sample.from_frame(df, weight_column="weight", ignored_columns=["id"])
 
         with self.assertRaisesRegex(ValueError, "cannot include id/weight"):
-            Sample.from_frame(df, ignore_columns=["weight"])
+            Sample.from_frame(df, ignored_columns=["weight"])
 
         with self.assertRaisesRegex(ValueError, "'outcomes' and 'ignored'"):
             Sample.from_frame(
                 df,
                 outcome_columns=["out"],
-                ignore_columns=["out"],
+                ignored_columns=["out"],
                 weight_column=None,
             )
 
         with self.assertRaisesRegex(ValueError, "not in df columns"):
             # pyre-ignore[6]: Intentionally passing int to test validation
-            Sample.from_frame(df, ignore_columns=["a", 3])
+            Sample.from_frame(df, ignored_columns=["a", 3])
 
         with self.assertRaisesRegex(ValueError, "not in df columns"):
-            Sample.from_frame(df, ignore_columns=["missing"])
+            Sample.from_frame(df, ignored_columns=["missing"])
 
         sample = Sample.from_frame(
             df,
             outcome_columns="out",
-            ignore_columns=["a", "a", "meta"],
+            ignored_columns=["a", "a", "meta"],
             weight_column=None,
         )
-        ignored = _assert_type(sample.ignored_columns())
+        ignored = _assert_type(sample.df_ignored)
         self.assertListEqual(ignored.columns.tolist(), ["a", "meta"])
         self.assertListEqual(sample.covars().names(), [])
 
         sample_no_ignored = Sample.from_frame(
             df, outcome_columns="out", weight_column=None
         )
-        self.assertIsNone(sample_no_ignored.ignored_columns())
+        self.assertIsNone(sample_no_ignored.df_ignored)
 
     def test_Sample_from_frame_type_conversion(self) -> None:
         """Test automatic type conversion for different numeric types.
@@ -2737,12 +2737,12 @@ class TestSampleConversion(balance.testutil.BalanceTestCase):
             ),
             id_column="id",
             weight_column="w",
-            ignore_columns=["b"],
+            ignored_columns=["b"],
         )
         sf = sample_with_ignored.to_sample_frame()
         self.assertIsInstance(sf, SampleFrame)
-        self.assertIsNotNone(sf.ignore_columns)
-        self.assertIn("b", sf.ignore_columns)
+        self.assertIsNotNone(sf.ignored_columns)
+        self.assertIn("b", sf.ignored_columns)
 
     def test_to_balance_frame_unadjusted(self) -> None:
         """to_balance_frame converts a Sample with target to a BalanceFrame."""

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -640,7 +640,7 @@ class TestSample_base_and_adjust_methods(
         s, t = self._create_test_sample_with_target()
 
         a = s.adjust(t, max_de=None, method="null")
-        m = a.model()
+        m = a.model
 
         self.assertEqual(_assert_type(m)["method"], "null_adjustment")
 
@@ -654,7 +654,7 @@ class TestSample_base_and_adjust_methods(
         s, t = self._create_test_sample_with_target()
 
         a = s.adjust(t, max_de=None, num_lambdas=1)
-        m = a.model()
+        m = a.model
 
         self.assertEqual(_assert_type(m)["method"], "ipw")
 
@@ -2309,7 +2309,7 @@ class TestSampleModelNone(balance.testutil.BalanceTestCase):
         Verifies lines 851-854 in sample_class.py.
         """
         sample = Sample.from_frame(pd.DataFrame({"a": [1, 2, 3], "id": [1, 2, 3]}))
-        self.assertIsNone(sample.model())
+        self.assertIsNone(sample.model)
 
 
 class TestSampleSetWeightsNonFloat(balance.testutil.BalanceTestCase):
@@ -2448,7 +2448,7 @@ class TestSampleDiagnosticsIPWModelParams(balance.testutil.BalanceTestCase):
 
     def _get_ipw_fit(self, adjusted: Sample) -> Any:
         """Return the fitted sklearn estimator for an IPW-adjusted sample."""
-        model = adjusted.model()
+        model = adjusted.model
         self.assertIsNotNone(model)
         self.assertIn("fit", model)
         fit = model["fit"]

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -2714,9 +2714,9 @@ class TestSampleConversion(balance.testutil.BalanceTestCase):
         self.assertIsInstance(sf, SampleFrame)
         self.assertEqual(sf.id_column_name, "id")
         self.assertEqual(sf.active_weight_column, "w")
-        self.assertIn("a", sf.covars_columns)
-        self.assertIn("b", sf.covars_columns)
-        self.assertIn("c", sf.covars_columns)
+        self.assertIn("a", sf.covar_columns)
+        self.assertIn("b", sf.covar_columns)
+        self.assertIn("c", sf.covar_columns)
 
     def test_to_sample_frame_with_outcomes(self) -> None:
         """to_sample_frame preserves outcome columns."""

--- a/tests/test_sample_diagnostics_helper.py
+++ b/tests/test_sample_diagnostics_helper.py
@@ -324,7 +324,7 @@ def test_build_summary_matches_sample_summary() -> None:
         design_effect=de,
         effective_sample_size=ess,
         effective_sample_proportion=essp,
-        model_dict=adjusted.model(),
+        model_dict=adjusted.model,
         outcome_means=None,
     )
 
@@ -353,7 +353,7 @@ def test_build_diagnostics_matches_sample_diagnostics() -> None:
         covars_df=adjusted.covars().df,
         target_covars_df=adjusted._links["target"].covars().df,
         weights_summary=adjusted.weights().summary(),
-        model_dict=adjusted.model(),
+        model_dict=adjusted.model,
         covars_asmd=adjusted.covars().asmd(),
         covars_asmd_main=adjusted.covars().asmd(aggregate_by_main_covar=True),
         outcome_columns=adjusted._outcome_columns,
@@ -396,7 +396,7 @@ def test_build_diagnostics_with_ipw_matches_sample_diagnostics() -> None:
         covars_df=adjusted.covars().df,
         target_covars_df=adjusted._links["target"].covars().df,
         weights_summary=adjusted.weights().summary(),
-        model_dict=adjusted.model(),
+        model_dict=adjusted.model,
         covars_asmd=adjusted.covars().asmd(),
         covars_asmd_main=adjusted.covars().asmd(aggregate_by_main_covar=True),
         outcome_columns=adjusted._outcome_columns,

--- a/tests/test_sample_frame.py
+++ b/tests/test_sample_frame.py
@@ -97,7 +97,7 @@ class TestSampleFrame(BalanceTestCase):
             id_column="id",
             covar_columns=["x"],
             weight_columns=["w"],
-            ignore_columns=["region"],
+            ignored_columns=["region"],
         )
         self.assertIsNotNone(sf.df_ignored)
         self.assertListEqual(list(sf.df_ignored.columns), ["region"])
@@ -107,7 +107,7 @@ class TestSampleFrame(BalanceTestCase):
         sf = SampleFrame._create(
             df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
-        self.assertIsNone(sf.ignored_columns())
+        self.assertIsNone(sf.df_ignored)
 
     def test_ignored_columns_present(self) -> None:
         df = pd.DataFrame(
@@ -118,25 +118,12 @@ class TestSampleFrame(BalanceTestCase):
             id_column="id",
             covar_columns=["x"],
             weight_columns=["w"],
-            ignore_columns=["region"],
+            ignored_columns=["region"],
         )
-        result = sf.ignored_columns()
+        result = sf.df_ignored
         self.assertIsNotNone(result)
         self.assertListEqual(list(result.columns), ["region"])
         self.assertListEqual(list(result["region"]), ["US", "UK"])
-
-    def test_ignored_columns_matches_df_ignored(self) -> None:
-        df = pd.DataFrame(
-            {"id": [1, 2], "x": [10, 20], "w": [1.0, 1.0], "region": ["US", "UK"]}
-        )
-        sf = SampleFrame._create(
-            df=df,
-            id_column="id",
-            covar_columns=["x"],
-            weight_columns=["w"],
-            ignore_columns=["region"],
-        )
-        pd.testing.assert_frame_equal(sf.ignored_columns(), sf.df_ignored)
 
     def test_id_column(self) -> None:
         df = pd.DataFrame({"id": [1, 2, 3], "x": [10, 20, 30], "w": [1.0, 1.0, 1.0]})
@@ -204,7 +191,7 @@ class TestSampleFrameMutableViewSafety(BalanceTestCase):
             df,
             outcome_columns=["y"],
             predicted_outcome_columns=["p_y"],
-            ignore_columns=["region"],
+            ignored_columns=["region"],
         )
 
     def test_df_covars_returns_copy(self) -> None:
@@ -335,36 +322,36 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
         result.append("injected")
         self.assertEqual(sf.predicted_outcome_columns, ["p_y"])
 
-    def test_ignore_columns(self) -> None:
+    def test_ignored_columns(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0], "region": ["US"]})
         sf = SampleFrame._create(
             df=df,
             id_column="id",
             covar_columns=["x"],
             weight_columns=["w"],
-            ignore_columns=["region"],
+            ignored_columns=["region"],
         )
-        self.assertEqual(sf.ignore_columns, ["region"])
+        self.assertEqual(sf.ignored_columns, ["region"])
 
-    def test_ignore_columns_empty(self) -> None:
+    def test_ignored_columns_empty(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
             df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
-        self.assertEqual(sf.ignore_columns, [])
+        self.assertEqual(sf.ignored_columns, [])
 
-    def test_ignore_columns_returns_copy(self) -> None:
+    def test_ignored_columns_returns_copy(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0], "region": ["US"]})
         sf = SampleFrame._create(
             df=df,
             id_column="id",
             covar_columns=["x"],
             weight_columns=["w"],
-            ignore_columns=["region"],
+            ignored_columns=["region"],
         )
-        result = sf.ignore_columns
+        result = sf.ignored_columns
         result.append("injected")
-        self.assertEqual(sf.ignore_columns, ["region"])
+        self.assertEqual(sf.ignored_columns, ["region"])
 
     def test_active_weight_column(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
@@ -511,7 +498,7 @@ class TestSampleFrameFromFrame(BalanceTestCase):
         sf = SampleFrame.from_frame(df, covar_columns=["a", "b"])
         self.assertListEqual(list(sf.df_covars.columns), ["a", "b"])
 
-    def test_from_frame_ignore_columns(self) -> None:
+    def test_from_frame_ignored_columns(self) -> None:
         df = pd.DataFrame(
             {
                 "id": ["1", "2"],
@@ -520,7 +507,7 @@ class TestSampleFrameFromFrame(BalanceTestCase):
                 "weight": [1.0, 2.0],
             }
         )
-        sf = SampleFrame.from_frame(df, ignore_columns=["region"])
+        sf = SampleFrame.from_frame(df, ignored_columns=["region"])
         self.assertIsNotNone(sf.df_ignored)
         self.assertListEqual(list(sf.df_ignored.columns), ["region"])
         # region should NOT be in covars
@@ -539,7 +526,7 @@ class TestSampleFrameFromFrame(BalanceTestCase):
     def test_from_frame_missing_ignore_column_raises(self) -> None:
         df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0]})
         with self.assertRaises(ValueError):
-            SampleFrame.from_frame(df, ignore_columns=["nonexistent"])
+            SampleFrame.from_frame(df, ignored_columns=["nonexistent"])
 
     def test_from_frame_no_id_column_raises(self) -> None:
         df = pd.DataFrame({"x": [10, 20], "weight": [1.0, 1.0]})
@@ -606,14 +593,14 @@ class TestSampleFrameFromFrame(BalanceTestCase):
         self.assertAlmostEqual(sf.df_weights.iloc[0, 0], 0.0, places=5)
 
     def test_from_frame_overlapping_outcome_and_ignored_raises(self) -> None:
-        """A column in both outcome_columns and ignore_columns raises ValueError."""
+        """A column in both outcome_columns and ignored_columns raises ValueError."""
         df = pd.DataFrame(
             {"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0], "y": [5, 6]}
         )
         with self.assertRaisesRegex(
             ValueError, "appear in both 'outcomes' and 'ignored'"
         ):
-            SampleFrame.from_frame(df, outcome_columns=["y"], ignore_columns=["y"])
+            SampleFrame.from_frame(df, outcome_columns=["y"], ignored_columns=["y"])
 
     def test_from_frame_overlapping_covar_and_outcome_raises(self) -> None:
         """A column in both explicit covar_columns and outcome_columns raises ValueError."""
@@ -1040,7 +1027,7 @@ class TestSampleFrameFromSample(BalanceTestCase):
                 "weight": [1.0, 1.0],
             }
         )
-        sample = Sample.from_frame(df, ignore_columns=["extra"])
+        sample = Sample.from_frame(df, ignored_columns=["extra"])
         sf = SampleFrame.from_sample(sample)
         self.assertEqual(sf._column_roles["ignored"], ["extra"])
         self.assertEqual(sf._column_roles["covars"], ["x"])

--- a/tests/test_sample_frame.py
+++ b/tests/test_sample_frame.py
@@ -41,7 +41,7 @@ class TestSampleFrame(BalanceTestCase):
         self.assertListEqual(sf._column_roles["covars"], ["x1", "x2"])
         self.assertListEqual(sf._column_roles["weights"], ["w"])
         self.assertListEqual(sf._column_roles["outcomes"], [])
-        self.assertEqual(sf._active_weight_column, "w")
+        self.assertEqual(sf._weight_column_name, "w")
 
     def test_df_covars(self) -> None:
         df = pd.DataFrame({"id": [1, 2], "a": [10, 20], "b": [30, 40], "w": [1.0, 2.0]})
@@ -244,21 +244,21 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
         result.append("injected")
         self.assertEqual(sf.covar_columns, ["x"])
 
-    def test_weight_columns(self) -> None:
+    def test_weight_columns_all(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w1": [1.0], "w2": [2.0]})
         sf = SampleFrame._create(
             df=df, id_column="id", covar_columns=["x"], weight_columns=["w1", "w2"]
         )
-        self.assertEqual(sf.weight_columns, ["w1", "w2"])
+        self.assertEqual(sf.weight_columns_all, ["w1", "w2"])
 
-    def test_weight_columns_returns_copy(self) -> None:
+    def test_weight_columns_all_returns_copy(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
             df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
-        result = sf.weight_columns
+        result = sf.weight_columns_all
         result.append("injected")
-        self.assertEqual(sf.weight_columns, ["w"])
+        self.assertEqual(sf.weight_columns_all, ["w"])
 
     def test_outcome_columns(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0], "y": [5]})
@@ -353,19 +353,19 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
         result.append("injected")
         self.assertEqual(sf.ignored_columns, ["region"])
 
-    def test_active_weight_column(self) -> None:
+    def test_weight_column(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
             df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
-        self.assertEqual(sf.active_weight_column, "w")
+        self.assertEqual(sf.weight_column, "w")
 
-    def test_active_weight_column_none(self) -> None:
+    def test_weight_column_none(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10]})
         sf = SampleFrame._create(
             df=df, id_column="id", covar_columns=["x"], weight_columns=[]
         )
-        self.assertIsNone(sf.active_weight_column)
+        self.assertIsNone(sf.weight_column)
 
     def test_id_column_name(self) -> None:
         df = pd.DataFrame({"my_id": ["a", "b"], "x": [10, 20], "w": [1.0, 1.0]})
@@ -576,7 +576,7 @@ class TestSampleFrameFromFrame(BalanceTestCase):
 
         # Weights should match
         pd.testing.assert_series_equal(
-            sample.weight_column, sf.df_weights.iloc[:, 0], check_names=False
+            sample.weight_series, sf.df_weights.iloc[:, 0], check_names=False
         )
 
         # IDs should match (both should be strings)
@@ -876,25 +876,25 @@ class TestSampleFrameBalanceDFSourceProtocol(BalanceTestCase):
         sf = self._make_sf()
         self.assertIsInstance(sf, BalanceDFSource)
 
-    def test_weight_column_returns_series(self) -> None:
+    def test_weight_series_returns_series(self) -> None:
         sf = self._make_sf()
-        wc = sf.weight_column
+        wc = sf.weight_series
         self.assertIsInstance(wc, pd.Series)
         self.assertEqual(wc.tolist(), [1.0, 2.0, 1.5])
 
-    def test_weight_column_returns_copy(self) -> None:
+    def test_weight_series_returns_copy(self) -> None:
         sf = self._make_sf()
-        wc = sf.weight_column
+        wc = sf.weight_series
         wc.iloc[0] = 999.0
-        self.assertAlmostEqual(sf.weight_column.iloc[0], 1.0, places=5)
+        self.assertAlmostEqual(sf.weight_series.iloc[0], 1.0, places=5)
 
-    def test_weight_column_no_active_raises(self) -> None:
+    def test_weight_series_no_active_raises(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10.0]})
         sf = SampleFrame._create(
             df=df, id_column="id", covar_columns=["x"], weight_columns=[]
         )
         with self.assertRaises(ValueError):
-            _ = sf.weight_column
+            _ = sf.weight_series
 
     def test_id_column_returns_series(self) -> None:
         sf = self._make_sf()
@@ -934,17 +934,17 @@ class TestSampleFrameBalanceDFSourceProtocol(BalanceTestCase):
     def test_set_weights_series(self) -> None:
         sf = self._make_sf()
         sf.set_weights(pd.Series([3.0, 4.0, 5.0]))
-        self.assertEqual(sf.weight_column.tolist(), [3.0, 4.0, 5.0])
+        self.assertEqual(sf.weight_series.tolist(), [3.0, 4.0, 5.0])
 
     def test_set_weights_float(self) -> None:
         sf = self._make_sf()
         sf.set_weights(2.5)
-        self.assertEqual(sf.weight_column.tolist(), [2.5, 2.5, 2.5])
+        self.assertEqual(sf.weight_series.tolist(), [2.5, 2.5, 2.5])
 
     def test_set_weights_none_resets_to_one(self) -> None:
         sf = self._make_sf()
         sf.set_weights(None)
-        self.assertEqual(sf.weight_column.tolist(), [1.0, 1.0, 1.0])
+        self.assertEqual(sf.weight_series.tolist(), [1.0, 1.0, 1.0])
 
     def test_set_weights_length_mismatch_raises(self) -> None:
         sf = self._make_sf()
@@ -998,7 +998,7 @@ class TestSampleFrameFromSample(BalanceTestCase):
         self.assertEqual(sf._id_column_name, "id")
         self.assertEqual(sf._column_roles["covars"], ["x"])
         self.assertEqual(sf._column_roles["weights"], ["weight"])
-        self.assertEqual(sf._active_weight_column, "weight")
+        self.assertEqual(sf._weight_column_name, "weight")
         self.assertEqual(len(sf._df), 3)
 
     def test_from_sample_with_outcomes(self) -> None:

--- a/tests/test_sample_frame.py
+++ b/tests/test_sample_frame.py
@@ -21,9 +21,11 @@ from balance.testutil import BalanceTestCase
 
 
 class TestSampleFrame(BalanceTestCase):
-    def test_direct_init_raises(self) -> None:
-        with self.assertRaises(NotImplementedError):
-            SampleFrame()
+    def test_direct_init_noop(self) -> None:
+        # __init__ is a no-op; object is uninitialised (for deepcopy support)
+        sf = SampleFrame.__new__(SampleFrame)
+        sf.__init__()
+        # No attributes set — just verifying it doesn't raise
 
     def test_create_basic(self) -> None:
         df = pd.DataFrame(
@@ -79,14 +81,14 @@ class TestSampleFrame(BalanceTestCase):
         self.assertIsNotNone(sf.df_outcomes)
         self.assertListEqual(list(sf.df_outcomes.columns), ["y"])
 
-    def test_df_misc_none(self) -> None:
+    def test_df_ignored_none(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
             df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
         )
-        self.assertIsNone(sf.df_misc)
+        self.assertIsNone(sf.df_ignored)
 
-    def test_df_misc_present(self) -> None:
+    def test_df_ignored_present(self) -> None:
         df = pd.DataFrame(
             {"id": [1, 2], "x": [10, 20], "w": [1.0, 1.0], "region": ["US", "UK"]}
         )
@@ -95,10 +97,10 @@ class TestSampleFrame(BalanceTestCase):
             id_column="id",
             covars_columns=["x"],
             weight_columns=["w"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
-        self.assertIsNotNone(sf.df_misc)
-        self.assertListEqual(list(sf.df_misc.columns), ["region"])
+        self.assertIsNotNone(sf.df_ignored)
+        self.assertListEqual(list(sf.df_ignored.columns), ["region"])
 
     def test_ignored_columns_none(self) -> None:
         df = pd.DataFrame({"id": [1, 2], "x": [10, 20], "w": [1.0, 1.0]})
@@ -116,14 +118,14 @@ class TestSampleFrame(BalanceTestCase):
             id_column="id",
             covars_columns=["x"],
             weight_columns=["w"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
         result = sf.ignored_columns()
         self.assertIsNotNone(result)
         self.assertListEqual(list(result.columns), ["region"])
         self.assertListEqual(list(result["region"]), ["US", "UK"])
 
-    def test_ignored_columns_matches_df_misc(self) -> None:
+    def test_ignored_columns_matches_df_ignored(self) -> None:
         df = pd.DataFrame(
             {"id": [1, 2], "x": [10, 20], "w": [1.0, 1.0], "region": ["US", "UK"]}
         )
@@ -132,9 +134,9 @@ class TestSampleFrame(BalanceTestCase):
             id_column="id",
             covars_columns=["x"],
             weight_columns=["w"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
-        pd.testing.assert_frame_equal(sf.ignored_columns(), sf.df_misc)
+        pd.testing.assert_frame_equal(sf.ignored_columns(), sf.df_ignored)
 
     def test_id_column(self) -> None:
         df = pd.DataFrame({"id": [1, 2, 3], "x": [10, 20, 30], "w": [1.0, 1.0, 1.0]})
@@ -202,7 +204,7 @@ class TestSampleFrameMutableViewSafety(BalanceTestCase):
             df,
             outcome_columns=["y"],
             predicted_outcome_columns=["p_y"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
 
     def test_df_covars_returns_copy(self) -> None:
@@ -224,11 +226,11 @@ class TestSampleFrameMutableViewSafety(BalanceTestCase):
         outcomes["y"] = [999.0, 999.0, 999.0]
         self.assertEqual(list(sf._df["y"]), [5.0, 6.0, 7.0])
 
-    def test_df_misc_returns_copy(self) -> None:
+    def test_df_ignored_returns_copy(self) -> None:
         sf = self._make_sf()
-        misc = sf.df_misc
-        self.assertIsNotNone(misc)
-        misc["region"] = ["XX", "XX", "XX"]
+        ignored = sf.df_ignored
+        self.assertIsNotNone(ignored)
+        ignored["region"] = ["XX", "XX", "XX"]
         self.assertEqual(list(sf._df["region"]), ["US", "UK", "CA"])
 
     def test_id_column_returns_copy(self) -> None:
@@ -333,36 +335,36 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
         result.append("injected")
         self.assertEqual(sf.predicted_outcome_columns, ["p_y"])
 
-    def test_misc_columns(self) -> None:
+    def test_ignore_columns(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0], "region": ["US"]})
         sf = SampleFrame._create(
             df=df,
             id_column="id",
             covars_columns=["x"],
             weight_columns=["w"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
-        self.assertEqual(sf.misc_columns, ["region"])
+        self.assertEqual(sf.ignore_columns, ["region"])
 
-    def test_misc_columns_empty(self) -> None:
+    def test_ignore_columns_empty(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
             df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
         )
-        self.assertEqual(sf.misc_columns, [])
+        self.assertEqual(sf.ignore_columns, [])
 
-    def test_misc_columns_returns_copy(self) -> None:
+    def test_ignore_columns_returns_copy(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0], "region": ["US"]})
         sf = SampleFrame._create(
             df=df,
             id_column="id",
             covars_columns=["x"],
             weight_columns=["w"],
-            misc_columns=["region"],
+            ignore_columns=["region"],
         )
-        result = sf.misc_columns
+        result = sf.ignore_columns
         result.append("injected")
-        self.assertEqual(sf.misc_columns, ["region"])
+        self.assertEqual(sf.ignore_columns, ["region"])
 
     def test_active_weight_column(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
@@ -509,7 +511,7 @@ class TestSampleFrameFromFrame(BalanceTestCase):
         sf = SampleFrame.from_frame(df, covars_columns=["a", "b"])
         self.assertListEqual(list(sf.df_covars.columns), ["a", "b"])
 
-    def test_from_frame_misc_columns(self) -> None:
+    def test_from_frame_ignore_columns(self) -> None:
         df = pd.DataFrame(
             {
                 "id": ["1", "2"],
@@ -518,9 +520,9 @@ class TestSampleFrameFromFrame(BalanceTestCase):
                 "weight": [1.0, 2.0],
             }
         )
-        sf = SampleFrame.from_frame(df, misc_columns=["region"])
-        self.assertIsNotNone(sf.df_misc)
-        self.assertListEqual(list(sf.df_misc.columns), ["region"])
+        sf = SampleFrame.from_frame(df, ignore_columns=["region"])
+        self.assertIsNotNone(sf.df_ignored)
+        self.assertListEqual(list(sf.df_ignored.columns), ["region"])
         # region should NOT be in covars
         self.assertNotIn("region", list(sf.df_covars.columns))
 
@@ -534,10 +536,10 @@ class TestSampleFrameFromFrame(BalanceTestCase):
         with self.assertRaises(ValueError):
             SampleFrame.from_frame(df, predicted_outcome_columns=["nonexistent"])
 
-    def test_from_frame_missing_misc_column_raises(self) -> None:
+    def test_from_frame_missing_ignore_column_raises(self) -> None:
         df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0]})
         with self.assertRaises(ValueError):
-            SampleFrame.from_frame(df, misc_columns=["nonexistent"])
+            SampleFrame.from_frame(df, ignore_columns=["nonexistent"])
 
     def test_from_frame_no_id_column_raises(self) -> None:
         df = pd.DataFrame({"x": [10, 20], "weight": [1.0, 1.0]})
@@ -603,13 +605,15 @@ class TestSampleFrameFromFrame(BalanceTestCase):
         sf = SampleFrame.from_frame(df)
         self.assertAlmostEqual(sf.df_weights.iloc[0, 0], 0.0, places=5)
 
-    def test_from_frame_overlapping_outcome_and_misc_raises(self) -> None:
-        """A column in both outcome_columns and misc_columns raises ValueError."""
+    def test_from_frame_overlapping_outcome_and_ignored_raises(self) -> None:
+        """A column in both outcome_columns and ignore_columns raises ValueError."""
         df = pd.DataFrame(
             {"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0], "y": [5, 6]}
         )
-        with self.assertRaisesRegex(ValueError, "appear in both 'outcomes' and 'misc'"):
-            SampleFrame.from_frame(df, outcome_columns=["y"], misc_columns=["y"])
+        with self.assertRaisesRegex(
+            ValueError, "appear in both 'outcomes' and 'ignored'"
+        ):
+            SampleFrame.from_frame(df, outcome_columns=["y"], ignore_columns=["y"])
 
     def test_from_frame_overlapping_covar_and_outcome_raises(self) -> None:
         """A column in both explicit covars_columns and outcome_columns raises ValueError."""
@@ -792,10 +796,17 @@ class TestSampleFrameWeightMetadata(BalanceTestCase):
             sf.add_weight_column("x", pd.Series([1.0, 1.0, 1.0]))
         self.assertIn("already exists in the DataFrame", str(ctx.exception))
 
-    def test_add_weight_column_length_mismatch_raises(self) -> None:
+    def test_add_weight_column_shorter_series_pads_with_nan(self) -> None:
+        sf = self._make_sf()
+        # Shorter Series is padded with NaN (supports na_action="drop")
+        sf.add_weight_column("w_short", pd.Series([1.0, 1.0]))
+        self.assertEqual(len(sf._df["w_short"]), 3)
+        self.assertTrue(pd.isna(sf._df["w_short"].iloc[2]))
+
+    def test_add_weight_column_longer_series_raises(self) -> None:
         sf = self._make_sf()
         with self.assertRaises(ValueError) as ctx:
-            sf.add_weight_column("w_bad", pd.Series([1.0, 1.0]))
+            sf.add_weight_column("w_bad", pd.Series([1.0] * 5))
         self.assertIn("length", str(ctx.exception))
 
     def test_multiple_weight_columns_workflow(self) -> None:
@@ -1031,7 +1042,7 @@ class TestSampleFrameFromSample(BalanceTestCase):
         )
         sample = Sample.from_frame(df, ignore_columns=["extra"])
         sf = SampleFrame.from_sample(sample)
-        self.assertEqual(sf._column_roles["misc"], ["extra"])
+        self.assertEqual(sf._column_roles["ignored"], ["extra"])
         self.assertEqual(sf._column_roles["covars"], ["x"])
 
     def test_from_sample_preserves_data(self) -> None:

--- a/tests/test_sample_frame.py
+++ b/tests/test_sample_frame.py
@@ -34,7 +34,7 @@ class TestSampleFrame(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["x1", "x2"],
+            covar_columns=["x1", "x2"],
             weight_columns=["w"],
         )
         self.assertEqual(len(sf.df), 3)
@@ -46,7 +46,7 @@ class TestSampleFrame(BalanceTestCase):
     def test_df_covars(self) -> None:
         df = pd.DataFrame({"id": [1, 2], "a": [10, 20], "b": [30, 40], "w": [1.0, 2.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["a", "b"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["a", "b"], weight_columns=["w"]
         )
         covars = sf.df_covars
         self.assertListEqual(list(covars.columns), ["a", "b"])
@@ -57,7 +57,7 @@ class TestSampleFrame(BalanceTestCase):
             {"id": [1, 2], "x": [10, 20], "w1": [1.0, 2.0], "w2": [3.0, 4.0]}
         )
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w1", "w2"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w1", "w2"]
         )
         # Active weight is the first one
         self.assertListEqual(list(sf.df_weights.columns), ["w1"])
@@ -65,7 +65,7 @@ class TestSampleFrame(BalanceTestCase):
     def test_df_outcomes_none(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         self.assertIsNone(sf.df_outcomes)
 
@@ -74,7 +74,7 @@ class TestSampleFrame(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
             outcome_columns=["y"],
         )
@@ -84,7 +84,7 @@ class TestSampleFrame(BalanceTestCase):
     def test_df_ignored_none(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         self.assertIsNone(sf.df_ignored)
 
@@ -95,7 +95,7 @@ class TestSampleFrame(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
             ignore_columns=["region"],
         )
@@ -105,7 +105,7 @@ class TestSampleFrame(BalanceTestCase):
     def test_ignored_columns_none(self) -> None:
         df = pd.DataFrame({"id": [1, 2], "x": [10, 20], "w": [1.0, 1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         self.assertIsNone(sf.ignored_columns())
 
@@ -116,7 +116,7 @@ class TestSampleFrame(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
             ignore_columns=["region"],
         )
@@ -132,7 +132,7 @@ class TestSampleFrame(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
             ignore_columns=["region"],
         )
@@ -141,7 +141,7 @@ class TestSampleFrame(BalanceTestCase):
     def test_id_column(self) -> None:
         df = pd.DataFrame({"id": [1, 2, 3], "x": [10, 20, 30], "w": [1.0, 1.0, 1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         self.assertIsInstance(sf.id_column, pd.Series)
         self.assertListEqual(list(sf.id_column), [1, 2, 3])
@@ -149,7 +149,7 @@ class TestSampleFrame(BalanceTestCase):
     def test_df_returns_copy(self) -> None:
         df = pd.DataFrame({"id": [1, 2], "x": [10, 20], "w": [1.0, 1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         df_copy = sf.df
         df_copy["x"] = [999, 999]
@@ -159,7 +159,7 @@ class TestSampleFrame(BalanceTestCase):
     def test_create_copies_input_df(self) -> None:
         df = pd.DataFrame({"id": [1, 2], "x": [10, 20], "w": [1.0, 1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         # Mutate the original DataFrame
         df["x"] = [999, 999]
@@ -173,7 +173,7 @@ class TestSampleFrame(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["a", "b"],
+            covar_columns=["a", "b"],
             weight_columns=["w"],
             outcome_columns=["y"],
         )
@@ -241,33 +241,33 @@ class TestSampleFrameMutableViewSafety(BalanceTestCase):
 
 
 class TestSampleFrameColumnRoleProperties(BalanceTestCase):
-    def test_covars_columns(self) -> None:
+    def test_covar_columns(self) -> None:
         df = pd.DataFrame({"id": [1, 2], "a": [10, 20], "b": [30, 40], "w": [1.0, 2.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["a", "b"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["a", "b"], weight_columns=["w"]
         )
-        self.assertEqual(sf.covars_columns, ["a", "b"])
+        self.assertEqual(sf.covar_columns, ["a", "b"])
 
-    def test_covars_columns_returns_copy(self) -> None:
+    def test_covar_columns_returns_copy(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
-        result = sf.covars_columns
+        result = sf.covar_columns
         result.append("injected")
-        self.assertEqual(sf.covars_columns, ["x"])
+        self.assertEqual(sf.covar_columns, ["x"])
 
     def test_weight_columns(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w1": [1.0], "w2": [2.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w1", "w2"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w1", "w2"]
         )
         self.assertEqual(sf.weight_columns, ["w1", "w2"])
 
     def test_weight_columns_returns_copy(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         result = sf.weight_columns
         result.append("injected")
@@ -278,7 +278,7 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
             outcome_columns=["y"],
         )
@@ -287,7 +287,7 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
     def test_outcome_columns_empty(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         self.assertEqual(sf.outcome_columns, [])
 
@@ -296,7 +296,7 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
             outcome_columns=["y"],
         )
@@ -309,7 +309,7 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
             predicted_outcome_columns=["p_y"],
         )
@@ -318,7 +318,7 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
     def test_predicted_outcome_columns_empty(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         self.assertEqual(sf.predicted_outcome_columns, [])
 
@@ -327,7 +327,7 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
             predicted_outcome_columns=["p_y"],
         )
@@ -340,7 +340,7 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
             ignore_columns=["region"],
         )
@@ -349,7 +349,7 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
     def test_ignore_columns_empty(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         self.assertEqual(sf.ignore_columns, [])
 
@@ -358,7 +358,7 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
         sf = SampleFrame._create(
             df=df,
             id_column="id",
-            covars_columns=["x"],
+            covar_columns=["x"],
             weight_columns=["w"],
             ignore_columns=["region"],
         )
@@ -369,21 +369,21 @@ class TestSampleFrameColumnRoleProperties(BalanceTestCase):
     def test_active_weight_column(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10], "w": [1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         self.assertEqual(sf.active_weight_column, "w")
 
     def test_active_weight_column_none(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=[]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=[]
         )
         self.assertIsNone(sf.active_weight_column)
 
     def test_id_column_name(self) -> None:
         df = pd.DataFrame({"my_id": ["a", "b"], "x": [10, 20], "w": [1.0, 1.0]})
         sf = SampleFrame._create(
-            df=df, id_column="my_id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="my_id", covar_columns=["x"], weight_columns=["w"]
         )
         self.assertEqual(sf.id_column_name, "my_id")
 
@@ -508,7 +508,7 @@ class TestSampleFrameFromFrame(BalanceTestCase):
                 "weight": [1.0, 2.0],
             }
         )
-        sf = SampleFrame.from_frame(df, covars_columns=["a", "b"])
+        sf = SampleFrame.from_frame(df, covar_columns=["a", "b"])
         self.assertListEqual(list(sf.df_covars.columns), ["a", "b"])
 
     def test_from_frame_ignore_columns(self) -> None:
@@ -616,21 +616,21 @@ class TestSampleFrameFromFrame(BalanceTestCase):
             SampleFrame.from_frame(df, outcome_columns=["y"], ignore_columns=["y"])
 
     def test_from_frame_overlapping_covar_and_outcome_raises(self) -> None:
-        """A column in both explicit covars_columns and outcome_columns raises ValueError."""
+        """A column in both explicit covar_columns and outcome_columns raises ValueError."""
         df = pd.DataFrame(
             {"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0], "y": [5, 6]}
         )
         with self.assertRaisesRegex(
             ValueError, "appear in both 'covars' and 'outcomes'"
         ):
-            SampleFrame.from_frame(df, covars_columns=["x", "y"], outcome_columns=["y"])
+            SampleFrame.from_frame(df, covar_columns=["x", "y"], outcome_columns=["y"])
 
 
 class TestSampleFrameDunderMethods(BalanceTestCase):
     def _make_sf(self) -> SampleFrame:
         df = pd.DataFrame({"id": [1, 2, 3], "x": [10, 20, 30], "w": [1.0, 1.0, 1.0]})
         return SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
 
     def test_len_returns_row_count(self) -> None:
@@ -640,7 +640,7 @@ class TestSampleFrameDunderMethods(BalanceTestCase):
     def test_len_empty_frame(self) -> None:
         df = pd.DataFrame({"id": [], "x": [], "w": []})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w"]
         )
         self.assertEqual(len(sf), 0)
 
@@ -687,7 +687,7 @@ class TestSampleFrameEdgeCases(BalanceTestCase):
     def test_df_weights_empty_weight_columns(self) -> None:
         df = pd.DataFrame({"id": [1, 2], "x": [10, 20]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=[]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=[]
         )
         w = sf.df_weights
         self.assertIsInstance(w, pd.DataFrame)
@@ -752,7 +752,7 @@ class TestSampleFrameWeightMetadata(BalanceTestCase):
             {"id": [1, 2], "x": [10, 20], "w1": [1.0, 2.0], "w2": [3.0, 4.0]}
         )
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=["w1", "w2"]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=["w1", "w2"]
         )
         self.assertEqual(list(sf.df_weights.columns), ["w1"])
         sf.set_active_weight("w2")
@@ -904,7 +904,7 @@ class TestSampleFrameBalanceDFSourceProtocol(BalanceTestCase):
     def test_weight_column_no_active_raises(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=[]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=[]
         )
         with self.assertRaises(ValueError):
             _ = sf.weight_column
@@ -967,7 +967,7 @@ class TestSampleFrameBalanceDFSourceProtocol(BalanceTestCase):
     def test_set_weights_no_active_raises(self) -> None:
         df = pd.DataFrame({"id": [1], "x": [10.0]})
         sf = SampleFrame._create(
-            df=df, id_column="id", covars_columns=["x"], weight_columns=[]
+            df=df, id_column="id", covar_columns=["x"], weight_columns=[]
         )
         with self.assertRaises(ValueError):
             sf.set_weights(pd.Series([1.0]))

--- a/tests/test_sample_internal.py
+++ b/tests/test_sample_internal.py
@@ -341,7 +341,7 @@ class TestSampleInternalSampleFrame(
             id_column="id",
             weight_column="weight",
             outcome_columns="y" if outcome else None,
-            ignore_columns="misc_col" if ignore else None,
+            ignored_columns="misc_col" if ignore else None,
             standardize_types=False,
         )
 

--- a/tests/test_sample_internal.py
+++ b/tests/test_sample_internal.py
@@ -522,7 +522,7 @@ class TestSampleInternalSampleFrame(
         # Both the plain weight_column attr and the SampleFrame's _df
         # should reflect the new weights.
         pd.testing.assert_series_equal(
-            s.weight_column,
+            s.weight_series,
             s._sample_frame._df["weight"],
         )
         self.assertEqual(s._sample_frame._df["weight"].tolist(), [2.0, 3.0, 4.0])

--- a/tests/test_sample_internal.py
+++ b/tests/test_sample_internal.py
@@ -251,7 +251,7 @@ class TestSampleModelNoAdjustmentModel(balance.testutil.BalanceTestCase):
         sample = Sample.from_frame(pd.DataFrame({"a": [1, 2, 3], "id": [1, 2, 3]}))
 
         # For an unadjusted sample, model() should return None
-        result = sample.model()
+        result = sample.model
         self.assertIsNone(result)
 
     def test_model_returns_adjustment_model_when_set(self) -> None:
@@ -263,7 +263,7 @@ class TestSampleModelNoAdjustmentModel(balance.testutil.BalanceTestCase):
         target = Sample.from_frame(pd.DataFrame({"a": [1, 2, 3], "id": [4, 5, 6]}))
         adjusted = sample.set_target(target).adjust(method="null")
 
-        result = adjusted.model()
+        result = adjusted.model
         self.assertIsNotNone(result)
         self.assertIsInstance(result, dict)
         self.assertIn("method", result)

--- a/tests/test_sample_internal.py
+++ b/tests/test_sample_internal.py
@@ -120,37 +120,37 @@ class TestSamplePrivateAPI(balance.testutil.BalanceTestCase):
             ),
         )
 
-    def test_Sample__check_if_adjusted(self) -> None:
+    def test_Sample__require_adjusted(self) -> None:
         with self.assertRaisesRegex(
             ValueError,
-            "This is not an adjusted Sample. Use sample.adjust to adjust the sample to target",
+            r"is not adjusted\. Use \.adjust\(\)",
         ):
-            s1._check_if_adjusted()
+            s1._require_adjusted()
         with self.assertRaisesRegex(
             ValueError,
-            "This is not an adjusted Sample. Use sample.adjust to adjust the sample to target",
+            r"is not adjusted\. Use \.adjust\(\)",
         ):
-            s3._check_if_adjusted()
+            s3._require_adjusted()
         self.assertTrue(
-            s3_adjusted_null._check_if_adjusted() is None
+            s3_adjusted_null._require_adjusted() is None
         )  # Does not raise an error
 
-    def test_Sample__no_target_error(self) -> None:
-        # test exception when the is no target
+    def test_Sample__require_target(self) -> None:
+        # test exception when there is no target
         with self.assertRaisesRegex(
             ValueError,
-            "This Sample does not have a target set. Use sample.set_target to add target",
+            r"does not have a target set\. Use \.set_target\(\)",
         ):
-            s1._no_target_error()
-        s3._no_target_error()  # Should not raise an error
+            s1._require_target()
+        s3._require_target()  # Should not raise an error
 
-    def test_Sample__check_outcomes_exists(self) -> None:
+    def test_Sample__require_outcomes(self) -> None:
         with self.assertRaisesRegex(
             ValueError,
-            "This Sample does not have outcome columns specified",
+            r"does not have outcome columns specified",
         ):
-            s2._check_outcomes_exists()
-        self.assertTrue(s1._check_outcomes_exists() is None)  # Does not raise an error
+            s2._require_outcomes()
+        self.assertTrue(s1._require_outcomes() is None)  # Does not raise an error
 
 
 class TestSampleDesignEffectDiagnostics(balance.testutil.BalanceTestCase):

--- a/tests/test_sample_internal.py
+++ b/tests/test_sample_internal.py
@@ -16,11 +16,13 @@ SampleFrame/BalanceFrame.
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from unittest.mock import MagicMock
+from copy import deepcopy
+from typing import Any
 
 import balance.testutil
 import pandas as pd
 from balance.sample_class import Sample
+from balance.sample_frame import SampleFrame
 
 
 # Test sample fixtures - shared across multiple test methods
@@ -154,15 +156,16 @@ class TestSamplePrivateAPI(balance.testutil.BalanceTestCase):
 class TestSampleDesignEffectDiagnostics(balance.testutil.BalanceTestCase):
     """Test cases for _design_effect_diagnostics edge cases (lines 342-351)."""
 
-    def test_design_effect_diagnostics_with_no_weight_column(self) -> None:
-        """Test _design_effect_diagnostics returns None values when weight_column is None.
+    def test_design_effect_diagnostics_with_uniform_weights(self) -> None:
+        """Test _design_effect_diagnostics with uniform weights returns Deff=1.
 
-        Verifies lines 344-345 in sample_class.py.
+        When all weights are equal, the design effect should be 1.0.
         """
         sample = Sample.from_frame(pd.DataFrame({"a": [1, 2, 3], "id": [1, 2, 3]}))
-        sample.weight_column = None
         result = sample._design_effect_diagnostics()
-        self.assertEqual(result, (None, None, None))
+        design_effect: float | None = result[0]
+        assert design_effect is not None
+        self.assertAlmostEqual(design_effect, 1.0)
 
     def test_design_effect_diagnostics_with_invalid_weights(self) -> None:
         """Test _design_effect_diagnostics handles ValueError gracefully.
@@ -267,72 +270,273 @@ class TestSampleModelNoAdjustmentModel(balance.testutil.BalanceTestCase):
 
 
 class TestSampleDesignEffectDiagnosticsExceptionTypes(balance.testutil.BalanceTestCase):
-    """Test cases for _design_effect_diagnostics exception handling (lines 349-351)."""
+    """Test cases for _design_effect_diagnostics exception handling."""
 
     def test_design_effect_diagnostics_type_error(self) -> None:
-        """Test _design_effect_diagnostics handles TypeError gracefully.
+        """Test _design_effect_diagnostics handles TypeError gracefully."""
+        from unittest.mock import patch
 
-        Verifies the try/except in _design_effect_diagnostics catches TypeError
-        from weights().design_effect().
-        """
         sample = Sample.from_frame(
             pd.DataFrame({"a": [1, 2, 3], "id": [1, 2, 3], "w": [1.0, 2.0, 3.0]}),
             weight_column="w",
         )
-
-        # Mock weights().design_effect() to raise TypeError
-        mock_weights = MagicMock()
-        mock_weights.design_effect = MagicMock(side_effect=TypeError("test error"))
-        original_weights = sample.weights
-        try:
-            sample.weights = MagicMock(return_value=mock_weights)
+        with patch(
+            "balance.stats_and_plots.weights_stats.design_effect",
+            side_effect=TypeError("test error"),
+        ):
             result = sample._design_effect_diagnostics()
             self.assertEqual(result, (None, None, None))
-        finally:
-            sample.weights = original_weights
 
     def test_design_effect_diagnostics_value_error(self) -> None:
-        """Test _design_effect_diagnostics handles ValueError gracefully.
+        """Test _design_effect_diagnostics handles ValueError gracefully."""
+        from unittest.mock import patch
 
-        Verifies the try/except in _design_effect_diagnostics catches ValueError
-        from weights().design_effect().
-        """
         sample = Sample.from_frame(
             pd.DataFrame({"a": [1, 2, 3], "id": [1, 2, 3], "w": [1.0, 2.0, 3.0]}),
             weight_column="w",
         )
-
-        # Mock weights().design_effect() to raise ValueError
-        mock_weights = MagicMock()
-        mock_weights.design_effect = MagicMock(side_effect=ValueError("test error"))
-        original_weights = sample.weights
-        try:
-            sample.weights = MagicMock(return_value=mock_weights)
+        with patch(
+            "balance.stats_and_plots.weights_stats.design_effect",
+            side_effect=ValueError("test error"),
+        ):
             result = sample._design_effect_diagnostics()
             self.assertEqual(result, (None, None, None))
-        finally:
-            sample.weights = original_weights
 
     def test_design_effect_diagnostics_zero_division_error(self) -> None:
-        """Test _design_effect_diagnostics handles ZeroDivisionError gracefully.
+        """Test _design_effect_diagnostics handles ZeroDivisionError gracefully."""
+        from unittest.mock import patch
 
-        Verifies the try/except in _design_effect_diagnostics catches
-        ZeroDivisionError from weights().design_effect().
-        """
         sample = Sample.from_frame(
             pd.DataFrame({"a": [1, 2, 3], "id": [1, 2, 3], "w": [1.0, 2.0, 3.0]}),
             weight_column="w",
         )
-
-        # Mock weights().design_effect() to raise ZeroDivisionError
-        mock_weights = MagicMock()
-        mock_weights.design_effect = MagicMock(
-            side_effect=ZeroDivisionError("test error")
-        )
-        original_weights = sample.weights
-        try:
-            sample.weights = MagicMock(return_value=mock_weights)
+        with patch(
+            "balance.stats_and_plots.weights_stats.design_effect",
+            side_effect=ZeroDivisionError("test error"),
+        ):
             result = sample._design_effect_diagnostics()
             self.assertEqual(result, (None, None, None))
-        finally:
-            sample.weights = original_weights
+
+
+class TestSampleInternalSampleFrame(
+    balance.testutil.BalanceTestCase,
+):
+    """Tests for the internal SampleFrame backing of Sample."""
+
+    def _make_sample(
+        self,
+        outcome: bool = True,
+        ignore: bool = False,
+    ) -> Sample:
+        data: dict[str, Any] = {
+            "id": ["1", "2", "3"],
+            "x": [10.0, 20.0, 30.0],
+            "y": [1.0, 2.0, 3.0],
+            "weight": [1.0, 1.0, 1.0],
+        }
+        if ignore:
+            data["misc_col"] = ["a", "b", "c"]
+        return Sample.from_frame(
+            pd.DataFrame(data),
+            id_column="id",
+            weight_column="weight",
+            outcome_columns="y" if outcome else None,
+            ignore_columns="misc_col" if ignore else None,
+            standardize_types=False,
+        )
+
+    def test_sample_has_sample_frame(self) -> None:
+        s = self._make_sample()
+        self.assertIsNotNone(s._sample_frame)
+        self.assertIsInstance(s._sample_frame, SampleFrame)
+
+    def test_df_property_returns_sample_frame_df(self) -> None:
+        s = self._make_sample()
+        # _df should be the same object as _sample_frame._df
+        self.assertIs(s._df, s._sample_frame._df)
+
+    def test_df_setter_updates_sample_frame(self) -> None:
+        s = self._make_sample()
+        new_df = s._df.copy()
+        new_df["x"] = [100.0, 200.0, 300.0]
+        s._df = new_df
+        pd.testing.assert_frame_equal(s._sample_frame._df, new_df)
+
+    def test_outcome_columns_property(self) -> None:
+        s = self._make_sample(outcome=True)
+        outcome_cols = s._outcome_columns
+        self.assertIsNotNone(outcome_cols)
+        assert outcome_cols is not None
+        self.assertEqual(outcome_cols.columns.tolist(), ["y"])
+        pd.testing.assert_series_equal(
+            outcome_cols["y"],
+            pd.Series([1.0, 2.0, 3.0], name="y"),
+            check_names=False,
+        )
+
+    def test_outcome_columns_none_when_no_outcomes(self) -> None:
+        s = self._make_sample(outcome=False)
+        self.assertIsNone(s._outcome_columns)
+
+    def test_outcome_columns_setter(self) -> None:
+        s = self._make_sample(outcome=True)
+        # Setting to None clears outcomes
+        s._outcome_columns = None
+        self.assertIsNone(s._outcome_columns)
+        self.assertEqual(s._sample_frame._column_roles["outcomes"], [])
+
+    def test_ignored_column_names_property(self) -> None:
+        s = self._make_sample(ignore=True)
+        self.assertEqual(s._ignored_column_names, ["misc_col"])
+
+    def test_ignored_column_names_empty_by_default(self) -> None:
+        s = self._make_sample(ignore=False)
+        self.assertEqual(s._ignored_column_names, [])
+
+    def test_ignored_column_names_setter(self) -> None:
+        s = self._make_sample(ignore=True)
+        s._ignored_column_names = ["x"]
+        self.assertEqual(s._sample_frame._column_roles["ignored"], ["x"])
+
+    def test_covar_columns_inferred_correctly(self) -> None:
+        s = self._make_sample(outcome=True, ignore=True)
+        # covars = all columns minus id, weight, outcome, ignored
+        self.assertEqual(s._covar_columns_names(), ["x"])
+
+    def test_from_frame_builds_sample_frame_with_correct_roles(self) -> None:
+        s = self._make_sample(outcome=True, ignore=True)
+        sf = s._sample_frame
+        self.assertEqual(sf._id_column_name, "id")
+        self.assertEqual(sf._column_roles["weights"], ["weight"])
+        self.assertEqual(sf._column_roles["outcomes"], ["y"])
+        self.assertEqual(sf._column_roles["ignored"], ["misc_col"])
+        self.assertEqual(sf._column_roles["covars"], ["x"])
+
+    def test_set_target_preserves_sample_frame(self) -> None:
+        s = self._make_sample()
+        t = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["4", "5", "6"],
+                    "x": [40.0, 50.0, 60.0],
+                    "y": [4.0, 5.0, 6.0],
+                    "weight": [1.0, 1.0, 1.0],
+                }
+            ),
+            id_column="id",
+            weight_column="weight",
+            outcome_columns="y",
+            standardize_types=False,
+        )
+        s_with_target = s.set_target(t)
+        self.assertIsNotNone(s_with_target._sample_frame)
+        # Target should also have its own SampleFrame
+        target = s_with_target._links["target"]
+        self.assertIsNotNone(target._sample_frame)
+
+    def test_unadjusted_has_no_weight_metadata(self) -> None:
+        s = self._make_sample()
+        self.assertEqual(s._sample_frame.weight_metadata(), {})
+
+    def test_adjust_records_weight_metadata(self) -> None:
+        s = self._make_sample()
+        t = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["4", "5", "6"],
+                    "x": [40.0, 50.0, 60.0],
+                    "weight": [1.0, 1.0, 1.0],
+                }
+            ),
+            id_column="id",
+            weight_column="weight",
+            standardize_types=False,
+        )
+        s_with_target = s.set_target(t)
+        adjusted = s_with_target.adjust(method="null")
+        meta = adjusted._sample_frame.weight_metadata()
+        self.assertEqual(meta["method"], "null")
+        self.assertTrue(meta["adjusted"])
+
+    def test_adjust_ipw_records_weight_metadata(self) -> None:
+        s = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [str(i) for i in range(20)],
+                    "x": [float(i) for i in range(20)],
+                    "weight": [1.0] * 20,
+                }
+            ),
+            id_column="id",
+            weight_column="weight",
+            standardize_types=False,
+        )
+        t = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [str(i) for i in range(20, 40)],
+                    "x": [float(i) for i in range(20, 40)],
+                    "weight": [1.0] * 20,
+                }
+            ),
+            id_column="id",
+            weight_column="weight",
+            standardize_types=False,
+        )
+        s_with_target = s.set_target(t)
+        adjusted = s_with_target.adjust(method="ipw")
+        meta = adjusted._sample_frame.weight_metadata()
+        self.assertEqual(meta["method"], "ipw")
+        self.assertTrue(meta["adjusted"])
+
+    def test_adjust_callable_records_weight_metadata(self) -> None:
+        def my_custom_method(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "weight": pd.Series([1.0, 1.0, 1.0]),
+                "model": {"method": "custom"},
+            }
+
+        s = self._make_sample()
+        t = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["4", "5", "6"],
+                    "x": [40.0, 50.0, 60.0],
+                    "weight": [1.0, 1.0, 1.0],
+                }
+            ),
+            id_column="id",
+            weight_column="weight",
+            standardize_types=False,
+        )
+        s_with_target = s.set_target(t)
+        adjusted = s_with_target.adjust(method=my_custom_method)
+        meta = adjusted._sample_frame.weight_metadata()
+        self.assertEqual(meta["method"], "my_custom_method")
+        self.assertTrue(meta["adjusted"])
+
+    def test_set_weights_syncs_sample_frame(self) -> None:
+        s = self._make_sample()
+        new_weights = pd.Series([2.0, 3.0, 4.0], index=s._df.index)
+        s.set_weights(new_weights)
+        # Both the plain weight_column attr and the SampleFrame's _df
+        # should reflect the new weights.
+        pd.testing.assert_series_equal(
+            s.weight_column,
+            s._sample_frame._df["weight"],
+        )
+        self.assertEqual(s._sample_frame._df["weight"].tolist(), [2.0, 3.0, 4.0])
+
+    def test_keep_only_some_rows_columns_preserves_outcomes(self) -> None:
+        s = self._make_sample(outcome=True)
+        # Keep only column "x" — outcome column "y" should be preserved
+        filtered = s.keep_only_some_rows_columns(columns_to_keep=["id", "x", "weight"])
+        self.assertIn("y", filtered._df.columns.tolist())
+
+    def test_deepcopy_preserves_sample_frame(self) -> None:
+        s = self._make_sample()
+        s2 = deepcopy(s)
+        self.assertIsNotNone(s2._sample_frame)
+        # Modifying the copy should not affect the original
+        s2._df["x"] = [100.0, 200.0, 300.0]
+        self.assertEqual(s._df["x"].tolist(), [10.0, 20.0, 30.0])

--- a/tests/test_stats_and_plots.py
+++ b/tests/test_stats_and_plots.py
@@ -897,10 +897,10 @@ class TestImpactOfWeightsOnOutcome(
         )
         adjusted = sample.set_target(target).adjust(method="null")
 
-        with self.assertRaisesRegex(ValueError, "This is not an adjusted Sample"):
+        with self.assertRaisesRegex(ValueError, r"is not adjusted\. Use \.adjust\(\)"):
             _validate_adjusted_samples(sample, adjusted)
 
-        with self.assertRaisesRegex(ValueError, "This is not an adjusted Sample"):
+        with self.assertRaisesRegex(ValueError, r"is not adjusted\. Use \.adjust\(\)"):
             _validate_adjusted_samples(adjusted, sample)
 
     def test_validate_adjusted_samples_success(self) -> None:

--- a/tests/test_util_data_transformation.py
+++ b/tests/test_util_data_transformation.py
@@ -528,8 +528,8 @@ class TestUtil(
         )
 
         # Check that model coefficients are identical
-        output_cat_var_model = output_cat_var.model()
-        output_string_var_model = output_string_var.model()
+        output_cat_var_model = output_cat_var.model
+        output_string_var_model = output_string_var.model
         output_cat_var_model = _assert_type(output_cat_var_model)
         output_string_var_model = _assert_type(output_string_var_model)
         self.assertEqual(

--- a/tests/test_util_pandas_utils.py
+++ b/tests/test_util_pandas_utils.py
@@ -506,7 +506,7 @@ class TestSample_high_cardinality_warnings(balance.testutil.BalanceTestCase):
         with self.assertLogs("balance", level="WARNING") as logs:
             result = sample.adjust(target, variables=["identifier"], num_lambdas=1)
 
-        self.assertTrue(np.allclose(result.weight_column, np.ones(len(sample_df))))
+        self.assertTrue(np.allclose(result.weight_series, np.ones(len(sample_df))))
         self.assertTrue(
             any(
                 "High-cardinality features detected" in log and "unique=10" in log
@@ -560,7 +560,7 @@ class TestSample_high_cardinality_warnings(balance.testutil.BalanceTestCase):
         with self.assertLogs("balance", level="WARNING") as logs:
             result = sample.adjust(target, variables=["identifier"], num_lambdas=1)
 
-        self.assertTrue(np.allclose(result.weight_column, np.ones(len(sample_df))))
+        self.assertTrue(np.allclose(result.weight_series, np.ones(len(sample_df))))
         self.assertTrue(
             any(
                 "High-cardinality features detected" in log and "unique=9" in log
@@ -584,7 +584,7 @@ class TestSample_high_cardinality_warnings(balance.testutil.BalanceTestCase):
         with self.assertLogs("balance", level="WARNING") as logs:
             result = sample.adjust(target, variables=["identifier"], num_lambdas=1)
 
-        self.assertTrue(np.allclose(result.weight_column, np.ones(len(sample_df))))
+        self.assertTrue(np.allclose(result.weight_series, np.ones(len(sample_df))))
         self.assertFalse(
             any("High-cardinality features detected" in log for log in logs.output)
         )

--- a/tutorials/balance_ascii_plots.ipynb
+++ b/tutorials/balance_ascii_plots.ipynb
@@ -154,7 +154,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "dfs = [\n    {\"df\": target.covars().df, \"weight\": target.weight_column},\n    {\"df\": sample_with_target.covars().df, \"weight\": sample_with_target.weight_column},\n    {\"df\": adjusted.covars().df, \"weight\": adjusted.weight_column},\n]\nprint(ascii_comparative_hist(\n    dfs, names=[\"Target\", \"Unadjusted\", \"Adjusted\"],\n    column=\"income\",\n))"
+   "source": "dfs = [\n    {\"df\": target.covars().df, \"weight\": target.weight_series},\n    {\"df\": sample_with_target.covars().df, \"weight\": sample_with_target.weight_series},\n    {\"df\": adjusted.covars().df, \"weight\": adjusted.weight_series},\n]\nprint(ascii_comparative_hist(\n    dfs, names=[\"Target\", \"Unadjusted\", \"Adjusted\"],\n    column=\"income\",\n))"
   },
   {
    "cell_type": "markdown",

--- a/tutorials/balance_quickstart_new_api.ipynb
+++ b/tutorials/balance_quickstart_new_api.ipynb
@@ -131,7 +131,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "print(f\"Covariates:  {sample_sf.covar_columns}\")\nprint(f\"Outcomes:    {sample_sf.outcome_columns}\")\nprint(f\"Weight cols: {sample_sf.weight_columns}\")\nprint(f\"Active wt:   {sample_sf.active_weight_column}\")\nprint(f\"ID column:   {sample_sf.id_column_name}\")\nprint(f\"Rows:        {len(sample_sf)}\")"
+   "source": "print(f\"Covariates:  {sample_sf.covar_columns}\")\nprint(f\"Outcomes:    {sample_sf.outcome_columns}\")\nprint(f\"Weight cols: {sample_sf.weight_columns_all}\")\nprint(f\"Active wt:   {sample_sf.weight_column}\")\nprint(f\"ID column:   {sample_sf.id_column_name}\")\nprint(f\"Rows:        {len(sample_sf)}\")"
   },
   {
    "cell_type": "code",

--- a/tutorials/balance_quickstart_new_api.ipynb
+++ b/tutorials/balance_quickstart_new_api.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This tutorial demonstrates the **new** `SampleFrame` + `BalanceFrame` API\n",
     "introduced in balance 0.18.0. It mirrors the original\n",
-    "`balance_quickstart.ipynb` step-by-step, but uses **only** the new classes —\n",
+    "`balance_quickstart.ipynb` step-by-step, but uses **only** the new classes \u2014\n",
     "no `Sample` object is needed.\n",
     "\n",
     "### Why a new API?\n",
@@ -16,7 +16,7 @@
     "| Old API (`Sample`) | New API (`SampleFrame` / `BalanceFrame`) |\n",
     "|---|---|\n",
     "| Column roles inferred by exclusion | Column roles declared explicitly |\n",
-    "| Mutable `.set_target()` / `.adjust()` | Immutable — `adjust()` returns a **new** object |\n",
+    "| Mutable `.set_target()` / `.adjust()` | Immutable \u2014 `adjust()` returns a **new** object |\n",
     "| One class does everything | Clear separation: data container vs. adjustment orchestrator |\n",
     "| Weight provenance not tracked | Weight metadata recorded per-column |\n",
     "\n",
@@ -122,7 +122,7 @@
     "### Inspecting a SampleFrame\n",
     "\n",
     "You can inspect the column roles and data shape at any time.\n",
-    "Unlike `Sample.df`, each role is a separate property — no magic\n",
+    "Unlike `Sample.df`, each role is a separate property \u2014 no magic\n",
     "\"everything-that's-left\" inference."
    ]
   },
@@ -168,7 +168,7 @@
     "With the old API you would call `sample.set_target(target)`. The new\n",
     "API constructs a `BalanceFrame` directly from two `SampleFrame` objects.\n",
     "\n",
-    "A `BalanceFrame` is **immutable** — `adjust()` returns a *new*\n",
+    "A `BalanceFrame` is **immutable** \u2014 `adjust()` returns a *new*\n",
     "BalanceFrame rather than mutating the existing one."
    ]
   },
@@ -177,10 +177,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "bf = BalanceFrame(responders=sample_sf, target=target_sf)\n",
-    "print(bf)"
-   ]
+   "source": "bf = BalanceFrame(sf_with_outcomes=sample_sf, sf_target=target_sf)\nprint(bf)"
   },
   {
    "cell_type": "markdown",
@@ -247,7 +244,7 @@
     "via logistic regression with lasso regularization).\n",
     "\n",
     "**Key difference from the old API:** `adjust()` returns a **new**\n",
-    "`BalanceFrame` — the original `bf` is unchanged."
+    "`BalanceFrame` \u2014 the original `bf` is unchanged."
    ]
   },
   {
@@ -345,7 +342,7 @@
     "### ASCII plots\n",
     "\n",
     "Use `library=\"balance\"` for a text-based comparison of unadjusted,\n",
-    "adjusted, and target — useful in terminals or logging contexts."
+    "adjusted, and target \u2014 useful in terminals or logging contexts."
    ]
   },
   {
@@ -385,22 +382,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Design effect and effective sample size\n",
-    "\n",
-    "The new API exposes `design_effect()` and `design_effect_prop()`\n",
-    "directly on BalanceFrame — no need to go through `weights().design_effect()`."
-   ]
+   "source": "### Design effect and effective sample size\n\nThe new API exposes design effect diagnostics through the weights view:\n`adjusted.weights().design_effect()` and `adjusted.weights().design_effect_prop()`."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "print(f\"Design effect:           {adjusted.design_effect():.4f}\")\n",
-    "print(f\"Effective sample size %: {adjusted.design_effect_prop():.2%}\")"
-   ]
+   "source": "print(f\"Design effect:           {adjusted.weights().design_effect():.4f}\")\nprint(f\"Effective sample size %: {adjusted.weights().design_effect_prop():.2%}\")"
   },
   {
    "cell_type": "markdown",
@@ -430,34 +419,21 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Analytics shortcuts\n",
-    "\n",
-    "BalanceFrame provides convenience methods for common analytics:"
-   ]
+   "source": "### Analytics via BalanceDF views\n\nThe new API accesses analytics through the `.covars()`, `.weights()`,\nand `.outcomes()` views rather than top-level convenience methods:"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "print(\"Covariate means (unadjusted / adjusted / target):\")\n",
-    "print(adjusted.covar_means())"
-   ]
+   "source": "print(\"Covariate means (unadjusted / adjusted / target):\")\nprint(adjusted.covars().mean().T)"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "print(\"Outcome SD proportional change:\")\n",
-    "print(adjusted.outcome_sd_prop())\n",
-    "print()\n",
-    "print(\"Outcome variance ratio (adjusted / unadjusted):\")\n",
-    "print(adjusted.outcome_variance_ratio())"
-   ]
+   "source": "print(\"Outcome SD proportional change:\")\nprint(adjusted.outcomes().outcome_sd_prop())\nprint()\nprint(\"Outcome variance ratio (adjusted / unadjusted):\")\nprint(adjusted.outcomes().outcome_variance_ratio())"
   },
   {
    "cell_type": "markdown",
@@ -466,12 +442,12 @@
     "## Other Adjustment Methods\n",
     "\n",
     "BalanceFrame supports all the same methods as Sample:\n",
-    "- `\"ipw\"` — inverse propensity weighting (default)\n",
-    "- `\"cbps\"` — covariate balancing propensity score\n",
-    "- `\"rake\"` — iterative proportional fitting (raking)\n",
-    "- `\"poststratify\"` — post-stratification\n",
+    "- `\"ipw\"` \u2014 inverse propensity weighting (default)\n",
+    "- `\"cbps\"` \u2014 covariate balancing propensity score\n",
+    "- `\"rake\"` \u2014 iterative proportional fitting (raking)\n",
+    "- `\"poststratify\"` \u2014 post-stratification\n",
     "\n",
-    "Each returns a **new** BalanceFrame — the original stays unchanged."
+    "Each returns a **new** BalanceFrame \u2014 the original stays unchanged."
    ]
   },
   {
@@ -479,36 +455,19 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "adjusted_cbps = bf.adjust(method=\"cbps\")\n",
-    "print(f\"CBPS design effect: {adjusted_cbps.design_effect():.4f}\")\n",
-    "print(adjusted_cbps.covars().asmd(aggregate_by_main_covar=True).T)"
-   ]
+   "source": "adjusted_cbps = bf.adjust(method=\"cbps\")\nprint(f\"CBPS design effect: {adjusted_cbps.weights().design_effect():.4f}\")\nprint(adjusted_cbps.covars().asmd(aggregate_by_main_covar=True).T)"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Transformations\n",
-    "\n",
-    "Custom per-column transformations can be set on a `SampleFrame` before\n",
-    "creating the `BalanceFrame`. If no transformations are set, balance\n",
-    "applies its default transformations automatically during `adjust()`."
-   ]
+   "source": "## Transformations\n\nTransformations (one-hot encoding, interaction terms, etc.) are applied\nautomatically during `adjust()`. You can also pass custom `transformations`\nvia kwargs. To inspect the transformed design matrix, use `model_matrix()`."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Set default transformations explicitly\n",
-    "sample_sf_t = SampleFrame.from_frame(sample_df, outcome_columns=[\"happiness\"])\n",
-    "sample_sf_t.set_default_transformations()\n",
-    "\n",
-    "print(\"Transformed covariates columns:\")\n",
-    "print(sample_sf_t.df_covars_transformed.columns.tolist())"
-   ]
+   "source": "# Inspect the model matrix (transformed covariates) used during adjustment\nprint(\"Transformed covariates columns:\")\nprint(adjusted.model_matrix().columns.tolist())"
   },
   {
    "cell_type": "markdown",
@@ -534,8 +493,9 @@
    "source": [
     "## Exporting results\n",
     "\n",
-    "The `.df` property combines responder, target, and (if adjusted)\n",
-    "unadjusted data into a single DataFrame with a `source` column."
+    "The `.df` property returns the responder DataFrame with id, covariates,\n",
+    "outcomes, weights, and any ignored columns. Use `.to_csv()` to export\n",
+    "the adjusted data."
    ]
   },
   {
@@ -544,9 +504,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "combined = adjusted.df\n",
-    "print(combined[\"source\"].value_counts())\n",
-    "print(combined.head())"
+    "print(\"Adjusted DataFrame columns:\", adjusted.df.columns.tolist())\n",
+    "print(adjusted.df.head())"
    ]
   },
   {
@@ -575,7 +534,7 @@
     "## Filtering rows/columns\n",
     "\n",
     "`keep_only_some_rows_columns()` returns a new BalanceFrame with\n",
-    "filtered data — the original remains unchanged (immutable pattern)."
+    "filtered data \u2014 the original remains unchanged (immutable pattern)."
    ]
   },
   {
@@ -585,8 +544,8 @@
    "outputs": [],
    "source": [
     "filtered = adjusted.keep_only_some_rows_columns(\n",
-    "    row_condition=\"gender == 'Female'\",\n",
-    "    column_names=[\"gender\", \"age\", \"income\"],\n",
+    "    rows_to_keep=\"gender == 'Female'\",\n",
+    "    columns_to_keep=[\"gender\", \"age\", \"income\"],\n",
     ")\n",
     "print(f\"Original rows: {len(adjusted.responders)}\")\n",
     "print(f\"Filtered rows: {len(filtered.responders)}\")\n",
@@ -596,21 +555,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Summary: Old vs New API side-by-side\n",
-    "\n",
-    "| Step | Old API (`Sample`) | New API (`SampleFrame` / `BalanceFrame`) |\n",
-    "|---|---|---|\n",
-    "| Load data | `s = Sample.from_frame(df)` | `sf = SampleFrame.from_frame(df)` |\n",
-    "| Pair sample + target | `s.set_target(target)` | `bf = BalanceFrame(responders=sf, target=tf)` |\n",
-    "| Adjust | `adjusted = s.adjust()` *(mutates s)* | `adjusted = bf.adjust()` *(bf unchanged)* |\n",
-    "| Summary | `adjusted.summary()` | `adjusted.summary()` |\n",
-    "| Diagnostics | `adjusted.diagnostics()` | `adjusted.diagnostics()` |\n",
-    "| Covariates | `adjusted.covars().mean()` | `adjusted.covars().mean()` |\n",
-    "| Design effect | `adjusted.design_effect()` | `adjusted.design_effect()` |\n",
-    "| CSV export | `adjusted.to_csv()` | `adjusted.to_csv()` |\n",
-    "| Filter | *(not available)* | `adjusted.keep_only_some_rows_columns(...)` |"
-   ]
+   "source": "## Summary: Old vs New API side-by-side\n\n| Step | Old API (`Sample`) | New API (`SampleFrame` / `BalanceFrame`) |\n|---|---|---|\n| Load data | `s = Sample.from_frame(df)` | `sf = SampleFrame.from_frame(df)` |\n| Pair sample + target | `s.set_target(target)` | `bf = BalanceFrame(sf_with_outcomes=sf, sf_target=tf)` |\n| Adjust | `adjusted = s.adjust()` *(mutates s)* | `adjusted = bf.adjust()` *(bf unchanged)* |\n| Summary | `adjusted.summary()` | `adjusted.summary()` |\n| Diagnostics | `adjusted.diagnostics()` | `adjusted.diagnostics()` |\n| Covariates | `adjusted.covars().mean()` | `adjusted.covars().mean()` |\n| Design effect | `adjusted.design_effect()` | `adjusted.weights().design_effect()` |\n| CSV export | `adjusted.to_csv()` | `adjusted.to_csv()` |\n| Filter | *(not available)* | `adjusted.keep_only_some_rows_columns(...)` |"
   }
  ],
  "metadata": {

--- a/tutorials/balance_quickstart_new_api.ipynb
+++ b/tutorials/balance_quickstart_new_api.ipynb
@@ -170,7 +170,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "bf = BalanceFrame(sf_with_outcomes=sample_sf, sf_target=target_sf)\nprint(bf)"
+   "source": "bf = BalanceFrame(sample=sample_sf, sf_target=target_sf)\nprint(bf)"
   },
   {
    "cell_type": "markdown",
@@ -548,7 +548,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Summary: Old vs New API side-by-side\n\n| Step | Old API (`Sample`) | New API (`SampleFrame` / `BalanceFrame`) |\n|---|---|---|\n| Load data | `s = Sample.from_frame(df)` | `sf = SampleFrame.from_frame(df)` |\n| Pair sample + target | `s.set_target(target)` | `bf = BalanceFrame(sf_with_outcomes=sf, sf_target=tf)` |\n| Adjust | `adjusted = s.adjust()` *(mutates s)* | `adjusted = bf.adjust()` *(bf unchanged)* |\n| Summary | `adjusted.summary()` | `adjusted.summary()` |\n| Diagnostics | `adjusted.diagnostics()` | `adjusted.diagnostics()` |\n| Covariates | `adjusted.covars().mean()` | `adjusted.covars().mean()` |\n| Design effect | `adjusted.design_effect()` | `adjusted.weights().design_effect()` |\n| CSV export | `adjusted.to_csv()` | `adjusted.to_csv()` |\n| Filter | *(not available)* | `adjusted.keep_only_some_rows_columns(...)` |"
+   "source": "## Summary: Old vs New API side-by-side\n\n| Step | Old API (`Sample`) | New API (`SampleFrame` / `BalanceFrame`) |\n|---|---|---|\n| Load data | `s = Sample.from_frame(df)` | `sf = SampleFrame.from_frame(df)` |\n| Pair sample + target | `s.set_target(target)` | `bf = BalanceFrame(sample=sf, sf_target=tf)` |\n| Adjust | `adjusted = s.adjust()` *(mutates s)* | `adjusted = bf.adjust()` *(bf unchanged)* |\n| Summary | `adjusted.summary()` | `adjusted.summary()` |\n| Diagnostics | `adjusted.diagnostics()` | `adjusted.diagnostics()` |\n| Covariates | `adjusted.covars().mean()` | `adjusted.covars().mean()` |\n| Design effect | `adjusted.design_effect()` | `adjusted.weights().design_effect()` |\n| CSV export | `adjusted.to_csv()` | `adjusted.to_csv()` |\n| Filter | *(not available)* | `adjusted.keep_only_some_rows_columns(...)` |"
   }
  ],
  "metadata": {

--- a/tutorials/balance_quickstart_new_api.ipynb
+++ b/tutorials/balance_quickstart_new_api.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This tutorial demonstrates the **new** `SampleFrame` + `BalanceFrame` API\n",
     "introduced in balance 0.18.0. It mirrors the original\n",
-    "`balance_quickstart.ipynb` step-by-step, but uses **only** the new classes \u2014\n",
+    "`balance_quickstart.ipynb` step-by-step, but uses **only** the new classes —\n",
     "no `Sample` object is needed.\n",
     "\n",
     "### Why a new API?\n",
@@ -16,7 +16,7 @@
     "| Old API (`Sample`) | New API (`SampleFrame` / `BalanceFrame`) |\n",
     "|---|---|\n",
     "| Column roles inferred by exclusion | Column roles declared explicitly |\n",
-    "| Mutable `.set_target()` / `.adjust()` | Immutable \u2014 `adjust()` returns a **new** object |\n",
+    "| Mutable `.set_target()` / `.adjust()` | Immutable — `adjust()` returns a **new** object |\n",
     "| One class does everything | Clear separation: data container vs. adjustment orchestrator |\n",
     "| Weight provenance not tracked | Weight metadata recorded per-column |\n",
     "\n",
@@ -122,7 +122,7 @@
     "### Inspecting a SampleFrame\n",
     "\n",
     "You can inspect the column roles and data shape at any time.\n",
-    "Unlike `Sample.df`, each role is a separate property \u2014 no magic\n",
+    "Unlike `Sample.df`, each role is a separate property — no magic\n",
     "\"everything-that's-left\" inference."
    ]
   },
@@ -131,14 +131,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "print(f\"Covariates:  {sample_sf.covars_columns}\")\n",
-    "print(f\"Outcomes:    {sample_sf.outcome_columns}\")\n",
-    "print(f\"Weight cols: {sample_sf.weight_columns}\")\n",
-    "print(f\"Active wt:   {sample_sf.active_weight_column}\")\n",
-    "print(f\"ID column:   {sample_sf.id_column_name}\")\n",
-    "print(f\"Rows:        {len(sample_sf)}\")"
-   ]
+   "source": "print(f\"Covariates:  {sample_sf.covar_columns}\")\nprint(f\"Outcomes:    {sample_sf.outcome_columns}\")\nprint(f\"Weight cols: {sample_sf.weight_columns}\")\nprint(f\"Active wt:   {sample_sf.active_weight_column}\")\nprint(f\"ID column:   {sample_sf.id_column_name}\")\nprint(f\"Rows:        {len(sample_sf)}\")"
   },
   {
    "cell_type": "code",
@@ -168,7 +161,7 @@
     "With the old API you would call `sample.set_target(target)`. The new\n",
     "API constructs a `BalanceFrame` directly from two `SampleFrame` objects.\n",
     "\n",
-    "A `BalanceFrame` is **immutable** \u2014 `adjust()` returns a *new*\n",
+    "A `BalanceFrame` is **immutable** — `adjust()` returns a *new*\n",
     "BalanceFrame rather than mutating the existing one."
    ]
   },
@@ -244,7 +237,7 @@
     "via logistic regression with lasso regularization).\n",
     "\n",
     "**Key difference from the old API:** `adjust()` returns a **new**\n",
-    "`BalanceFrame` \u2014 the original `bf` is unchanged."
+    "`BalanceFrame` — the original `bf` is unchanged."
    ]
   },
   {
@@ -342,7 +335,7 @@
     "### ASCII plots\n",
     "\n",
     "Use `library=\"balance\"` for a text-based comparison of unadjusted,\n",
-    "adjusted, and target \u2014 useful in terminals or logging contexts."
+    "adjusted, and target — useful in terminals or logging contexts."
    ]
   },
   {
@@ -442,12 +435,12 @@
     "## Other Adjustment Methods\n",
     "\n",
     "BalanceFrame supports all the same methods as Sample:\n",
-    "- `\"ipw\"` \u2014 inverse propensity weighting (default)\n",
-    "- `\"cbps\"` \u2014 covariate balancing propensity score\n",
-    "- `\"rake\"` \u2014 iterative proportional fitting (raking)\n",
-    "- `\"poststratify\"` \u2014 post-stratification\n",
+    "- `\"ipw\"` — inverse propensity weighting (default)\n",
+    "- `\"cbps\"` — covariate balancing propensity score\n",
+    "- `\"rake\"` — iterative proportional fitting (raking)\n",
+    "- `\"poststratify\"` — post-stratification\n",
     "\n",
-    "Each returns a **new** BalanceFrame \u2014 the original stays unchanged."
+    "Each returns a **new** BalanceFrame — the original stays unchanged."
    ]
   },
   {
@@ -534,7 +527,7 @@
     "## Filtering rows/columns\n",
     "\n",
     "`keep_only_some_rows_columns()` returns a new BalanceFrame with\n",
-    "filtered data \u2014 the original remains unchanged (immutable pattern)."
+    "filtered data — the original remains unchanged (immutable pattern)."
    ]
   },
   {

--- a/website/docs/tutorials/index.mdx
+++ b/website/docs/tutorials/index.mdx
@@ -18,3 +18,4 @@ If you are new to balance, we suggest getting started with the [balance Quicksta
 6. [**comparing_cbps_in_r_vs_python_using_sim_data**](./comparing_cbps_in_r_vs_python_using_sim_data) - This notebook compares the results of running CBPS in R and Python. In R using the `BCPS` package, and in Python using the `balance` package. The results are almost identical.
 7. [**CLI tutorial**](./balance_cli_tutorial) - Walks through the balance command-line interface workflow, including building an input dataset, running the CLI, and reviewing diagnostics.
 8. [**balance_ascii_plots**](./balance_ascii_plots) - Demonstrates how to use ASCII plots for visualizing covariate distributions and balance diagnostics in a text-based format.
+9. [**quickstart_new_api**](./quickstart_new_api) - Like the quickstart tutorial, but demonstrates the new SampleFrame-based API with explicit column roles (covars, outcomes, ignored) for clearer, more predictable data handling.

--- a/website/docs/tutorials/quickstart_new_api.mdx
+++ b/website/docs/tutorials/quickstart_new_api.mdx
@@ -1,0 +1,13 @@
+---
+title: Quickstart (New API)
+sidebar_position: 10
+hide_table_of_contents: true
+hide_title: true
+---
+
+import HTMLLoader from '@site/src/components/HTMLLoader';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+Link to notebook: [balance_quickstart_new_api.ipynb](https://github.com/facebookresearch/balance/blob/main/tutorials/balance_quickstart_new_api.ipynb)
+
+<HTMLLoader docFile={useBaseUrl('html/tutorials/balance_quickstart_new_api.html')}/>


### PR DESCRIPTION
Summary:

Final cleanup diff: modernize type annotations and fix PascalCase method names.

### Type annotation modernization
| Old | New | File |
|-----|-----|------|
| `Dict[str, ...]` | `dict[str, ...]` | balancedf_class.py |
| `Tuple[...]` | `tuple[...]` | balancedf_class.py |
| `List[str]` | `list[str]` | sample_class.py |
| `cast(pd.DataFrame, ...)` | `_assert_type(...)` | sample_frame.py |

### PascalCase → snake_case method renames
| Old | New |
|-----|-----|
| `_check_if_not_BalanceDF()` | `_check_if_not_balancedf()` |
| `_BalanceDF_child_from_linked_samples()` | `_balancedf_child_from_linked_samples()` |

### Scope
- 7 files: 4 source, 3 tests.
- No behavioral changes — annotation modernization + naming convention fix.
- Removed unused `Dict`, `Tuple`, `List`, `cast` imports.

Reviewed By: sahil350

Differential Revision: D99546908
