### PR TITLE
Add tests to reach 100% code coverage (#412)

### DIFF
--- a/balance/utils/model_matrix.py
+++ b/balance/utils/model_matrix.py
@@ -823,7 +823,7 @@ def build_design_matrix(
     if fit_scaler is not None:
         combined_matrix = fit_scaler.transform(combined_matrix)
     elif scaler_weights is not None:
-        scaler = StandardScaler(with_mean=False, copy=False)
+        scaler = StandardScaler(with_mean=False)
         combined_matrix = scaler.fit_transform(
             combined_matrix, sample_weight=scaler_weights
         )

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -3363,3 +3363,848 @@ class TestBalanceFrameSklearnLikeApi(BalanceTestCase):
         )
         with self.assertRaisesRegex(ValueError, "not yet supported"):
             adjusted.predict_weights(data=holdout_bf)
+
+
+# =====================================================================
+# Coverage tests for uncovered lines in balance_frame.py
+# =====================================================================
+
+
+class TestBalanceFrameIdColumnWarning(BalanceTestCase):
+    """Cover lines 201-208: id_column property FutureWarning."""
+
+    def test_id_column_raises_future_warning(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
+        )
+        bf = BalanceFrame(sample=resp_sf)
+        with self.assertWarns(FutureWarning):
+            result = bf.id_column
+        self.assertEqual(result, "id")
+
+
+class TestBalanceFrameWeightSeriesNone(BalanceTestCase):
+    """Cover lines 215-216: weight_series returns None on ValueError."""
+
+    def test_weight_series_returns_none_on_value_error(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
+        )
+        bf = BalanceFrame(sample=resp_sf)
+        with patch.object(
+            type(bf._sf_sample),
+            "weight_series",
+            new_callable=lambda: property(
+                lambda self: (_ for _ in ()).throw(ValueError("no weight"))
+            ),
+        ):
+            result = bf.weight_series
+        self.assertIsNone(result)
+
+
+class TestBalanceFrameOutcomeColumnsSetter(BalanceTestCase):
+    """Cover line 247: _outcome_columns setter when set to None."""
+
+    def test_set_outcome_columns_to_none_clears_roles(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["1", "2"],
+                    "x": [1.0, 2.0],
+                    "y": [0.5, 0.6],
+                    "weight": [1.0, 1.0],
+                }
+            ),
+            outcome_columns=["y"],
+        )
+        bf = BalanceFrame(sample=resp_sf)
+        self.assertIsNotNone(bf._outcome_columns)
+        bf._outcome_columns = None
+        self.assertIsNone(bf._outcome_columns)
+        self.assertEqual(bf._sf_sample._column_roles["outcomes"], [])
+
+    def test_set_outcome_columns_to_dataframe(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["1", "2"],
+                    "x": [1.0, 2.0],
+                    "y": [0.5, 0.6],
+                    "weight": [1.0, 1.0],
+                }
+            ),
+        )
+        bf = BalanceFrame(sample=resp_sf)
+        bf._outcome_columns = pd.DataFrame({"y": [0.5, 0.6]})
+        self.assertEqual(bf._sf_sample._column_roles["outcomes"], ["y"])
+
+
+class TestBalanceFrameDfAccessors(BalanceTestCase):
+    """Cover lines 418, 423-425, 430: df_responders, df_target, df_responders_unadjusted."""
+
+    def test_df_responders(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
+        )
+        tgt_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["3", "4"], "x": [1.5, 2.5], "weight": [1.0, 1.0]})
+        )
+        bf = BalanceFrame(sample=resp_sf, target=tgt_sf)
+        pd.testing.assert_frame_equal(bf.df_responders, resp_sf.df)
+
+    def test_df_target_with_target(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
+        )
+        tgt_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["3", "4"], "x": [1.5, 2.5], "weight": [1.0, 1.0]})
+        )
+        bf = BalanceFrame(sample=resp_sf, target=tgt_sf)
+        pd.testing.assert_frame_equal(_assert_type(bf.df_target), tgt_sf.df)
+
+    def test_df_target_without_target(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
+        )
+        bf = BalanceFrame(sample=resp_sf)
+        self.assertIsNone(bf.df_target)
+
+    def test_df_responders_unadjusted(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
+        )
+        tgt_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["3", "4"], "x": [1.5, 2.5], "weight": [1.0, 1.0]})
+        )
+        bf = BalanceFrame(sample=resp_sf, target=tgt_sf)
+        pd.testing.assert_frame_equal(bf.df_responders_unadjusted, resp_sf.df)
+
+
+class TestBalanceFrameGetCovarsNoTarget(BalanceTestCase):
+    """Cover line 661: _get_covars raises when no target."""
+
+    def test_get_covars_raises_without_target(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
+        )
+        bf = BalanceFrame(sample=resp_sf)
+        with self.assertRaises(ValueError):
+            bf._get_covars()
+
+
+class TestBalanceFrameSetFittedModelValidation(BalanceTestCase):
+    """Cover lines 1148, 1151, 1158, 1169, 1211: set_fitted_model validation."""
+
+    def _make_fitted(self) -> tuple[BalanceFrame, SampleFrame, SampleFrame]:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"s{i}" for i in range(8)],
+                    "x": [0.1, 0.3, 0.7, 1.1, 1.4, 1.7, 2.0, 2.2],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        tgt_sf = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"t{i}" for i in range(8)],
+                    "x": [0.2, 0.5, 0.8, 1.0, 1.6, 1.9, 2.1, 2.4],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        bf = BalanceFrame(sample=resp_sf, target=tgt_sf)
+        fitted = bf.fit(method="ipw")
+        return fitted, resp_sf, tgt_sf
+
+    def test_model_not_dict_raises(self) -> None:
+        """Line 1148: fitted model is not a dict."""
+        fitted, resp_sf, tgt_sf = self._make_fitted()
+        # pyre-ignore[8]
+        fitted._adjustment_model = "not_a_dict"
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(resp_sf._df.copy()),
+            target=SampleFrame.from_frame(tgt_sf._df.copy()),
+        )
+        with self.assertRaisesRegex(ValueError, "valid adjustment model dict"):
+            holdout.set_fitted_model(fitted)
+
+    def test_method_not_ipw_raises(self) -> None:
+        """Line 1151: method is not ipw."""
+        fitted, resp_sf, tgt_sf = self._make_fitted()
+        _assert_type(fitted._adjustment_model)["method"] = "cbps"
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(resp_sf._df.copy()),
+            target=SampleFrame.from_frame(tgt_sf._df.copy()),
+        )
+        with self.assertRaisesRegex(ValueError, "only IPW models"):
+            holdout.set_fitted_model(fitted)
+
+    def test_missing_fit_raises(self) -> None:
+        """Line 1158: model missing fit key."""
+        fitted, resp_sf, tgt_sf = self._make_fitted()
+        _assert_type(fitted._adjustment_model)["fit"] = None
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(resp_sf._df.copy()),
+            target=SampleFrame.from_frame(tgt_sf._df.copy()),
+        )
+        with self.assertRaisesRegex(ValueError, "missing estimator"):
+            holdout.set_fitted_model(fitted)
+
+    def test_mismatched_target_covariates_raises(self) -> None:
+        """Line 1169: target covariates mismatch."""
+        fitted, resp_sf, _tgt_sf = self._make_fitted()
+        # Create holdout with matching sample covars but different target covars.
+        # Use _create to set explicit covar_columns on the target.
+        holdout_tgt = SampleFrame._create(
+            df=pd.DataFrame(
+                {
+                    "id": [f"ht{i}" for i in range(8)],
+                    "x": [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5],
+                    "z": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],
+                    "weight": [1.0] * 8,
+                }
+            ),
+            id_column="id",
+            covar_columns=["x", "z"],
+            weight_columns=["weight"],
+        )
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(resp_sf._df.copy()),
+            target=holdout_tgt,
+        )
+        with self.assertRaisesRegex(ValueError, "matching target covariate"):
+            holdout.set_fitted_model(fitted)
+
+    def test_set_fitted_model_inplace_false(self) -> None:
+        """Line 1211: inplace=False branch."""
+        fitted, resp_sf, tgt_sf = self._make_fitted()
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(resp_sf._df.copy()),
+            target=SampleFrame.from_frame(tgt_sf._df.copy()),
+        )
+        result = holdout.set_fitted_model(fitted, inplace=False)
+        self.assertIsNot(result, holdout)
+        self.assertTrue(result.is_adjusted)
+        self.assertFalse(holdout.is_adjusted)
+
+    def test_set_fitted_model_inplace_true(self) -> None:
+        """Line 1211: inplace=True (default) branch."""
+        fitted, resp_sf, tgt_sf = self._make_fitted()
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(resp_sf._df.copy()),
+            target=SampleFrame.from_frame(tgt_sf._df.copy()),
+        )
+        result = holdout.set_fitted_model(fitted, inplace=True)
+        self.assertIs(result, holdout)
+        self.assertTrue(holdout.is_adjusted)
+
+
+class TestBalanceFrameRequireIpwModelAndHelpers(BalanceTestCase):
+    """Cover lines 1270, 1282, 1291, 1310, 1317, 1328, 1333."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.resp_sf = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"s{i}" for i in range(8)],
+                    "x": [0.1, 0.3, 0.7, 1.1, 1.4, 1.7, 2.0, 2.2],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        self.tgt_sf = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"t{i}" for i in range(8)],
+                    "x": [0.2, 0.5, 0.8, 1.0, 1.6, 1.9, 2.1, 2.4],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        self.bf = BalanceFrame(sample=self.resp_sf, target=self.tgt_sf)
+
+    def test_require_ipw_model_non_ipw_raises(self) -> None:
+        """Line 1270: non-IPW model."""
+        adjusted = self.bf.fit(method="null")
+        with self.assertRaisesRegex(ValueError, "only IPW models"):
+            adjusted._require_ipw_model()
+
+    def test_require_ipw_model_missing_fit_info(self) -> None:
+        """Line 1270: IPW method but missing fit info."""
+        adjusted = self.bf.fit(method="ipw")
+        model = _assert_type(adjusted.model)
+        model["fit"] = None
+        model["X_matrix_columns"] = None
+        with self.assertRaisesRegex(ValueError, "missing fitted model"):
+            adjusted._require_ipw_model()
+
+    def test_matrix_to_dataframe_numpy_array(self) -> None:
+        """Line 1282: numpy array path."""
+        arr = np.array([[1.0, 2.0], [3.0, 4.0]])
+        idx = pd.Index([0, 1])
+        cols = ["a", "b"]
+        result = self.bf._matrix_to_dataframe(arr, idx, cols)
+        self.assertEqual(result.shape, (2, 2))
+        self.assertEqual(list(result.columns), ["a", "b"])
+
+    def test_matrix_to_dataframe_spmatrix(self) -> None:
+        """Line 1291: sparse matrix conversion."""
+        from scipy.sparse import csr_matrix
+
+        arr = csr_matrix(np.array([[1.0, 2.0], [3.0, 4.0]]))
+        idx = pd.Index([0, 1])
+        cols = ["a", "b"]
+        result = self.bf._matrix_to_dataframe(arr, idx, cols)
+        self.assertEqual(result.shape, (2, 2))
+
+    def test_matrix_to_dataframe_unknown_type_raises(self) -> None:
+        """Line 1291: unknown matrix type raises ValueError."""
+        with self.assertRaisesRegex(ValueError, "unavailable"):
+            self.bf._matrix_to_dataframe("not_a_matrix", pd.Index([0]), ["a"])
+
+    def test_align_to_index_mismatched_unique(self) -> None:
+        """Line 1310: indices are unique, same length, but different values."""
+        data = pd.Series([1, 2], index=pd.Index([10, 20]))
+        target_idx = pd.Index([30, 40])
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            self.bf._align_to_index(data, target_idx, "test")
+
+    def test_align_to_index_mismatched_length(self) -> None:
+        """Line 1317: non-unique indices with different lengths."""
+        # Non-unique indices to bypass the first if-branch
+        data = pd.Series([1, 2, 3], index=pd.Index(["a", "a", "b"]))
+        target_idx = pd.Index(["a", "a"])
+        with self.assertRaisesRegex(ValueError, "lengths differ"):
+            self.bf._align_to_index(data, target_idx, "test")
+
+    def test_ipw_class_index_missing_classes(self) -> None:
+        """Line 1328: missing classes_ attribute."""
+
+        class FakeModel:
+            pass
+
+        with self.assertRaisesRegex(ValueError, "missing classes_"):
+            BalanceFrame._ipw_class_index(FakeModel())
+
+    def test_ipw_class_index_missing_class_1(self) -> None:
+        """Line 1333: classes_ present but class 1 is missing."""
+
+        class FakeModel:
+            classes_ = [0, 2]
+
+        with self.assertRaisesRegex(ValueError, "missing class label 1"):
+            BalanceFrame._ipw_class_index(FakeModel())
+
+
+class TestBalanceFrameComputeIpwMatricesInferType(BalanceTestCase):
+    """Cover lines 1375-1381: infer matrix_type from stored artifacts."""
+
+    def test_infer_matrix_type_from_sparse_artifact(self) -> None:
+        from scipy.sparse import csr_matrix
+
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {
+                        "id": [f"s{i}" for i in range(8)],
+                        "x": [0.1, 0.3, 0.7, 1.1, 1.4, 1.7, 2.0, 2.2],
+                        "weight": [1.0] * 8,
+                    }
+                )
+            ),
+            target=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {
+                        "id": [f"t{i}" for i in range(8)],
+                        "x": [0.2, 0.5, 0.8, 1.0, 1.6, 1.9, 2.1, 2.4],
+                        "weight": [1.0] * 8,
+                    }
+                )
+            ),
+        )
+        fitted = bf.fit(method="ipw")
+        model = _assert_type(fitted.model)
+        # Remove explicit fit_matrix_type to force inference
+        model.pop("fit_matrix_type", None)
+        # Store a sparse matrix in model_matrix_sample to trigger inference
+        model["model_matrix_sample"] = csr_matrix(np.eye(8))
+        # The method should infer matrix_type as "sparse" and not crash
+        sample_matrix, target_matrix = fitted._compute_ipw_matrices(model)
+        self.assertIsNotNone(sample_matrix)
+        self.assertIsNotNone(target_matrix)
+
+    def _make_bf_and_fitted(self) -> tuple[BalanceFrame, BalanceFrame]:
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {
+                        "id": [f"s{i}" for i in range(8)],
+                        "x": [0.1, 0.3, 0.7, 1.1, 1.4, 1.7, 2.0, 2.2],
+                        "weight": [1.0] * 8,
+                    }
+                )
+            ),
+            target=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {
+                        "id": [f"t{i}" for i in range(8)],
+                        "x": [0.2, 0.5, 0.8, 1.0, 1.6, 1.9, 2.1, 2.4],
+                        "weight": [1.0] * 8,
+                    }
+                )
+            ),
+        )
+        fitted = bf.fit(method="ipw")
+        return bf, fitted
+
+    def test_infer_matrix_type_from_ndarray_artifact(self) -> None:
+        _bf, fitted = self._make_bf_and_fitted()
+        model = _assert_type(fitted.model)
+        model.pop("fit_matrix_type", None)
+        model["model_matrix_sample"] = np.eye(8)
+        sample_matrix, target_matrix = fitted._compute_ipw_matrices(model)
+        self.assertIsNotNone(sample_matrix)
+
+    def test_infer_matrix_type_from_dataframe_artifact(self) -> None:
+        _bf, fitted = self._make_bf_and_fitted()
+        model = _assert_type(fitted.model)
+        model.pop("fit_matrix_type", None)
+        model["model_matrix_sample"] = pd.DataFrame(np.eye(8))
+        sample_matrix, target_matrix = fitted._compute_ipw_matrices(model)
+        self.assertIsNotNone(sample_matrix)
+
+
+class TestBalanceFrameIsArtifactStale(BalanceTestCase):
+    """Cover line 1407: _is_artifact_stale returns True when artifact is None."""
+
+    def test_stale_when_artifact_is_none(self) -> None:
+        result = BalanceFrame._is_artifact_stale(None, pd.Index([0]), pd.Index([0]))
+        self.assertTrue(result)
+
+    def test_stale_when_length_mismatch(self) -> None:
+        arr = np.array([1.0, 2.0])
+        result = BalanceFrame._is_artifact_stale(arr, pd.Index([0, 1]), pd.Index([0]))
+        self.assertTrue(result)
+
+    def test_not_stale_when_matching(self) -> None:
+        arr = np.array([1.0, 2.0])
+        idx = pd.Index([0, 1])
+        result = BalanceFrame._is_artifact_stale(arr, idx, idx)
+        self.assertFalse(result)
+
+
+class TestBalanceFrameValidateDataCovariates(BalanceTestCase):
+    """Cover line 1485: mismatched target covariates in _validate_data_covariates."""
+
+    def test_mismatched_target_covariates(self) -> None:
+        bf1 = BalanceFrame(
+            sample=SampleFrame._create(
+                df=pd.DataFrame({"id": ["1"], "x": [1.0], "weight": [1.0]}),
+                id_column="id",
+                covar_columns=["x"],
+                weight_columns=["weight"],
+            ),
+            target=SampleFrame._create(
+                df=pd.DataFrame({"id": ["2"], "x": [2.0], "weight": [1.0]}),
+                id_column="id",
+                covar_columns=["x"],
+                weight_columns=["weight"],
+            ),
+        )
+        # Build data with sample covar "x" matching bf1, but target covar
+        # "x" AND "z" so it differs from bf1's target (just "x").
+        # Use _create to set explicit covar_columns.
+        data_sample = SampleFrame._create(
+            df=pd.DataFrame({"id": ["3"], "x": [3.0], "weight": [1.0]}),
+            id_column="id",
+            covar_columns=["x"],
+            weight_columns=["weight"],
+        )
+        data_target = SampleFrame._create(
+            df=pd.DataFrame({"id": ["4"], "x": [4.0], "z": [5.0], "weight": [1.0]}),
+            id_column="id",
+            covar_columns=["x", "z"],
+            weight_columns=["weight"],
+        )
+        data = BalanceFrame(sample=data_sample, target=data_target)
+        with self.assertRaisesRegex(ValueError, "matching target covariate"):
+            bf1._validate_data_covariates(data)
+
+
+class TestBalanceFrameDesignMatrixTargetErrors(BalanceTestCase):
+    """Cover lines 1578, 1629: design_matrix errors for target path."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        sample = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"s{i}" for i in range(8)],
+                    "x": [0.1, 0.3, 0.7, 1.1, 1.4, 1.7, 2.0, 2.2],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        target = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"t{i}" for i in range(8)],
+                    "x": [0.2, 0.5, 0.8, 1.0, 1.6, 1.9, 2.1, 2.4],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        self.bf = BalanceFrame.from_sample(sample.set_target(target))
+        self.fitted = self.bf.fit(method="ipw")
+
+    def test_design_matrix_data_on_target_no_target(self) -> None:
+        """Line 1578: data must have a target set for on='target'."""
+        data_no_target = BalanceFrame(
+            sample=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {
+                        "id": ["h1", "h2"],
+                        "x": [1.0, 2.0],
+                        "weight": [1.0, 1.0],
+                    }
+                )
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "target"):
+            self.fitted.design_matrix(on="target", data=data_no_target)
+
+    def test_design_matrix_on_target_missing_matrix(self) -> None:
+        """Line 1629: IPW model missing fit-time target matrix."""
+        model = _assert_type(self.fitted.model)
+        model.pop("model_matrix_target", None)
+        with self.assertRaisesRegex(ValueError, "missing fit-time target matrix"):
+            self.fitted.design_matrix(on="target")
+
+
+class TestBalanceFramePredictProbaTargetErrors(BalanceTestCase):
+    """Cover lines 1749, 1778: predict_proba errors for data= target path."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        sample = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"s{i}" for i in range(8)],
+                    "x": [0.1, 0.3, 0.7, 1.1, 1.4, 1.7, 2.0, 2.2],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        target = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"t{i}" for i in range(8)],
+                    "x": [0.2, 0.5, 0.8, 1.0, 1.6, 1.9, 2.1, 2.4],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        self.bf = BalanceFrame.from_sample(sample.set_target(target))
+        self.fitted = self.bf.fit(method="ipw")
+
+    def test_predict_proba_data_on_target_no_target(self) -> None:
+        """Line 1749: data must have a target set for on='target'."""
+        data_no_target = BalanceFrame(
+            sample=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {"id": ["h1", "h2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]}
+                )
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "target"):
+            self.fitted.predict_proba(on="target", data=data_no_target)
+
+    def test_predict_proba_link_output_for_target_data(self) -> None:
+        """Line 1778: target link transform path in data= mode."""
+        holdout_bf = BalanceFrame(
+            sample=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {"id": ["h1", "h2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]}
+                )
+            ),
+            target=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {"id": ["ht1", "ht2"], "x": [1.5, 2.5], "weight": [1.0, 1.0]}
+                )
+            ),
+        )
+        result = self.fitted.predict_proba(on="target", output="link", data=holdout_bf)
+        self.assertEqual(result.shape[0], 2)
+        self.assertTrue(np.all(np.isfinite(result.to_numpy())))
+
+
+class TestBalanceFramePredictWeightsDataErrors(BalanceTestCase):
+    """Cover lines 1926, 1938: predict_weights data= error branches."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        sample = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"s{i}" for i in range(8)],
+                    "x": [0.1, 0.3, 0.7, 1.1, 1.4, 1.7, 2.0, 2.2],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        target = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"t{i}" for i in range(8)],
+                    "x": [0.2, 0.5, 0.8, 1.0, 1.6, 1.9, 2.1, 2.4],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        self.bf = BalanceFrame.from_sample(sample.set_target(target))
+        self.fitted = self.bf.fit(method="ipw")
+
+    def test_predict_weights_data_missing_metadata(self) -> None:
+        """Line 1926: IPW model metadata missing fitted model info."""
+        model = _assert_type(self.fitted.model)
+        model["fit"] = None
+        model["X_matrix_columns"] = None
+        holdout_bf = BalanceFrame(
+            sample=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {"id": ["h1", "h2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]}
+                )
+            ),
+            target=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {"id": ["ht1", "ht2"], "x": [1.5, 2.5], "weight": [1.0, 1.0]}
+                )
+            ),
+        )
+        with self.assertRaisesRegex(ValueError, "missing fitted model"):
+            self.fitted.predict_weights(data=holdout_bf)
+
+
+class TestBalanceFrameResolveTrainingWeights(BalanceTestCase):
+    """Cover lines 2049-2053, 2061-2065: _resolve_training_weights fallbacks."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        sample = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"s{i}" for i in range(8)],
+                    "x": [0.1, 0.3, 0.7, 1.1, 1.4, 1.7, 2.0, 2.2],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        target = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": [f"t{i}" for i in range(8)],
+                    "x": [0.2, 0.5, 0.8, 1.0, 1.6, 1.9, 2.1, 2.4],
+                    "weight": [1.0] * 8,
+                }
+            )
+        )
+        self.bf = BalanceFrame.from_sample(sample.set_target(target))
+        self.fitted = self.bf.fit(method="ipw")
+
+    def test_sample_weights_fallback(self) -> None:
+        """Lines 2049-2053: sample weights fallback when training weights unavailable."""
+        model = _assert_type(self.fitted.model)
+        model.pop("training_sample_weights", None)
+        link = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+        with self.assertLogs("balance", level="WARNING") as cm:
+            sample_w, target_w = self.fitted._resolve_design_weights(model, link)
+        self.assertTrue(any("training_sample_weights" in msg for msg in cm.output))
+        self.assertEqual(len(sample_w), 8)
+
+    def test_target_weights_fallback(self) -> None:
+        """Lines 2061-2065: target weights fallback when training weights unavailable."""
+        model = _assert_type(self.fitted.model)
+        model.pop("training_target_weights", None)
+        link = np.array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+        with self.assertLogs("balance", level="WARNING") as cm:
+            sample_w, target_w = self.fitted._resolve_design_weights(model, link)
+        self.assertTrue(any("training_target_weights" in msg for msg in cm.output))
+        self.assertEqual(len(target_w), 8)
+
+
+class TestBalanceFramePredictWeightsIpwIndexMismatch(BalanceTestCase):
+    """Cover lines 2076, 2095: _predict_weights_ipw sample index mismatch."""
+
+    def test_predict_weights_ipw_missing_fit_info(self) -> None:
+        """Line 2076: IPW model metadata missing fitted model info."""
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {
+                        "id": [f"s{i}" for i in range(8)],
+                        "x": [0.1, 0.3, 0.7, 1.1, 1.4, 1.7, 2.0, 2.2],
+                        "weight": [1.0] * 8,
+                    }
+                )
+            ),
+            target=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {
+                        "id": [f"t{i}" for i in range(8)],
+                        "x": [0.2, 0.5, 0.8, 1.0, 1.6, 1.9, 2.1, 2.4],
+                        "weight": [1.0] * 8,
+                    }
+                )
+            ),
+        )
+        adjusted = bf.fit(method="ipw")
+        model = _assert_type(adjusted.model)
+        model["fit"] = None
+        model["X_matrix_columns"] = None
+        with self.assertRaisesRegex(ValueError, "missing fitted model"):
+            adjusted._predict_weights_ipw(model)
+
+    def test_predict_weights_ipw_index_fallback(self) -> None:
+        """Line 2095: sample_idx fallback when it doesn't match current."""
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {
+                        "id": [f"s{i}" for i in range(8)],
+                        "x": [0.1, 0.3, 0.7, 1.1, 1.4, 1.7, 2.0, 2.2],
+                        "weight": [1.0] * 8,
+                    }
+                )
+            ),
+            target=SampleFrame.from_frame(
+                pd.DataFrame(
+                    {
+                        "id": [f"t{i}" for i in range(8)],
+                        "x": [0.2, 0.5, 0.8, 1.0, 1.6, 1.9, 2.1, 2.4],
+                        "weight": [1.0] * 8,
+                    }
+                )
+            ),
+        )
+        adjusted = bf.fit(method="ipw")
+        model = _assert_type(adjusted.model)
+        # Set sample_index to something that doesn't match current
+        model["sample_index"] = pd.Index([f"a{i}" for i in range(8)])
+        # This should still work by falling back
+        w = adjusted._predict_weights_ipw(model)
+        self.assertEqual(len(w), 8)
+
+
+class TestBalanceFrameToSampleNoTarget(BalanceTestCase):
+    """Cover line 2218: to_sample without target raises ValueError."""
+
+    def test_to_sample_without_target_raises(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
+        )
+        bf = BalanceFrame(sample=resp_sf)
+        with self.assertRaisesRegex(ValueError, "no target"):
+            bf.to_sample()
+
+
+class TestBalanceFrameEffectiveSampleSizeNone(BalanceTestCase):
+    """Cover line 2410: _design_effect_diagnostics returns None,None,None for non-finite de."""
+
+    def test_design_effect_nonfinite_returns_three_nones(self) -> None:
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["1", "2"], "x": [1.0, 2.0], "weight": [1.0, 1.0]})
+        )
+        tgt_sf = SampleFrame.from_frame(
+            pd.DataFrame({"id": ["3", "4"], "x": [1.5, 2.5], "weight": [1.0, 1.0]})
+        )
+        bf = BalanceFrame(sample=resp_sf, target=tgt_sf)
+        from balance.stats_and_plots import weights_stats
+
+        with patch.object(weights_stats, "design_effect", return_value=float("inf")):
+            de, ess, essp = bf._design_effect_diagnostics()
+        self.assertIsNone(de)
+        self.assertIsNone(ess)
+        self.assertIsNone(essp)
+
+
+class TestBalanceFrameKeepOnlyPreAdjustAndLinks(BalanceTestCase):
+    """Cover lines 2777, 2790-2791: keep_only_some_rows_columns with pre_adjust and _links."""
+
+    def test_filter_pre_adjust_when_differs_from_sample(self) -> None:
+        """Line 2777: filter pre_adjust when it differs from sample."""
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["1", "2", "3"],
+                    "x": [10.0, 20.0, 30.0],
+                    "weight": [1.0, 1.0, 1.0],
+                }
+            )
+        )
+        tgt_sf = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["4", "5", "6"],
+                    "x": [15.0, 25.0, 35.0],
+                    "weight": [1.0, 1.0, 1.0],
+                }
+            )
+        )
+        bf = BalanceFrame(sample=resp_sf, target=tgt_sf)
+        adjusted = bf.adjust(method="null")
+        # adjusted has pre_adjust != sample
+        filtered = adjusted.keep_only_some_rows_columns(rows_to_keep="x > 15")
+        self.assertEqual(len(filtered.responders._df), 2)
+        self.assertIsNotNone(filtered.unadjusted)
+        assert filtered.unadjusted is not None
+        self.assertEqual(len(filtered.unadjusted._df), 2)
+
+    def test_links_filter_error_is_caught(self) -> None:
+        """Lines 2790-2791: catch errors filtering _links."""
+        resp_sf = SampleFrame.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["1", "2"],
+                    "x": [1.0, 2.0],
+                    "weight": [1.0, 1.0],
+                }
+            )
+        )
+        bf = BalanceFrame(sample=resp_sf)
+        # Put a BalanceFrame in _links whose keep_only_some_rows_columns will fail
+        linked_bf = BalanceFrame(
+            sample=SampleFrame.from_frame(
+                pd.DataFrame({"id": ["3"], "z": [99.0], "weight": [1.0]})
+            )
+        )
+        bf._links["test_link"] = linked_bf
+        # Filter using column "x" which doesn't exist in linked_bf -> raises
+        with self.assertLogs("balance", level="WARNING"):
+            result = bf.keep_only_some_rows_columns(rows_to_keep="x > 0")
+        self.assertIsNotNone(result)
+
+
+class TestBalanceFrameFilterSfPredicted(BalanceTestCase):
+    """Cover line 2859: _filter_sf for predicted column roles."""
+
+    def test_filter_sf_predicted_columns(self) -> None:
+        sf = SampleFrame._create(
+            df=pd.DataFrame(
+                {
+                    "id": ["1", "2"],
+                    "x": [1.0, 2.0],
+                    "pred": [0.5, 0.6],
+                    "weight": [1.0, 1.0],
+                }
+            ),
+            id_column="id",
+            covar_columns=["x"],
+            weight_columns=["weight"],
+        )
+        sf._column_roles["predicted"] = ["pred"]
+        filtered = BalanceFrame._filter_sf(sf, None, ["x"])
+        # predicted column should be filtered (pred not in keep set)
+        self.assertEqual(filtered._column_roles.get("predicted", []), [])

