### PR TITLE
Fix Pyre type errors in build_design_matrix helpers (#411)

### DIFF
--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -2025,8 +2025,7 @@ class BalanceFrame:
             and model_sample_idx.equals(current_sample_idx)
         ):
             return model_link
-        # pyre-ignore[16]: predict_proba(on="sample") always returns a Series
-        return _assert_type(self.predict_proba(on="sample", output="link")).to_numpy()
+        return self.predict_proba(on="sample", output="link").to_numpy()
 
     def _resolve_design_weights(
         self,

--- a/balance/balancedf_class.py
+++ b/balance/balancedf_class.py
@@ -3297,13 +3297,11 @@ class BalanceDFWeights(BalanceDF):
         # TODO: decide if we want more quantiles of the weights.
 
         # adding prop_above_and_below
-        tmp_props = weights_stats.prop_above_and_below(the_weights)
-        weights_diag_var.extend(
-            tmp_props.index.to_list()  # pyre-ignore[16]: existing defaults make sure this output is pd.Series with relevant methods.
+        tmp_props = _assert_type(
+            weights_stats.prop_above_and_below(the_weights), pd.Series
         )
-        weights_diag_value.extend(
-            tmp_props.to_list()  # pyre-ignore[16]: existing defaults make sure this output is pd.Series with relevant methods.
-        )
+        weights_diag_var.extend(tmp_props.index.to_list())
+        weights_diag_value.extend(tmp_props.to_list())
         # TODO: decide if we want more numbers (e.g.: 2/3 and 3/2)
 
         # adding nonparametric_skew and weighted_median_breakdown_point

--- a/balance/sample_frame.py
+++ b/balance/sample_frame.py
@@ -736,6 +736,15 @@ class SampleFrame:
 
         Returns:
             str: The ID column name.
+
+        Examples:
+            >>> import pandas as pd
+            >>> from balance.sample_frame import SampleFrame
+            >>> df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20],
+            ...                    "weight": [1.0, 1.0]})
+            >>> sf = SampleFrame.from_frame(df)
+            >>> sf.id_column
+            'id'
         """
         # TODO: remove this warning after 2026-06-01 — by then users will
         # have migrated to id_series for data access.
@@ -1047,8 +1056,7 @@ class SampleFrame:
         """
         from balance.balancedf_class import BalanceDFCovars
 
-        # pyre-ignore[6]: SampleFrame satisfies BalanceDFSource at runtime
-        return BalanceDFCovars(self, formula=formula)
+        return BalanceDFCovars(cast("BalanceDFSource", self), formula=formula)
 
     def weights(self) -> Any:
         """Return a :class:`~balance.balancedf_class.BalanceDFWeights` for this SampleFrame.
@@ -1070,8 +1078,7 @@ class SampleFrame:
         """
         from balance.balancedf_class import BalanceDFWeights
 
-        # pyre-ignore[6]: SampleFrame satisfies BalanceDFSource at runtime
-        return BalanceDFWeights(self)
+        return BalanceDFWeights(cast("BalanceDFSource", self))
 
     def outcomes(self) -> Any | None:
         """Return a :class:`~balance.balancedf_class.BalanceDFOutcomes`, or None.
@@ -1097,8 +1104,7 @@ class SampleFrame:
         # Deferred import to avoid circular dependency with balancedf_class
         from balance.balancedf_class import BalanceDFOutcomes
 
-        # pyre-ignore[6]: SampleFrame satisfies BalanceDFSource at runtime
-        return BalanceDFOutcomes(self)
+        return BalanceDFOutcomes(cast("BalanceDFSource", self))
 
     @property
     def df(self) -> pd.DataFrame:

--- a/balance/stats_and_plots/weighted_comparisons_stats.py
+++ b/balance/stats_and_plots/weighted_comparisons_stats.py
@@ -609,8 +609,12 @@ def asmd(
         target_std = descriptive_stats(target_df, target_weights, "std")
         sample_std = descriptive_stats(sample_df, sample_weights, "std")
         std = np.sqrt(((sample_std**2) + (target_std**2)) / 2)
+    else:
+        raise ValueError(
+            f"Unknown std_type: {std_type!r}. Use 'sample', 'target', or 'pooled'."
+        )
 
-    out = abs(sample_mean - target_mean) / std  # pyre-ignore[61]: std is always defined
+    out = abs(sample_mean - target_mean) / std
 
     #  Remove na indicator columns; it's OK to assume that these columns are
     #  indicators because add_na_indicator enforces it

--- a/balance/stats_and_plots/weighted_stats.py
+++ b/balance/stats_and_plots/weighted_stats.py
@@ -299,8 +299,7 @@ def ci_of_weighted_mean(
         # Apply a lambda function to round a pd.Series of tuples to x decimal places
         ci = ci.apply(lambda t: tuple(round(x, round_ndigits) for x in t))
 
-    # pyre-ignore
-    return ci
+    return _assert_type(ci, pd.Series)
 
 
 def weighted_var(

--- a/balance/utils/data_transformation.py
+++ b/balance/utils/data_transformation.py
@@ -189,7 +189,7 @@ def qcut(
     Returns:
         Series of type object with intervals.
     """
-    if s.shape[0] < q:  # pyre-ignore[58]: Comparison is valid in practice
+    if s.shape[0] < float(q):
         logger.warning("Not quantizing, too few values")
         return s
     else:

--- a/balance/utils/model_matrix.py
+++ b/balance/utils/model_matrix.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, cast, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -17,7 +17,11 @@ from balance.utils.data_transformation import (
     add_na_indicator,
     add_na_indicator_to_combined,
 )
