### PR TITLE
Implement TODOs for weight handling and baseline reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# 0.20.0 (Unreleased)
+
+## New Features
+
+- **Modernized weight dtype checks for pandas 3.0 compatibility**
+  - Replaced deprecated float-dtype checks in `SampleFrame.set_weights()` paths
+    with dtype kind (`dtype.kind == "f"`) checks.
+  - Ensures weight assignment continues to cast to `float64` without relying on
+    deprecated pandas APIs.
+
+- **Safer target replacement on adjusted objects**
+  - `BalanceFrame.set_target(...)` now emits a warning when replacing the target
+    on an adjusted object in in-place mode because this resets responder weights
+    to pre-adjust values and drops the current adjustment result.
+
+- **Added `BalanceFrame.set_as_pre_adjust()`**
+  - New helper to lock in the current responder state as the new
+    pre-adjust baseline.
+  - Supports both immutable usage (`in_place=False`, default) and in-place
+    mutation (`in_place=True`).
+  - Clears the current adjustment model and unadjusted link since the object
+    is no longer considered adjusted after baseline reset.
+
+## Tests
+
+- Added coverage for:
+  - warning emission when replacing target on adjusted objects,
+  - `set_as_pre_adjust()` behavior (copy and in-place),
+  - and weight-column casting when active weight dtype is non-float.
+
 # 0.19.0 (2026-04-06)
 
 ## Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 - **Modernized weight dtype checks for pandas 3.0 compatibility**
   - Replaced deprecated float-dtype checks in `SampleFrame.set_weights()` paths
-    with dtype kind (`dtype.kind == "f"`) checks.
-  - Ensures weight assignment continues to cast to `float64` without relying on
-    deprecated pandas APIs.
+    with explicit exact-`float64` checks.
+  - Ensures weight assignment always coerces to exact `float64` without relying
+    on deprecated pandas APIs.
 
 - **Safer target replacement on adjusted objects**
   - `BalanceFrame.set_target(...)` now emits a warning when replacing the target
@@ -25,8 +25,11 @@
 
 - Added coverage for:
   - warning emission when replacing target on adjusted objects,
+  - no-warning behavior when replacing target on unadjusted objects,
   - `set_as_pre_adjust()` behavior (copy and in-place),
-  - and weight-column casting when active weight dtype is non-float.
+  - synchronization of inherited `SampleFrame` views after
+    `Sample.set_as_pre_adjust()`,
+  - and weight-column casting when active weight dtype is non-float/float32.
 
 # 0.19.0 (2026-04-06)
 

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -540,11 +540,18 @@ class BalanceFrame:
             this operation.
         """
         bf = self if in_place else deepcopy(self)
-        frozen = copy.deepcopy(bf._sf_sample)
+        frozen = bf._sf_sample
         bf._sf_sample_pre_adjust = frozen
         bf._sf_sample = frozen
         bf._adjustment_model = None
         bf._links.pop("unadjusted", None)
+        if isinstance(bf, SampleFrame):
+            bf._df = frozen._df
+            bf._id_column_name = frozen._id_column_name
+            bf._column_roles = frozen._column_roles
+            bf._weight_column_name = frozen._weight_column_name
+            bf._weight_metadata = frozen._weight_metadata
+            bf._df_dtypes = frozen._df_dtypes
         return bf
 
     @property

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -513,6 +513,7 @@ class BalanceFrame:
                 # Reset adjustment state — old adjustment is no longer valid.
                 self._sf_sample = self._sf_sample_pre_adjust
                 self._adjustment_model = None
+                self._links.pop("unadjusted", None)
                 return self
             else:
                 return type(self)._create(

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -556,8 +556,16 @@ class BalanceFrame:
             Any current adjustment model is cleared because the object is no
             longer considered adjusted after this operation.
         """
-        bf = self if in_place else deepcopy(self)
-        frozen = bf._sf_sample
+        if in_place:
+            bf = self
+            frozen = bf._sf_sample
+        else:
+            frozen = copy.deepcopy(self._sf_sample)
+            bf = type(self)._create(sample=frozen, target=self._sf_target)
+            # Preserve a richer target link (e.g., BalanceFrame/Sample object)
+            # when present on the original.
+            if "target" in self._links:
+                bf._links["target"] = self._links["target"]
         bf._sf_sample_pre_adjust = frozen
         bf._sf_sample = frozen
         bf._adjustment_model = None

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -502,10 +502,15 @@ class BalanceFrame:
             BalanceFrame._validate_covariate_overlap(self._sf_sample, target)
 
             if in_place:
+                if self.is_adjusted:
+                    logger.warning(
+                        "Replacing target on an adjusted object resets responder "
+                        "weights to pre-adjust values and discards current "
+                        "adjustment results."
+                    )
                 self._sf_target = target
                 self._links["target"] = target
                 # Reset adjustment state — old adjustment is no longer valid.
-                # TODO: add logger.warning when discarding adjusted weights (silent data loss risk)
                 self._sf_sample = self._sf_sample_pre_adjust
                 self._adjustment_model = None
                 return self
@@ -517,9 +522,30 @@ class BalanceFrame:
 
         raise TypeError("A target, a Sample object, must be specified")
 
-    # TODO: Add a set_as_pre_adjust() method that resets
-    # _sf_sample_pre_adjust to the current _sf_sample state, allowing
-    # users to "lock in" a compound adjustment as the new baseline.
+    def set_as_pre_adjust(self, *, in_place: bool = False) -> Self:
+        """Set the current responder state as the new pre-adjust baseline.
+
+        This "locks in" the current responder weights (which may already be
+        adjusted and/or trimmed) as the baseline for future diagnostics and
+        subsequent adjustments.
+
+        Args:
+            in_place: If True, mutate this object and return it. If False
+                (default), return a deep-copied object with the baseline reset.
+
+        Returns:
+            BalanceFrame with ``_sf_sample_pre_adjust`` reset to a deep copy of
+            the current responder SampleFrame. Any current adjustment model is
+            cleared because the object is no longer considered adjusted after
+            this operation.
+        """
+        bf = self if in_place else deepcopy(self)
+        frozen = copy.deepcopy(bf._sf_sample)
+        bf._sf_sample_pre_adjust = frozen
+        bf._sf_sample = frozen
+        bf._adjustment_model = None
+        bf._links.pop("unadjusted", None)
+        return bf
 
     @property
     def is_adjusted(self) -> _CallableBool:

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -544,17 +544,33 @@ class BalanceFrame:
 
         Args:
             in_place: If True, mutate this object and return it. If False
-                (default), return a deep-copied object with the baseline reset.
+                (default), return a new object with a deep-copied responder
+                frame and reset baseline.
 
         Returns:
             BalanceFrame with ``_sf_sample_pre_adjust`` reset to the current
-            responder SampleFrame state. In copy mode (``in_place=False``), the
-            responder frame is already deep-copied as part of ``deepcopy(self)``.
-            In in-place mode, the baseline is set to the existing responder
+            responder SampleFrame state. In copy mode (``in_place=False``),
+            only the responder frame is deep-copied and used to construct a new
+            object (the full ``_links`` graph is not deep-copied). In in-place
+            mode, the baseline is set to the existing responder
             frame object so baseline/current share identity, matching
             unadjusted-object semantics elsewhere in the API.
             Any current adjustment model is cleared because the object is no
             longer considered adjusted after this operation.