--- a/tests/test_balancedf.py
+++ b/tests/test_balancedf.py
@@ -3674,3 +3674,77 @@ class TestBalanceDFSourceProtocol(BalanceTestCase):
         # outcomes
         outcomes = s3_null.outcomes()
         self.assertIsNotNone(outcomes.df)
+
+
+class TestBalanceDF_kld_formula_base(BalanceTestCase):
+    """Cover BalanceDF._kld_formula returning None (line 1454)."""
+
+    def test_kld_formula_returns_none(self) -> None:
+        """Base BalanceDF._kld_formula() should return None."""
+        bdf = s1.covars()
+        # BalanceDFCovars inherits _kld_formula from BalanceDF
+        result = BalanceDF._kld_formula(bdf)
+        self.assertIsNone(result)
+
+
+class TestBalanceDFOutcomes_no_outcome_columns(BalanceTestCase):
+    """Cover BalanceDFOutcomes.__init__ raising ValueError (lines 2241-2242)."""
+
+    def test_raises_when_no_outcome_columns(self) -> None:
+        """Creating BalanceDFOutcomes from a Sample without outcomes raises ValueError."""
+        sample_no_outcomes = Sample.from_frame(
+            pd.DataFrame({"a": [1, 2, 3], "id": [1, 2, 3], "w": [1.0, 1.0, 1.0]}),
+            id_column="id",
+            weight_column="w",
+        )
+        with self.assertRaisesRegex(ValueError, "no outcome columns are defined"):
+            BalanceDFOutcomes(sample=sample_no_outcomes)  # pyre-ignore[6]
+
+
+class TestBalanceDFWeights_design_effect_prop_type_error(BalanceTestCase):
+    """Cover BalanceDFWeights.design_effect_prop raising TypeError (line 3017)."""
+
+    def test_raises_when_unadjusted_is_not_weights(self) -> None:
+        """design_effect_prop raises TypeError when unadjusted is not BalanceDFWeights."""
+        s3_adj = s3.adjust(method="null")
+        weights = s3_adj.weights()
+
+        original_method: object = weights._balancedf_child_from_linked_samples
+
+        def mock_linked() -> dict[str, object]:
+            result = original_method()  # pyre-ignore[29]
+            result["unadjusted"] = "not_a_weights_object"
+            return result
+
+        weights._balancedf_child_from_linked_samples = mock_linked  # type: ignore[assignment]
+        try:
+            with self.assertRaisesRegex(TypeError, "Expected BalanceDFWeights"):
+                weights.design_effect_prop()
+        finally:
+            weights._balancedf_child_from_linked_samples = original_method  # type: ignore[assignment]
+
+
+class TestBalanceDFWeights_r_indicator_scalar_ndarray(BalanceTestCase):
+    """Cover BalanceDFWeights.r_indicator 0-d ndarray reshape (line 3122)."""
+
+    def test_r_indicator_with_scalar_ndarray_target_propensity(self) -> None:
+        """Passing a 0-d numpy array as target_propensity triggers reshape to 1D."""
+        # Create a sample and target each with 1 row so that the
+        # 0-d array reshaped to shape (1,) matches the target row count.
+        one_sample = Sample.from_frame(
+            pd.DataFrame({"a": [1], "id": [1], "w": [1.0]}),
+            id_column="id",
+            weight_column="w",
+        )
+        one_target = Sample.from_frame(
+            pd.DataFrame({"a": [2], "id": [2], "w": [1.0]}),
+            id_column="id",
+            weight_column="w",
+        )
+        adj = one_sample.set_target(one_target).adjust(method="null")
+        weights = adj.weights()
+        # Pass a 0-d numpy array as target_propensity
+        scalar_array = np.array(0.5)
+        self.assertEqual(scalar_array.ndim, 0)
+        result = weights.r_indicator(target_propensity=scalar_array)
+        self.assertIsInstance(result, (float, np.floating))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2097,3 +2097,14 @@ class TestCliExceptionHandling(balance.testutil.BalanceTestCase):
             diagnostics_df = pd.read_csv(diagnostics_out_file)
             self.assertIn("adjustment_failure", diagnostics_df["metric"].values)
             self.assertIn("adjustment_failure_reason", diagnostics_df["metric"].values)