-from balance.utils.input_validation import _isinstance_sample, choose_variables
+from balance.utils.input_validation import (
+    _assert_type,
+    _isinstance_sample,
+    choose_variables,
+)
 from balance.utils.pandas_utils import _make_df_column_names_unique
 from pandas.api.types import (
     is_bool_dtype,
@@ -550,7 +554,7 @@ def _build_projected_model_matrix(
     # that were present at fit time.
     combined = pd.concat((sample_covars, target_covars), axis=0)
     combined = add_na_indicator_to_combined(combined)
-    formula_items = (
+    formula_items: List[str] = (
         [formula]
         if isinstance(formula, str)
         else formula if isinstance(formula, list) else []
@@ -558,12 +562,12 @@ def _build_projected_model_matrix(
     # TODO: Replace this hard-coded regex with a shared
     # constant from the NA indicator naming convention in
     # data_transformation.py / add_na_indicator().
-    expected_na_indicators = {
+    expected_na_indicators: set[str] = {
         token
-        for formula_item in formula_items  # pyre-ignore[6]
+        for formula_item in formula_items
         for token in re.findall(r"\b_is_na_[A-Za-z0-9_]+\b", formula_item)
     }
-    for indicator in expected_na_indicators:  # pyre-ignore[6]
+    for indicator in expected_na_indicators:
         if indicator not in combined.columns:
             combined[indicator] = False
 
@@ -575,10 +579,12 @@ def _build_projected_model_matrix(
         one_hot_encoding=one_hot_encoding,
         add_na=False,
     )
-    sparse_matrix: csc_matrix = model_matrix_out["model_matrix"]  # pyre-ignore[9]
-    sparse_columns: list[str] = model_matrix_out[
-        "model_matrix_columns_names"
-    ]  # pyre-ignore[9]
+    sparse_matrix: csc_matrix = _assert_type(
+        model_matrix_out["model_matrix"], csc_matrix
+    )
+    sparse_columns: list[str] = _assert_type(
+        model_matrix_out["model_matrix_columns_names"], list
+    )
 
     # Project to the stored column set.
     sparse_col_to_idx = {col: i for i, col in enumerate(sparse_columns)}
@@ -604,9 +610,9 @@ def _build_projected_model_matrix(
     # (fit_penalties_skl is applied separately), but we return a correctly-
     # sized vector for consistency.
     penalty_factor_expanded: Optional[List[float]] = [1.0] * len(project_to_columns)
-    resolved_formula: str | list[str] | None = model_matrix_out.get(
-        "formula"
-    )  # pyre-ignore[9]
+    resolved_formula: str | list[str] | None = cast(
+        Optional[Union[str, List[str]]], model_matrix_out.get("formula")
+    )
     return (
         combined_matrix,
         project_to_columns,
@@ -636,20 +642,19 @@ def _build_training_model_matrix(
         penalty_factor=penalty_factor,
         one_hot_encoding=one_hot_encoding,
     )
-    combined_matrix: Union[pd.DataFrame, np.ndarray, csc_matrix] = model_matrix_output[
-        "model_matrix"
-    ]  # pyre-ignore[9]
-    columns: list[str] = model_matrix_output[
-        "model_matrix_columns_names"
-    ]  # pyre-ignore[9]
-    penalty_factor_expanded = list(
-        model_matrix_output.get(
-            "penalty_factor", [1.0] * len(columns)
-        )  # pyre-ignore[6]
+    combined_matrix: Union[pd.DataFrame, np.ndarray, csc_matrix] = cast(
+        Union[pd.DataFrame, np.ndarray, csc_matrix],
+        model_matrix_output["model_matrix"],
     )
-    resolved_formula: str | list[str] | None = model_matrix_output.get(
-        "formula"
-    )  # pyre-ignore[9]
+    columns: list[str] = _assert_type(
+        model_matrix_output["model_matrix_columns_names"], list
+    )
+    penalty_factor_expanded = list(
+        model_matrix_output.get("penalty_factor", [1.0] * len(columns))
+    )
+    resolved_formula: str | list[str] | None = cast(
+        Optional[Union[str, List[str]]], model_matrix_output.get("formula")
+    )
     return combined_matrix, columns, penalty_factor_expanded, resolved_formula
 
 
@@ -835,9 +840,8 @@ def build_design_matrix(
                 f"the number of matrix columns ({n_cols})."
             )
         if isinstance(combined_matrix, spmatrix):
-            combined_matrix = combined_matrix @ diags(
-                penalties_arr, format="csc"
-            )  # pyre-ignore[58]
+            penalty_diag = diags(penalties_arr, format="csc")
+            combined_matrix = combined_matrix @ penalty_diag  # pyre-ignore[58]
         else:
             combined_matrix = np.asarray(combined_matrix) * penalties_arr
 


### PR DESCRIPTION
Summary:

Replace `# pyre-ignore` comments with proper `cast()` calls in `_build_projected_model_matrix()` and `_build_training_model_matrix()`. The `model_matrix()` return dict has type `Dict[str, Any]`, so accessing keys like `"model_matrix_columns_names"` returns `Any` which Pyre can't narrow to `List[str]`. Using `cast()` makes the narrowing explicit.

Also fix `spmatrix @ diags()` Pyre error by splitting into two lines so the `pyre-ignore[58]` comment applies correctly.

Reviewed By: sahil350

Differential Revision: D100847786