+
+        Examples:
+            >>> import pandas as pd
+            >>> from balance.sample_frame import SampleFrame
+            >>> from balance.balance_frame import BalanceFrame
+            >>> resp = SampleFrame.from_frame(
+            ...     pd.DataFrame({"id": [1, 2], "x": [10.0, 20.0], "weight": [1.0, 1.0]}))
+            >>> tgt = SampleFrame.from_frame(
+            ...     pd.DataFrame({"id": [3, 4], "x": [15.0, 25.0], "weight": [1.0, 1.0]}))
+            >>> adjusted = BalanceFrame(sample=resp, target=tgt).adjust(method="null")
+            >>> baseline_locked = adjusted.set_as_pre_adjust()  # copy mode
+            >>> baseline_locked.is_adjusted
+            False
+            >>> _ = adjusted.set_as_pre_adjust(in_place=True)  # in-place mode
         """
         if in_place:
             bf = self

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -159,6 +159,21 @@ class BalanceFrame:
     #         _links["unadjusted"] → BalanceFrame
     _links = None
 
+    def _sync_sampleframe_state_from_responder(self, responder: SampleFrame) -> None:
+        """Sync inherited SampleFrame fields from a responder SampleFrame.
+
+        This is only needed when ``self`` is also a ``SampleFrame`` (e.g.
+        ``Sample`` via multiple inheritance), so inherited SampleFrame
+        properties stay consistent with ``_sf_sample``.
+        """
+        if isinstance(self, SampleFrame):
+            self._df = responder._df
+            self._id_column_name = responder._id_column_name
+            self._column_roles = responder._column_roles
+            self._weight_column_name = responder._weight_column_name
+            self._weight_metadata = responder._weight_metadata
+            self._df_dtypes = responder._df_dtypes
+
     @property
     def _df_dtypes(self) -> pd.Series | None:
         """Original dtypes, delegated to ``_sf_sample._df_dtypes``."""
@@ -332,13 +347,7 @@ class BalanceFrame:
         # When the instance is also a SampleFrame (e.g., Sample inherits
         # from both BalanceFrame and SampleFrame), copy SampleFrame state
         # so that inherited SampleFrame properties work on the instance.
-        if isinstance(instance, SampleFrame):
-            instance._df = sample._df
-            instance._id_column_name = sample._id_column_name
-            instance._column_roles = sample._column_roles
-            instance._weight_column_name = sample._weight_column_name
-            instance._weight_metadata = sample._weight_metadata
-            instance._df_dtypes = sample._df_dtypes
+        instance._sync_sampleframe_state_from_responder(sample)
 
         # Validate covariate overlap using public properties
         if target is not None:
@@ -516,6 +525,7 @@ class BalanceFrame:
                 self._sf_sample = self._sf_sample_pre_adjust
                 self._adjustment_model = None
                 self._links.pop("unadjusted", None)
+                self._sync_sampleframe_state_from_responder(self._sf_sample)
                 return self
             else:
                 return type(self)._create(
@@ -552,13 +562,7 @@ class BalanceFrame:
         bf._sf_sample = frozen
         bf._adjustment_model = None
         bf._links.pop("unadjusted", None)
-        if isinstance(bf, SampleFrame):
-            bf._df = frozen._df
-            bf._id_column_name = frozen._id_column_name
-            bf._column_roles = frozen._column_roles
-            bf._weight_column_name = frozen._weight_column_name
-            bf._weight_metadata = frozen._weight_metadata
-            bf._df_dtypes = frozen._df_dtypes
+        bf._sync_sampleframe_state_from_responder(frozen)
         return bf
 
     @property

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -534,10 +534,14 @@ class BalanceFrame:
                 (default), return a deep-copied object with the baseline reset.
 
         Returns:
-            BalanceFrame with ``_sf_sample_pre_adjust`` reset to a deep copy of
-            the current responder SampleFrame. Any current adjustment model is
-            cleared because the object is no longer considered adjusted after
-            this operation.
+            BalanceFrame with ``_sf_sample_pre_adjust`` reset to the current
+            responder SampleFrame state. In copy mode (``in_place=False``), the
+            responder frame is already deep-copied as part of ``deepcopy(self)``.
+            In in-place mode, the baseline is set to the existing responder
+            frame object so baseline/current share identity, matching
+            unadjusted-object semantics elsewhere in the API.
+            Any current adjustment model is cleared because the object is no
+            longer considered adjusted after this operation.
         """
         bf = self if in_place else deepcopy(self)
         frozen = bf._sf_sample

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -506,7 +506,9 @@ class BalanceFrame:
                     logger.warning(
                         "Replacing target on an adjusted object resets responder "
                         "weights to pre-adjust values and discards current "
-                        "adjustment results."
+                        "adjustment results. Pass in_place=False to return a new "
+                        "object and keep the current adjusted state on this "
+                        "instance."
                     )
                 self._sf_target = target
                 self._links["target"] = target

--- a/balance/sample_frame.py
+++ b/balance/sample_frame.py
@@ -31,12 +31,6 @@ if TYPE_CHECKING:
 logger: logging.Logger = logging.getLogger(__package__)
 
 
-def _is_float_dtype_kind(series: pd.Series) -> bool:
-    """Return True when the series dtype has NumPy kind ``"f"`` (float)."""
-    dtype_kind = getattr(series.dtype, "kind", None)
-    return dtype_kind == "f"
-
-
 def _is_float64_dtype(series: pd.Series) -> bool:
     """Return True when the series dtype is exactly NumPy float64."""
     return series.dtype == np.dtype("float64")

--- a/balance/sample_frame.py
+++ b/balance/sample_frame.py
@@ -31,6 +31,12 @@ if TYPE_CHECKING:
 logger: logging.Logger = logging.getLogger(__package__)
 
 