+
+
+class TestCliParseColumnsNone(balance.testutil.BalanceTestCase):
+    """Cover _parse_csv_columns_arg raising ValueError when value is None (line 42)."""
+
+    def test_parse_csv_columns_arg_raises_on_none(self) -> None:
+        """_parse_csv_columns_arg(None, ...) raises ValueError."""
+        from balance.cli import _parse_csv_columns_arg
+
+        with self.assertRaisesRegex(ValueError, "cannot be None"):
+            _parse_csv_columns_arg(None, "test_arg")

--- a/tests/test_rake.py
+++ b/tests/test_rake.py
@@ -1495,3 +1495,117 @@ class TestRunIpfNumpyNanConv(balance.testutil.BalanceTestCase):
         self.assertIsInstance(iterations_df, pd.DataFrame)
         # Check that convergence history is recorded
         self.assertGreater(len(iterations_df), 0)
+
+
+class TestRakeValidation(
+    balance.testutil.BalanceTestCase,
+):
+    """Tests for uncovered validation paths in rake module."""
+
+    def test_hare_niemeyer_all_zero_proportions(self) -> None:
+        """Test _hare_niemeyer_allocation raises ValueError when all proportions are zero (line 515)."""
+        with self.assertRaisesRegex(ValueError, "All proportions are zero or empty"):
+            _hare_niemeyer_allocation({"a": 0, "b": 0}, 5)
+
+    def test_realize_dicts_nan_proportion(self) -> None:
+        """Test _realize_dicts_of_proportions raises ValueError for NaN proportion (line 660)."""
+        with self.assertRaisesRegex(ValueError, "finite"):
+            _realize_dicts_of_proportions({"v1": {"a": float("nan"), "b": 0.5}})
+
+    def test_realize_dicts_inf_proportion(self) -> None:
+        """Test _realize_dicts_of_proportions raises ValueError for inf proportion (line 660)."""
+        with self.assertRaisesRegex(ValueError, "finite"):
+            _realize_dicts_of_proportions({"v1": {"a": float("inf"), "b": 0.5}})
+
+    def test_realize_dicts_negative_proportion(self) -> None:
+        """Test _realize_dicts_of_proportions raises ValueError for negative proportion (line 665)."""
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            _realize_dicts_of_proportions({"v1": {"a": -0.5, "b": 0.5}})
+
+    def test_realize_dicts_bool_proportion(self) -> None:
+        """Test _realize_dicts_of_proportions raises ValueError for bool proportion (line 654-655)."""
+        with self.assertRaisesRegex(ValueError, "real number.*not bool"):
+            _realize_dicts_of_proportions({"v1": {"a": True, "b": 0.5}})
+
+    def test_validate_props_float_conversion_error(self) -> None:
+        """Lines 654-655: ValueError when proportion is not convertible to float."""
+        import numbers
+
+        class BadReal(numbers.Real):
+            """A numbers.Real subclass whose float() raises TypeError."""
+
+            def __float__(self) -> float:
+                raise TypeError("cannot convert")
+
+            # Abstract method stubs required by numbers.Real ABC:
+            def __abs__(self) -> "BadReal":
+                return self
+
+            def __add__(self, other: object) -> "BadReal":
+                return self
+
+            def __ceil__(self) -> int:
+                return 0
+
+            def __eq__(self, other: object) -> bool:
+                return False
+
+            def __floor__(self) -> int:
+                return 0
+
+            def __floordiv__(self, other: object) -> "BadReal":
+                return self
+
+            def __le__(self, other: object) -> bool:
+                return False
+
+            def __lt__(self, other: object) -> bool:
+                return False
+
+            def __mod__(self, other: object) -> "BadReal":
+                return self
+
+            def __mul__(self, other: object) -> "BadReal":
+                return self
+
+            def __neg__(self) -> "BadReal":
+                return self
+
+            def __pos__(self) -> "BadReal":
+                return self
+
+            def __pow__(self, other: object) -> "BadReal":
+                return self
+
+            def __radd__(self, other: object) -> "BadReal":
+                return self
+
+            def __rfloordiv__(self, other: object) -> "BadReal":
+                return self
+
+            def __rmod__(self, other: object) -> "BadReal":
+                return self
+
+            def __rmul__(self, other: object) -> "BadReal":
+                return self
+
+            def __round__(self, ndigits: int = 0) -> "BadReal":
+                return self
+
+            def __rpow__(self, other: object) -> "BadReal":
+                return self
+
+            def __rtruediv__(self, other: object) -> "BadReal":
+                return self
+
+            def __truediv__(self, other: object) -> "BadReal":
+                return self
+
+            def __trunc__(self) -> int:
+                return 0
+
+            def __hash__(self) -> int:
+                return 0
+
+        with self.assertRaisesRegex(ValueError, "convertible to float"):
+            _realize_dicts_of_proportions({"var": {"cat": BadReal()}})  # pyre-ignore[6]

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -2911,3 +2911,32 @@ class TestCallableBool(balance.testutil.BalanceTestCase):
 
         self.assertEqual(5 * _CallableBool(True), 5)
         self.assertEqual(5 * _CallableBool(False), 0)
+
+
+class TestSampleFrameSetterCoverage(balance.testutil.BalanceTestCase):
+    """Cover the _sample_frame setter (lines 170-172) and _balance_frame setter (line 181)."""
+
+    def test_sample_frame_setter_updates_internal_state(self) -> None:
+        """Setting _sample_frame to a non-None value updates both _sf_sample and _sf_sample_pre_adjust."""
+        sample = Sample.from_frame(
+            pd.DataFrame({"a": [1, 2, 3], "id": [1, 2, 3], "w": [1.0, 1.0, 1.0]}),
+            id_column="id",
+            weight_column="w",
+        )
+        new_sf = SampleFrame.from_frame(
+            pd.DataFrame({"a": [10, 20], "id": [10, 20], "w": [2.0, 2.0]}),
+            id_column="id",
+            weight_column="w",
+        )
+        sample._sample_frame = new_sf
+        self.assertIs(sample._sf_sample, new_sf)
+        self.assertIs(sample._sf_sample_pre_adjust, new_sf)
+
+    def test_balance_frame_setter_is_noop(self) -> None:
+        """Setting _balance_frame should not raise (it is a no-op)."""
+        sample = Sample.from_frame(
+            pd.DataFrame({"a": [1, 2], "id": [1, 2]}),
+        )
+        # Should not raise
+        sample._balance_frame = None
+        sample._balance_frame = "anything"  # type: ignore[assignment]