+def _is_float_dtype_kind(series: pd.Series) -> bool:
+    """Return True when the series dtype has NumPy kind ``"f"`` (float)."""
+    dtype_kind = getattr(series.dtype, "kind", None)
+    return dtype_kind == "f"
+
+
 class SampleFrame:
     """A DataFrame container with explicit column-role metadata.
 
@@ -846,8 +852,7 @@ class SampleFrame:
         wc = self._weight_column_name
 
         # Ensure the column is float64 before any assignment.
-        # TODO: replace deprecated is_float_dtype (removed in pandas 3.0) with dtype.kind check
-        if not pd.api.types.is_float_dtype(self._df[wc]):
+        if not _is_float_dtype_kind(self._df[wc]):
             self._df[wc] = self._df[wc].astype("float64")
 
         if weights is None:
@@ -866,8 +871,7 @@ class SampleFrame:
                 f"use_index=True requires a pandas Series (got {type(weights).__name__}). "
                 "Pass a Series with an appropriate index, or use use_index=False."
             )
-        # TODO: replace deprecated is_float_dtype (removed in pandas 3.0) with dtype.kind check
-        if not pd.api.types.is_float_dtype(weights):
+        if not _is_float_dtype_kind(weights):
             weights = weights.astype("float64")
         if not all(idx in weights.index for idx in self._df.index):
             logger.warning(
@@ -884,8 +888,7 @@ class SampleFrame:
                 f"DataFrame length ({len(self._df)})"
             )
         if isinstance(weights, pd.Series):
-            # TODO: replace deprecated is_float_dtype (removed in pandas 3.0) with dtype.kind check
-            if not pd.api.types.is_float_dtype(weights):
+            if not _is_float_dtype_kind(weights):
                 weights = weights.astype("float64")
             self._df[wc] = weights.to_numpy()
         else:

--- a/balance/sample_frame.py
+++ b/balance/sample_frame.py
@@ -37,6 +37,11 @@ def _is_float_dtype_kind(series: pd.Series) -> bool:
     return dtype_kind == "f"
 
 
+def _is_float64_dtype(series: pd.Series) -> bool:
+    """Return True when the series dtype is exactly NumPy float64."""
+    return series.dtype == np.dtype("float64")
+
+
 class SampleFrame:
     """A DataFrame container with explicit column-role metadata.
 
@@ -852,7 +857,7 @@ class SampleFrame:
         wc = self._weight_column_name
 
         # Ensure the column is float64 before any assignment.
-        if not _is_float_dtype_kind(self._df[wc]):
+        if not _is_float64_dtype(self._df[wc]):
             self._df[wc] = self._df[wc].astype("float64")
 
         if weights is None:
@@ -871,7 +876,7 @@ class SampleFrame:
                 f"use_index=True requires a pandas Series (got {type(weights).__name__}). "
                 "Pass a Series with an appropriate index, or use use_index=False."
             )
-        if not _is_float_dtype_kind(weights):
+        if not _is_float64_dtype(weights):
             weights = weights.astype("float64")
         if not all(idx in weights.index for idx in self._df.index):
             logger.warning(
@@ -888,7 +893,7 @@ class SampleFrame:
                 f"DataFrame length ({len(self._df)})"
             )
         if isinstance(weights, pd.Series):
-            if not _is_float_dtype_kind(weights):
+            if not _is_float64_dtype(weights):
                 weights = weights.astype("float64")
             self._df[wc] = weights.to_numpy()
         else:

--- a/balance/stats_and_plots/weighted_comparisons_plots.py
+++ b/balance/stats_and_plots/weighted_comparisons_plots.py
@@ -13,6 +13,8 @@ from __future__ import (
     unicode_literals,
 )
 
+import inspect
+
 import logging
 import random
 from typing import Any, cast, Dict, List, Literal, Optional, Tuple, TypedDict, Union
@@ -397,7 +399,10 @@ def plot_hist_kde(
     }
     if dist_type != "ecdf":
         kwargs_for_dist_function["common_norm"] = False
-    if dist_type == "kde":
+    if (
+        dist_type == "kde"
+        and "warn_singular" in inspect.signature(dist_function).parameters
+    ):
         kwargs_for_dist_function["warn_singular"] = False
     # Set explicit bins for histplot when using weights to avoid seaborn 'bins cannot be auto' warning.
     # Use Freedman-Diaconis rule which adapts to data distribution.

--- a/balance/stats_and_plots/weighted_comparisons_plots.py
+++ b/balance/stats_and_plots/weighted_comparisons_plots.py
@@ -399,11 +399,15 @@ def plot_hist_kde(
     }
     if dist_type != "ecdf":
         kwargs_for_dist_function["common_norm"] = False