--- a/tests/test_sample_diagnostics_helper.py
+++ b/tests/test_sample_diagnostics_helper.py
@@ -406,3 +406,37 @@ def test_build_diagnostics_with_ipw_matches_sample_diagnostics() -> None:
     )
 
     pd.testing.assert_frame_equal(result, expected)
+
+
+def test_build_diagnostics_model_dict_none_shows_unknown_method() -> None:
+    """When model_dict is None, _build_diagnostics should include 'unknown' adjustment method."""
+    sample = Sample.from_frame(
+        pd.DataFrame({"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}),
+        id_column="id",
+        weight_column="weight",
+        standardize_types=False,
+    )
+    target = Sample.from_frame(
+        pd.DataFrame({"id": ["3", "4"], "x": [0, 1], "weight": [1.0, 1.0]}),
+        id_column="id",
+        weight_column="weight",
+        standardize_types=False,
+    )
+    adjusted = sample.set_target(target).adjust(method="null")
+
+    result = _build_diagnostics(
+        covars_df=adjusted.covars().df,
+        target_covars_df=adjusted._links["target"].covars().df,
+        weights_summary=adjusted.weights().summary(),
+        model_dict=None,
+        covars_asmd=adjusted.covars().asmd(),
+        covars_asmd_main=adjusted.covars().asmd(aggregate_by_main_covar=True),
+        outcome_columns=adjusted._outcome_columns,
+        weights_impact_on_outcome_method="t_test",
+        weights_impact_on_outcome_conf_level=0.95,
+        outcome_impact=None,
+    )
+
+    method_rows = result[result["metric"] == "adjustment_method"]
+    assert len(method_rows) == 1
+    assert method_rows["var"].iloc[0] == "unknown"

--- a/tests/test_sample_frame.py
+++ b/tests/test_sample_frame.py
@@ -7,6 +7,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pandas as pd
 from balance.balancedf_class import (
@@ -1204,3 +1206,135 @@ class TestSampleFrameFromFrameEdgeCases(BalanceTestCase):
                 weight_column="weight",
                 outcome_columns=["weight"],
             )
+
+
+class TestSampleFrameUncoveredLines(BalanceTestCase):
+    """Tests targeting specific uncovered lines in sample_frame.py."""
+
+    def test_from_frame_predicted_outcome_columns_string(self) -> None:
+        """Line 244: predicted_outcome_columns as a string is normalised to list."""
+        df = pd.DataFrame(
+            {"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0], "p_y": [0.3, 0.7]}
+        )
+        sf = SampleFrame.from_frame(df, predicted_outcome_columns="p_y")
+        self.assertEqual(sf.predicted_outcome_columns, ["p_y"])
+
+    def test_from_frame_missing_covar_columns_raises(self) -> None:
+        """Line 402: ValueError when explicit covar_columns are not in df."""
+        df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0]})
+        with self.assertRaises(ValueError) as ctx:
+            SampleFrame.from_frame(df, covar_columns=["nonexistent"])
+        self.assertIn("nonexistent", str(ctx.exception))
+
+    def test_from_frame_covar_includes_id_warns(self) -> None:
+        """Line 444: warns when explicit covariates include the id column."""
+        df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0]})
+        with self.assertLogs("balance", level="WARNING") as cm:
+            SampleFrame.from_frame(df, covar_columns=["x", "id"])
+        self.assertTrue(
+            any("id or weight columns" in msg for msg in cm.output),
+            f"Expected warning about id/weight in covars, got: {cm.output}",
+        )
+
+    def test_weight_column_property_future_warning(self) -> None:
+        """Lines 593-600: weight_column property issues FutureWarning."""
+        df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0]})
+        sf = SampleFrame.from_frame(df)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = sf.weight_column
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, FutureWarning))
+            self.assertIn(
+                "weight_column now returns the column name", str(w[0].message)
+            )
+        self.assertEqual(result, "weight")
+
+    def test_id_column_property_future_warning(self) -> None:
+        """Lines 751-758: id_column property issues FutureWarning."""
+        df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 1.0]})
+        sf = SampleFrame.from_frame(df)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = sf.id_column
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, FutureWarning))
+            self.assertIn("id_column now returns the column name", str(w[0].message))
+        self.assertEqual(result, "id")
+
+    def test_set_weights_use_index_non_series_raises(self) -> None:
+        """Line 899: TypeError when use_index=True but weights is not a Series."""
+        df = pd.DataFrame(
+            {"id": ["1", "2", "3"], "x": [10, 20, 30], "weight": [1.0, 1.0, 1.0]}
+        )
+        sf = SampleFrame.from_frame(df)
+        with self.assertRaises(TypeError) as ctx:
+            sf.set_weights(np.array([1.0, 2.0, 3.0]), use_index=True)  # pyre-ignore[6]
+        self.assertIn("use_index=True requires a pandas Series", str(ctx.exception))
+
+    def test_rename_weight_column_bad_old_name(self) -> None:
+        """Lines 1214-1218: rename_weight_column raises when old_name is not a weight column."""
+        df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 2.0]})
+        sf = SampleFrame.from_frame(df)
+        with self.assertRaisesRegex(ValueError, "is not a weight column"):
+            sf.rename_weight_column("nonexistent", "new_weight")
+
+    def test_rename_weight_column_new_name_exists(self) -> None:
+        """Lines 1219-1223: rename_weight_column raises when new_name already exists in df."""
+        df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 2.0]})
+        sf = SampleFrame.from_frame(df)
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            sf.rename_weight_column("weight", "x")
+
+    def test_rename_weight_column(self) -> None:
+        """Lines 1214-1234: rename_weight_column updates df, roles, pointer, metadata."""
+        df = pd.DataFrame({"id": ["1", "2"], "x": [10, 20], "weight": [1.0, 2.0]})
+        sf = SampleFrame.from_frame(df)
+        sf.set_weight_metadata("weight", {"method": "ipw"})
+        sf.rename_weight_column("weight", "w_new")
+        # Old column gone, new column present
+        self.assertNotIn("weight", sf._df.columns)
+        self.assertIn("w_new", sf._df.columns)
+        # Column roles updated
+        self.assertIn("w_new", sf._column_roles["weights"])
+        self.assertNotIn("weight", sf._column_roles["weights"])
+        # Active weight pointer updated
+        self.assertEqual(sf._weight_column_name, "w_new")
+        # Metadata migrated
+        self.assertEqual(sf.weight_metadata("w_new"), {"method": "ipw"})
+
+    def test_from_sample_no_id_raises(self) -> None:
+        """Line 1362: ValueError when Sample has no id_column."""
+        from unittest.mock import MagicMock
+
+        sample = MagicMock(spec=Sample)
+        sample.id_series = None
+        with self.assertRaises(ValueError) as ctx:
+            SampleFrame.from_sample(sample)
+        self.assertIn("id_column", str(ctx.exception))
+
+    def test_from_sample_no_weight_raises(self) -> None:
+        """Line 1366: ValueError when Sample has no weight_column."""
+        from unittest.mock import MagicMock
+
+        sample = MagicMock(spec=Sample)
+        sample.id_series = pd.Series(["1"], name="id")
+        sample.weight_series = None
+        with self.assertRaises(ValueError) as ctx:
+            SampleFrame.from_sample(sample)
+        self.assertIn("weight_column", str(ctx.exception))
+
+    def test_from_sample_no_dataframe_raises(self) -> None:
+        """Line 1380: ValueError when Sample has no DataFrame."""
+        from unittest.mock import MagicMock
+
+        sample = MagicMock(spec=Sample)
+        sample.id_series = pd.Series(["1"], name="id")
+        sample.weight_series = pd.Series([1.0], name="weight")
+        sample._outcome_columns = None
+        sample._ignored_column_names = []
+        sample._covar_columns_names.return_value = ["x"]
+        sample._df = None
+        with self.assertRaises(ValueError) as ctx:
+            SampleFrame.from_sample(sample)
+        self.assertIn("no DataFrame", str(ctx.exception))

--- a/tests/test_stats_and_plots.py
+++ b/tests/test_stats_and_plots.py
@@ -3628,3 +3628,23 @@ class TestEmptyCategoriesError(balance.testutil.BalanceTestCase):
                 ValueError, "Discrete columns must contain at least one category"
             ):
                 weighted_comparisons_stats.ks(sample_df, target_df)
+
+    def test_coerce_r_indicator_propensities_scalar(self) -> None:
+        """Test _coerce_r_indicator_propensities reshapes scalar (ndim==0) to 1D array (line 54)."""
+        from balance.stats_and_plots.weighted_comparisons_stats import (
+            _coerce_r_indicator_propensities,
+        )
+
+        result = _coerce_r_indicator_propensities(0.5, "test")
+        self.assertEqual(result.ndim, 1)
+        self.assertEqual(len(result), 1)
+        self.assertAlmostEqual(result[0], 0.5)
+
+    def test_asmd_unknown_std_type(self) -> None:
+        """Test asmd raises ValueError for unknown std_type (line 613)."""
+        sample_df = pd.DataFrame({"a": [1.0, 2.0, 3.0]})
+        target_df = pd.DataFrame({"a": [4.0, 5.0, 6.0]})
+        with self.assertRaisesRegex(ValueError, "std_type must be in"):
+            weighted_comparisons_stats.asmd(
+                sample_df, target_df, std_type="invalid"  # pyre-ignore[6]
+            )