-    if (
-        dist_type == "kde"
-        and "warn_singular" in inspect.signature(dist_function).parameters
-    ):
-        kwargs_for_dist_function["warn_singular"] = False
+    if dist_type == "kde":
+        try:
+            supports_warn_singular = (
+                "warn_singular" in inspect.signature(dist_function).parameters
+            )
+        except (TypeError, ValueError):
+            supports_warn_singular = False
+        if supports_warn_singular:
+            kwargs_for_dist_function["warn_singular"] = False
     # Set explicit bins for histplot when using weights to avoid seaborn 'bins cannot be auto' warning.
     # Use Freedman-Diaconis rule which adapts to data distribution.
     if dist_type == "hist" and weighted:

--- a/balance/stats_and_plots/weighted_comparisons_plots.py
+++ b/balance/stats_and_plots/weighted_comparisons_plots.py
@@ -397,6 +397,8 @@ def plot_hist_kde(
     }
     if dist_type != "ecdf":
         kwargs_for_dist_function["common_norm"] = False
+    if dist_type == "kde":
+        kwargs_for_dist_function["warn_singular"] = False
     # Set explicit bins for histplot when using weights to avoid seaborn 'bins cannot be auto' warning.
     # Use Freedman-Diaconis rule which adapts to data distribution.
     if dist_type == "hist" and weighted:

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -599,8 +599,9 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
             }
         )
         tgt2_sf = SampleFrame.from_frame(tgt2_df)
-        # set_target returns a NEW BalanceFrame; the original stays adjusted.
+        # For SampleFrame targets, set_target defaults to in-place behavior.
         retargeted = adjusted.set_target(tgt2_sf)
+        self.assertIs(retargeted, adjusted)
         self.assertFalse(retargeted.is_adjusted)
         self.assertIsNone(retargeted.model)
         self.assertNotIn("unadjusted", retargeted._links)

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -11,6 +11,7 @@ import copy
 import io
 import logging
 from typing import Any, Literal
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -632,8 +633,9 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
                 }
             )
         )
-        with self.assertNoLogs("balance", level="WARNING"):
+        with patch("balance.balance_frame.logger.warning") as mock_warning:
             bf.set_target(tgt2_sf)
+        self.assertFalse(mock_warning.called)
 
     def test_set_target_non_sampleframe_raises(self) -> None:
         bf = BalanceFrame(sample=self.resp_sf)

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -602,6 +602,39 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         self.assertFalse(retargeted.is_adjusted)
         self.assertIsNone(retargeted.model)
 
+    def test_set_target_on_adjusted_logs_reset_warning(self) -> None:
+        adjusted = BalanceFrame(sample=self.resp_sf, target=self.tgt_sf).adjust(
+            method="null"
+        )
+        tgt2_sf = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["7", "8"],
+                    "x1": [50.0, 60.0],
+                    "x2": [5.0, 6.0],
+                    "weight": [1.0, 1.0],
+                }
+            )
+        )
+        with self.assertLogs("balance", level="WARNING") as cm:
+            adjusted.set_target(tgt2_sf)
+        self.assertIn("discards current adjustment results", cm.output[0])
+
+    def test_set_target_on_unadjusted_does_not_log_reset_warning(self) -> None:
+        bf = BalanceFrame(sample=self.resp_sf, target=self.tgt_sf)
+        tgt2_sf = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["7", "8"],
+                    "x1": [50.0, 60.0],
+                    "x2": [5.0, 6.0],
+                    "weight": [1.0, 1.0],
+                }
+            )
+        )
+        with self.assertNoLogs("balance", level="WARNING"):
+            bf.set_target(tgt2_sf)
+
     def test_set_target_non_sampleframe_raises(self) -> None:
         bf = BalanceFrame(sample=self.resp_sf)
         with self.assertRaises(TypeError):
@@ -1996,6 +2029,53 @@ class TestBalanceFrameSetWeights(BalanceTestCase):
         weights = pd.Series([5.0, 6.0], index=bf.df.index)
         bf.set_weights(weights, use_index=True)
         self.assertEqual(_assert_type(bf.weight_series).tolist(), [5.0, 6.0])