--- a/tests/test_util_model_matrix.py
+++ b/tests/test_util_model_matrix.py
@@ -13,13 +13,15 @@ import pandas as pd
 from balance.sample_class import Sample
 from balance.util import _assert_type
 from balance.utils.model_matrix import (
+    _build_projected_model_matrix,
+    build_design_matrix,
     build_model_matrix,
     dot_expansion,
     formula_generator,
     model_matrix,
     process_formula,
 )
-from scipy.sparse import csc_matrix
+from scipy.sparse import csc_matrix, issparse
 
 
 class TestUtil(
@@ -710,3 +712,153 @@ class TestModelMatrixEdgeCases(balance.testutil.BalanceTestCase):
 
         with self.assertRaisesRegex(ValueError, "Dropping rows led to empty target"):
             model_matrix(sample_df, target_df, add_na=False)
+
+
+class TestBuildProjectedModelMatrix(
+    balance.testutil.BalanceTestCase,
+):
+    """Tests for _build_projected_model_matrix and build_design_matrix uncovered lines."""
+
+    def test_build_projected_model_matrix_na_action_drop_raises(self) -> None:
+        """Test that _build_projected_model_matrix raises ValueError when na_action='drop' (line 546)."""
+        sample_df = pd.DataFrame({"a": [1, 2, 3]})
+        target_df = pd.DataFrame({"a": [4, 5, 6]})
+        with self.assertRaisesRegex(ValueError, "unsupported when na_action='drop'"):
+            _build_projected_model_matrix(
+                sample_df,
+                target_df,
+                formula=None,
+                one_hot_encoding=False,
+                na_action="drop",
+                project_to_columns=["a"],
+            )
+
+    def test_build_projected_model_matrix_no_overlapping_columns(self) -> None:
+        """Test that an empty sparse matrix is created when no columns overlap (line 607)."""
+        sample_df = pd.DataFrame({"a": [1, 2, 3]})
+        target_df = pd.DataFrame({"a": [4, 5, 6]})
+        result = _build_projected_model_matrix(
+            sample_df,
+            target_df,
+            formula=None,
+            one_hot_encoding=False,
+            na_action="add_indicator",
+            project_to_columns=["nonexistent_col1", "nonexistent_col2"],
+        )
+        combined_matrix = result[0]
+        self.assertIsInstance(combined_matrix, csc_matrix)
+        self.assertEqual(combined_matrix.shape, (6, 2))
+        # All entries should be zero
+        self.assertEqual(combined_matrix.nnz, 0)
+
+    def test_build_design_matrix_scaler_weights_without_fit_scaler(self) -> None:
+        """Test that a new StandardScaler is created when scaler_weights is provided but fit_scaler is None (lines 826-830)."""
+        sample_df = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": [4.0, 5.0, 6.0]})
+        target_df = pd.DataFrame({"a": [7.0, 8.0, 9.0], "b": [10.0, 11.0, 12.0]})
+        weights = np.ones(6)
+        result = build_design_matrix(
+            sample_df,
+            target_df,
+            use_model_matrix=False,
+            na_action="add_indicator",
+            scaler_weights=weights,
+        )
+        self.assertIsNotNone(result["fit_scaler"])
+
+    def test_build_design_matrix_penalty_rescaling_sparse(self) -> None:
+        """Test penalty rescaling on sparse matrix (lines 842-844)."""
+        sample_df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        target_df = pd.DataFrame({"a": [5.0, 6.0], "b": [7.0, 8.0]})
+        result = build_design_matrix(
+            sample_df,
+            target_df,
+            use_model_matrix=True,
+            na_action="add_indicator",
+            fit_penalties_skl=[2.0, 2.0],
+            matrix_type="sparse",
+        )
+        self.assertIsInstance(result["combined_matrix"], csc_matrix)
+        self.assertIsNotNone(result["fit_penalties_skl"])
+
+    def test_build_design_matrix_penalty_rescaling_dense(self) -> None:
+        """Test penalty rescaling on dense (DataFrame/ndarray) matrix (line 846)."""
+        sample_df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        target_df = pd.DataFrame({"a": [5.0, 6.0], "b": [7.0, 8.0]})
+        result = build_design_matrix(
+            sample_df,
+            target_df,
+            use_model_matrix=False,
+            na_action="add_indicator",
+            fit_penalties_skl=[2.0, 2.0],
+            matrix_type="dense",
+        )
+        self.assertIsInstance(result["combined_matrix"], np.ndarray)
+
+    def test_build_design_matrix_dense_from_sparse(self) -> None:
+        """Test converting sparse matrix to dense ndarray (line 851)."""
+        sample_df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        target_df = pd.DataFrame({"a": [5.0, 6.0], "b": [7.0, 8.0]})
+        result = build_design_matrix(
+            sample_df,
+            target_df,
+            use_model_matrix=True,
+            na_action="add_indicator",
+            matrix_type="dense",
+        )
+        self.assertIsInstance(result["combined_matrix"], np.ndarray)
+
+    def test_build_design_matrix_dense_from_dataframe(self) -> None:
+        """Test converting DataFrame to ndarray (line 852-853)."""
+        sample_df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        target_df = pd.DataFrame({"a": [5.0, 6.0], "b": [7.0, 8.0]})
+        result = build_design_matrix(
+            sample_df,
+            target_df,
+            use_model_matrix=False,
+            na_action="add_indicator",
+            matrix_type="dense",
+        )
+        self.assertIsInstance(result["combined_matrix"], np.ndarray)
+
+    def test_build_design_matrix_sparse_from_ndarray(self) -> None:
+        """Test converting ndarray to csc_matrix (line 856)."""
+        sample_df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        target_df = pd.DataFrame({"a": [5.0, 6.0], "b": [7.0, 8.0]})
+        # First build dense, then request sparse to trigger ndarray -> csc conversion
+        # Use use_model_matrix=True which produces sparse, then we need dense first.
+        # Actually, use_model_matrix=False produces DataFrame. Let's use penalty to get ndarray first.
+        result = build_design_matrix(
+            sample_df,
+            target_df,
+            use_model_matrix=False,
+            na_action="add_indicator",
+            fit_penalties_skl=[2.0, 2.0],
+            matrix_type="sparse",
+        )
+        self.assertTrue(issparse(result["combined_matrix"]))
+
+    def test_build_design_matrix_sparse_from_dataframe(self) -> None:
+        """Test converting DataFrame to csc_matrix (line 858)."""
+        sample_df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        target_df = pd.DataFrame({"a": [5.0, 6.0], "b": [7.0, 8.0]})
+        result = build_design_matrix(
+            sample_df,
+            target_df,
+            use_model_matrix=False,
+            na_action="add_indicator",
+            matrix_type="sparse",
+        )
+        self.assertTrue(issparse(result["combined_matrix"]))
+
+    def test_build_design_matrix_penalty_length_mismatch(self) -> None:
+        """Line 838: ValueError when fit_penalties_skl length doesn't match columns."""
+        sample_df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        target_df = pd.DataFrame({"a": [5.0, 6.0], "b": [7.0, 8.0]})
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            build_design_matrix(
+                sample_df,
+                target_df,
+                use_model_matrix=False,
+                na_action="add_indicator",
+                fit_penalties_skl=[1.0, 2.0, 3.0],  # 3 penalties for 2 columns
+            )

--- a/tests/test_weighted_comparisons_plots.py
+++ b/tests/test_weighted_comparisons_plots.py
@@ -2055,3 +2055,34 @@ class TestPlotDistSeabornDistType(balance.testutil.BalanceTestCase):
             )
         self.assertIn("seaborn library does not support", str(context.exception))
         self.assertIn("hist_ascii", str(context.exception))
+
+    def test_seaborn_plot_dist_empty_variables_returns_early(self) -> None:
+        """Test seaborn_plot_dist returns early when variables list is empty after filtering (lines 685-686)."""
+        # Use DataFrames with no common columns so choose_variables returns []
+        df1 = pd.DataFrame({"v1": [1.0, 2.0, 3.0]})
+        df2 = pd.DataFrame({"v2": [4.0, 5.0, 6.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df1, "weight": pd.Series(np.ones(3))},
+            {"df": df2, "weight": pd.Series(np.ones(3))},
+        ]
+        result = weighted_comparisons_plots.seaborn_plot_dist(
+            dfs,
+            names=["self", "target"],
+            return_axes=False,
+        )
+        self.assertIsNone(result)
+
+    def test_seaborn_plot_dist_empty_variables_returns_empty_list(self) -> None:
+        """Test seaborn_plot_dist returns [] when return_axes=True and variables empty (lines 685-686)."""
+        df1 = pd.DataFrame({"v1": [1.0, 2.0, 3.0]})
+        df2 = pd.DataFrame({"v2": [4.0, 5.0, 6.0]})
+        dfs: List[DataFrameWithWeight] = [
+            {"df": df1, "weight": pd.Series(np.ones(3))},
+            {"df": df2, "weight": pd.Series(np.ones(3))},
+        ]
+        result = weighted_comparisons_plots.seaborn_plot_dist(
+            dfs,
+            names=["self", "target"],
+            return_axes=True,
+        )
+        self.assertEqual(result, [])


### PR DESCRIPTION
Summary:

Add ~70 new test methods across 10 test files covering all previously uncovered lines (110 lines) in the balance package. Coverage was at 98% with gaps in balance_frame.py, sample_frame.py, sample_class.py, balancedf_class.py, cli.py, summary_utils.py, model_matrix.py, rake.py, weighted_comparisons_plots.py, and weighted_comparisons_stats.py.

Key areas covered:
- FutureWarning deprecation paths for id_column/weight_column property changes
- Error validation branches in set_fitted_model, design_matrix, predict_proba, predict_weights
- IPW model helper methods (_require_ipw_model, _matrix_to_dataframe, _align_to_index, _ipw_class_index)
- Training weights fallback logic in _resolve_design_weights
- SampleFrame.from_frame edge cases (string column args, missing covariates, covar/id overlap warning)
- SampleFrame.rename_weight_column and from_sample validation
- BalanceDF base class methods and BalanceDFOutcomes/Weights error paths
- build_design_matrix scaler, penalty rescaling, and matrix type conversion branches
- Rake validation for proportions (zero, NaN, inf, negative, non-float)
- ASMD unknown std_type and r_indicator scalar reshaping
- Empty variables early return in seaborn_plot_dist
- Fix StandardScaler copy=False read-only array bug in model_matrix.py

Differential Revision: D100949347