+
+
+class TestBalanceFrameSetAsPreAdjust(BalanceTestCase):
+    def _make_adjusted(self) -> BalanceFrame:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
+        )
+        tgt_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["3", "4"], "x": [1.5, 2.5], "weight": [1.0, 1.0]})
+        )
+        return BalanceFrame(sample=resp_sf, target=tgt_sf).adjust(method="null")
+
+    def test_set_as_pre_adjust_returns_copy_by_default(self) -> None:
+        adjusted = self._make_adjusted()
+        reset = adjusted.set_as_pre_adjust()
+        self.assertIsNot(reset, adjusted)
+        self.assertFalse(reset.is_adjusted)
+        self.assertNotIn("unadjusted", reset._links)
+        self.assertIsNone(reset.model)
+        # Original object remains adjusted and keeps its model.
+        self.assertTrue(adjusted.is_adjusted)
+        self.assertIsNotNone(adjusted.model)
+
+    def test_set_as_pre_adjust_in_place(self) -> None:
+        adjusted = self._make_adjusted()
+        result = adjusted.set_as_pre_adjust(in_place=True)
+        self.assertIs(result, adjusted)
+        self.assertFalse(adjusted.is_adjusted)
+        self.assertNotIn("unadjusted", adjusted._links)
+        self.assertIsNone(adjusted.model)
+
+    def test_set_as_pre_adjust_preserves_target_link(self) -> None:
+        adjusted = self._make_adjusted()
+        reset = adjusted.set_as_pre_adjust()
+        self.assertTrue(reset.has_target())
+
+    def test_set_as_pre_adjust_unadjusted_noop_semantics(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
+        )
+        tgt_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["3", "4"], "x": [1.5, 2.5], "weight": [1.0, 1.0]})
+        )
+        bf = BalanceFrame(sample=resp_sf, target=tgt_sf)
+        reset = bf.set_as_pre_adjust()
+        self.assertFalse(reset.is_adjusted)
+        self.assertIsNone(reset.model)
 
 
 class TestBalanceFrameTrim(BalanceTestCase):

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -588,6 +588,7 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         bf = BalanceFrame(sample=self.resp_sf, target=self.tgt_sf)
         adjusted = bf.adjust(method="null")
         self.assertTrue(adjusted.is_adjusted)
+        self.assertIn("unadjusted", adjusted._links)
         # Replace target on the adjusted frame — should reset adjustment state
         tgt2_df = pd.DataFrame(
             {
@@ -602,6 +603,7 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         retargeted = adjusted.set_target(tgt2_sf)
         self.assertFalse(retargeted.is_adjusted)
         self.assertIsNone(retargeted.model)
+        self.assertNotIn("unadjusted", retargeted._links)
 
     def test_set_target_on_adjusted_logs_reset_warning(self) -> None:
         adjusted = BalanceFrame(sample=self.resp_sf, target=self.tgt_sf).adjust(

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -622,7 +622,9 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
         )
         with self.assertLogs("balance", level="WARNING") as cm:
             adjusted.set_target(tgt2_sf)
-        self.assertIn("discards current adjustment results", cm.output[0])
+        self.assertTrue(
+            any("discards current adjustment results" in line for line in cm.output)
+        )
 
     def test_set_target_on_unadjusted_does_not_log_reset_warning(self) -> None:
         bf = BalanceFrame(sample=self.resp_sf, target=self.tgt_sf)

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -2039,6 +2039,10 @@ class TestBalanceFrameSetWeights(BalanceTestCase):
 
 
 class TestBalanceFrameSetAsPreAdjust(BalanceTestCase):
+    class _NoDeepcopy:
+        def __deepcopy__(self, memo: dict[int, object]) -> object:
+            raise RuntimeError("should not be deep-copied")
+
     def _make_adjusted(self) -> BalanceFrame:
         resp_sf = SampleFrame.from_frame(
             pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
@@ -2083,6 +2087,12 @@ class TestBalanceFrameSetAsPreAdjust(BalanceTestCase):
         reset = bf.set_as_pre_adjust()
         self.assertFalse(reset.is_adjusted)
         self.assertIsNone(reset.model)
+
+    def test_set_as_pre_adjust_copy_does_not_deepcopy_unadjusted_link(self) -> None:
+        adjusted = self._make_adjusted()
+        adjusted._links["unadjusted"] = self._NoDeepcopy()
+        reset = adjusted.set_as_pre_adjust()
+        self.assertFalse(reset.is_adjusted)
 
 
 class TestBalanceFrameTrim(BalanceTestCase):

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -2787,6 +2787,58 @@ class TestSampleSetAsPreAdjust(balance.testutil.BalanceTestCase):
         pd.testing.assert_frame_equal(reset.df_covars, reset._sf_sample.df_covars)
 
 
+class TestSampleSetTargetRegression(balance.testutil.BalanceTestCase):
+    def test_set_target_in_place_after_adjust_keeps_sampleframe_state_synced(
+        self,
+    ) -> None:
+        sample = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [1, 2, 3],
+                    "x": [10.0, 20.0, 30.0],
+                    "weight": [1.0, 1.0, 1.0],
+                }
+            ),
+            id_column="id",
+            weight_column="weight",
+        )
+        target1 = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [4, 5, 6],
+                    "x": [12.0, 22.0, 32.0],
+                    "weight": [1.0, 1.0, 1.0],
+                }
+            ),
+            id_column="id",
+            weight_column="weight",
+        )
+        target2 = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [7, 8, 9],
+                    "x": [11.0, 21.0, 31.0],
+                    "weight": [1.0, 1.0, 1.0],
+                }
+            ),
+            id_column="id",
+            weight_column="weight",
+        )
+
+        adjusted = sample.set_target(target1).adjust(method="null")
+        self.assertTrue(adjusted.is_adjusted)
+
+        retargeted = adjusted.set_target(target2.to_sample_frame())
+        self.assertIs(retargeted, adjusted)
+        self.assertFalse(retargeted.is_adjusted)
+        # Regression: inherited SampleFrame views must track _sf_sample after reset.
+        pd.testing.assert_frame_equal(retargeted._df, retargeted._sf_sample._df)
+        pd.testing.assert_series_equal(
+            retargeted.df_weights.iloc[:, 0],
+            retargeted._sf_sample.df_weights.iloc[:, 0],
+        )
+
+
 class TestCallableBool(balance.testutil.BalanceTestCase):
     """Tests for the _CallableBool helper class."""
 

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -2754,6 +2754,39 @@ class TestSampleConversion(balance.testutil.BalanceTestCase):
             s1.to_balance_frame()
 
 
+class TestSampleSetAsPreAdjust(balance.testutil.BalanceTestCase):
+    def test_set_as_pre_adjust_keeps_sampleframe_views_in_sync(self) -> None:
+        sample = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [1, 2, 3],
+                    "x": [10.0, 20.0, 30.0],
+                    "weight": [1.0, 1.0, 1.0],
+                }
+            ),
+            id_column="id",
+            weight_column="weight",
+        )
+        target = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [4, 5, 6],
+                    "x": [12.0, 22.0, 32.0],
+                    "weight": [1.0, 1.0, 1.0],
+                }
+            ),
+            id_column="id",
+            weight_column="weight",
+        )
+        adjusted = sample.set_target(target).adjust(method="null")
+        reset = adjusted.set_as_pre_adjust()
+
+        self.assertFalse(reset.is_adjusted)
+        self.assertIsNone(reset.model)
+        pd.testing.assert_frame_equal(reset._df, reset._sf_sample._df)
+        pd.testing.assert_frame_equal(reset.df_covars, reset._sf_sample.df_covars)
+
+
 class TestCallableBool(balance.testutil.BalanceTestCase):
     """Tests for the _CallableBool helper class."""
 

--- a/tests/test_sample_frame.py
+++ b/tests/test_sample_frame.py
@@ -947,6 +947,14 @@ class TestSampleFrameBalanceDFSourceProtocol(BalanceTestCase):
         sf.set_weights(pd.Series([3, 4, 5]))
         self.assertEqual(sf._df[sf._weight_column_name].dtype, np.float64)
 
+    def test_set_weights_upcasts_float32_column_to_float64(self) -> None:
+        sf = self._make_sf()
+        sf._df[sf._weight_column_name] = sf._df[sf._weight_column_name].astype(
+            "float32"
+        )
+        sf.set_weights(pd.Series([3.0, 4.0, 5.0], dtype="float32"))
+        self.assertEqual(sf._df[sf._weight_column_name].dtype, np.float64)
+
     def test_set_weights_none_resets_to_one(self) -> None:
         sf = self._make_sf()
         sf.set_weights(None)

--- a/tests/test_sample_frame.py
+++ b/tests/test_sample_frame.py
@@ -941,6 +941,12 @@ class TestSampleFrameBalanceDFSourceProtocol(BalanceTestCase):
         sf.set_weights(2.5)
         self.assertEqual(sf.weight_series.tolist(), [2.5, 2.5, 2.5])
 
+    def test_set_weights_casts_non_float_weight_column_to_float64(self) -> None:
+        sf = self._make_sf()
+        sf._df[sf._weight_column_name] = sf._df[sf._weight_column_name].astype("int64")
+        sf.set_weights(pd.Series([3, 4, 5]))
+        self.assertEqual(sf._df[sf._weight_column_name].dtype, np.float64)
+
     def test_set_weights_none_resets_to_one(self) -> None:
         sf = self._make_sf()
         sf.set_weights(None)

--- a/tests/test_weighted_comparisons_plots.py
+++ b/tests/test_weighted_comparisons_plots.py
@@ -161,7 +161,7 @@ class Test_weighted_comparisons_plots(balance.testutil.BalanceTestCase):
 
         # Set up matplotlib figure
         plt.figure(1)
-        fig, ax = plt.subplots(1, 1, figsize=(7.2, 7.2))
+        _, ax = plt.subplots(1, 1, figsize=(7.2, 7.2))
 
         # Create test data with proper type
         test_data: List[DataFrameWithWeight] = [
@@ -480,7 +480,7 @@ class Test_weighted_comparisons_plots(balance.testutil.BalanceTestCase):
         )
 
         # Test 1: ylim parameter
-        fig, ax = plt.subplots(1, 1, figsize=(7.2, 7.2))
+        _, ax = plt.subplots(1, 1, figsize=(7.2, 7.2))
         test_data: List[DataFrameWithWeight] = [
             {"df": test_df, "weight": pd.Series((1, 1, 1, 1))},
             {"df": test_df, "weight": pd.Series((2, 1, 1, 1))},
@@ -498,7 +498,7 @@ class Test_weighted_comparisons_plots(balance.testutil.BalanceTestCase):
         self.assertEqual(ylim[1], 1)
 
         # Test 2: custom title
-        fig, ax = plt.subplots(1, 1, figsize=(7.2, 7.2))
+        _, ax = plt.subplots(1, 1, figsize=(7.2, 7.2))
         custom_title = "Custom Bar Plot Title"
         plot_bar(
             [{"df": test_df, "weight": pd.Series((1, 1, 1, 1))}],

--- a/tests/test_weighted_comparisons_plots.py
+++ b/tests/test_weighted_comparisons_plots.py
@@ -950,7 +950,7 @@ class Test_weighted_comparisons_plots(balance.testutil.BalanceTestCase):
             {"df": test_df, "weight": pd.Series(np.ones(len(test_df)))},
             {"df": test_df, "weight": pd.Series(np.ones(len(test_df)))},
         ]
-        fig, ax = plt.subplots(1, 1, figsize=(7.2, 7.2))
+        _, ax = plt.subplots(1, 1, figsize=(7.2, 7.2))
         with patch(
             "balance.stats_and_plots.weighted_comparisons_plots.inspect.signature",
             side_effect=ValueError("unsupported signature"),

--- a/tests/test_weighted_comparisons_plots.py
+++ b/tests/test_weighted_comparisons_plots.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from typing import List
+from unittest.mock import patch
 
 import balance.testutil
 import matplotlib
@@ -940,6 +941,28 @@ class Test_weighted_comparisons_plots(balance.testutil.BalanceTestCase):
                 ecdf_y_values_self_unweighted, ecdf_y_values_target_unweighted
             ):
                 self.assertAlmostEqual(y_self, y_target, places=5)
+
+    def test_plot_hist_kde_handles_signature_inspection_failure(self) -> None:
+        from balance.stats_and_plots.weighted_comparisons_plots import plot_hist_kde
+
+        test_df = pd.DataFrame({"v1": [1, 2, 2, 3, 4, 5]})
+        test_data: List[DataFrameWithWeight] = [
+            {"df": test_df, "weight": pd.Series(np.ones(len(test_df)))},
+            {"df": test_df, "weight": pd.Series(np.ones(len(test_df)))},
+        ]
+        fig, ax = plt.subplots(1, 1, figsize=(7.2, 7.2))
+        with patch(
+            "balance.stats_and_plots.weighted_comparisons_plots.inspect.signature",
+            side_effect=ValueError("unsupported signature"),
+        ):
+            plot_hist_kde(
+                test_data,
+                names=["self", "target"],
+                column="v1",
+                axis=ax,
+                weighted=True,
+                dist_type="kde",
+            )
 
     def test_plot_hist_kde_unweighted(self) -> None:
         """


### PR DESCRIPTION
- Replaced deprecated float-dtype checks in `SampleFrame.set_weights()` paths with explicit exact-`float64` checks.
- Implemented the `BalanceFrame.set_target(...)` TODO warning: retargeting an already-adjusted object in-place now logs a warning before resetting to pre-adjust weights.
- Implemented a new `BalanceFrame.set_as_pre_adjust(in_place=False)` method to “lock in” the current responder state as the new baseline and clear the unadjusted link.
- Eliminated the remaining plot warning path in tests by setting `warn_singular=False` for KDE plotting calls.
- Added appropiate tests.