### PR TITLE
Holdout design-matrix projection diagnostics + consolidate sklearn test helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,15 @@
     own `formula=` argument, it should accept both additive and
     interaction terms (unlike poststratify).
 
+- **Improved holdout design-matrix robustness diagnostics**
+  - `build_design_matrix()` now uses a shared NA-indicator token pattern from
+    `data_transformation.py` when parsing formula terms, avoiding duplicated
+    hard-coded regex logic.
+  - In raw-covariate holdout projection mode (`use_model_matrix=False` with
+    `project_to_columns=...`), missing fit-time columns now emit a warning
+    before zero-fill reindexing so unseen holdout features are explicit.
+  - Missing-column warnings are now de-duplicated and preserve request order,
+    preventing redundant repeated column names in diagnostics.
 ## Breaking Changes
 
 - **Changed `id_column` to return the column name (`str`)** on `SampleFrame`,

--- a/balance/testutil.py
+++ b/balance/testutil.py
@@ -22,6 +22,29 @@ import pandas as pd
 from balance.util import _assert_type  # noqa: F401
 
 
+def _has_sklearn_1_4() -> bool:
+    """Return True if scikit-learn >= 1.4 is available.
+
+    Some tests exercise sklearn features (e.g. native categorical support in
+    ``HistGradientBoostingClassifier``) that require scikit-learn >= 1.4.
+    Tests that need this should be decorated with BOTH
+    ``@pytest.mark.requires_sklearn_1_4`` (deselects at collection time under
+    pytest, via conftest.py) and
+    ``@unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, ...)`` (fallback for
+    environments that run the unittest runner directly, where pytest markers
+    are a no-op). See ``CLAUDE.md`` for the full rationale.
+    """
+    try:
+        import sklearn
+
+        return tuple(int(x) for x in sklearn.__version__.split(".")[:2]) >= (1, 4)
+    except Exception:
+        return False
+
+
+_SKLEARN_1_4_AVAILABLE: bool = _has_sklearn_1_4()
+
+
 @contextmanager
 def tempfile_path() -> Generator[str, None, None]:
     """Yield a cross-platform temporary file path and remove it afterwards."""

--- a/balance/utils/data_transformation.py
+++ b/balance/utils/data_transformation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import re
 import warnings
 from itertools import combinations
 from typing import Any, List, Tuple
@@ -19,6 +20,11 @@ from balance.utils.input_validation import choose_variables
 from balance.utils.pandas_utils import _safe_fillna_and_infer
 
 logger: logging.Logger = logging.getLogger(__package__)
+
+NA_INDICATOR_PREFIX: str = "_is_na_"
+NA_INDICATOR_TOKEN_PATTERN: str = (
+    rf"(?<![A-Za-z0-9_]){re.escape(NA_INDICATOR_PREFIX)}[A-Za-z0-9_]+(?![A-Za-z0-9_])"
+)
 
 
 def add_na_indicator(
@@ -40,17 +46,17 @@ def add_na_indicator(
     Returns:
         pd.DataFrame: New dataframe with additional columns
     """
-    already_na_cols = [c for c in df.columns if c.startswith("_is_na_")]
+    already_na_cols = [c for c in df.columns if c.startswith(NA_INDICATOR_PREFIX)]
     if len(already_na_cols) > 0:
         raise ValueError(
             "Can't add NA indicator to DataFrame which contains"
-            f"columns which start with '_is_na_': {already_na_cols}"
+            f"columns which start with '{NA_INDICATOR_PREFIX}': {already_na_cols}"
         )
 
     na = df.isnull()
     na_cols = list(df.columns[na.any(axis="index")])
     na_indicators = na.loc[:, na_cols]
-    na_indicators.columns = ("_is_na_" + c for c in na_indicators.columns)
+    na_indicators.columns = (NA_INDICATOR_PREFIX + c for c in na_indicators.columns)
 
     categorical_cols = list(df.columns[df.dtypes == "category"])
     non_numeric_cols = list(
@@ -116,7 +122,9 @@ def add_na_indicator_to_combined(df: pd.DataFrame) -> pd.DataFrame:
         ['x', '_is_na_x', '_is_na_y']
     """
     existing_indicator_cols = [
-        col for col in df.columns if isinstance(col, str) and col.startswith("_is_na_")
+        col
+        for col in df.columns
+        if isinstance(col, str) and col.startswith(NA_INDICATOR_PREFIX)
     ]
     if not existing_indicator_cols:
         return add_na_indicator(df)

--- a/balance/utils/model_matrix.py
+++ b/balance/utils/model_matrix.py
@@ -16,6 +16,7 @@ import pandas as pd
 from balance.utils.data_transformation import (
     add_na_indicator,
     add_na_indicator_to_combined,
+    NA_INDICATOR_TOKEN_PATTERN,
 )
 from balance.utils.input_validation import (
     _assert_type,
@@ -35,6 +36,14 @@ from scipy.sparse import csc_matrix, diags, hstack, spmatrix
 from sklearn.preprocessing import StandardScaler
 
 logger: logging.Logger = logging.getLogger(__package__)
+
+
+def _ordered_unique_missing_columns(
+    requested_columns: list[str], existing_columns: pd.Index
+) -> list[str]:
+    """Return missing requested columns (deduplicated, original order preserved)."""
+    existing_set = set(existing_columns)
+    return [col for col in dict.fromkeys(requested_columns) if col not in existing_set]
 
 
 def formula_generator(variables: List[str], formula_type: str = "additive") -> str:
@@ -559,13 +568,10 @@ def _build_projected_model_matrix(
         if isinstance(formula, str)
         else formula if isinstance(formula, list) else []
     )
-    # TODO: Replace this hard-coded regex with a shared
-    # constant from the NA indicator naming convention in
-    # data_transformation.py / add_na_indicator().
     expected_na_indicators: set[str] = {
         token
         for formula_item in formula_items
-        for token in re.findall(r"\b_is_na_[A-Za-z0-9_]+\b", formula_item)
+        for token in re.findall(NA_INDICATOR_TOKEN_PATTERN, formula_item)
     }
     for indicator in expected_na_indicators:
         if indicator not in combined.columns:
@@ -820,9 +826,17 @@ def build_design_matrix(
         )
 
     # -- Step 2: Reindex DataFrame to stored columns (raw holdout path) ----
-    # TODO: Log a warning when columns are missing — unseen
-    # categorical levels in holdout data are silently zero-filled here.
     if isinstance(combined_matrix, pd.DataFrame) and project_to_columns is not None:
+        missing_projection_columns = _ordered_unique_missing_columns(
+            project_to_columns, combined_matrix.columns
+        )
+        if missing_projection_columns:
+            logger.warning(
+                "build_design_matrix: holdout data is missing %d fit-time "
+                "column(s); zero-filling unseen columns: %s",
+                len(missing_projection_columns),
+                missing_projection_columns,
+            )
         combined_matrix = combined_matrix.reindex(
             columns=project_to_columns, fill_value=0
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ matplotlib.use("Agg", force=True)
 
 import plotly.io as pio  # noqa: E402
 import pytest  # noqa: E402
+from balance.testutil import _SKLEARN_1_4_AVAILABLE  # noqa: E402
 
 # Force plotly to use a non-interactive renderer so tests don't open a browser.
 pio.renderers.default = "json"
@@ -28,19 +29,6 @@ pio.renderers.default = "json"
 # warnings in CI output.  By deselecting at collection time the tests simply
 # disappear from the run — no warnings, no noise.
 # ---------------------------------------------------------------------------
-
-
-def _has_sklearn_1_4() -> bool:
-    """Return True if scikit-learn >= 1.4 is available."""
-    try:
-        import sklearn
-
-        return tuple(int(x) for x in sklearn.__version__.split(".")[:2]) >= (1, 4)
-    except Exception:
-        return False
-
-
-_SKLEARN_1_4_AVAILABLE: bool = _has_sklearn_1_4()
 
 
 def pytest_collection_modifyitems(

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -16,24 +16,15 @@ from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
+import pytest
 from balance.balance_frame import BalanceFrame
 from balance.datasets import load_data
 from balance.sample_class import Sample
 from balance.sample_frame import SampleFrame
-from balance.testutil import BalanceTestCase
+from balance.testutil import _SKLEARN_1_4_AVAILABLE, BalanceTestCase
 from balance.util import _assert_type
 from balance.weighting_methods.ipw import ipw as ipw_func
 from scipy.special import expit
-
-
-def _has_sklearn_1_4() -> bool:
-    """Return True if scikit-learn >= 1.4 is available."""
-    try:
-        import sklearn
-
-        return tuple(int(x) for x in sklearn.__version__.split(".")[:2]) >= (1, 4)
-    except Exception:
-        return False
 
 
 class TestBalanceFrameConstruction(BalanceTestCase):
@@ -2960,10 +2951,8 @@ class TestBalanceFrameSklearnLikeApi(BalanceTestCase):
         )
         np.testing.assert_allclose(adjusted_weights, expected.to_numpy())
 
-    @unittest.skipUnless(
-        bool(_has_sklearn_1_4()),
-        "requires scikit-learn >= 1.4",
-    )
+    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    @unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires scikit-learn >= 1.4")
     def test_use_model_matrix_false_recompute_matches_fit_preprocessing(self) -> None:
         from sklearn.ensemble import HistGradientBoostingClassifier
 

--- a/tests/test_e2e_from_tutorials.py
+++ b/tests/test_e2e_from_tutorials.py
@@ -28,19 +28,7 @@ import pytest
 from balance import load_data, Sample
 from balance.balance_frame import BalanceFrame
 from balance.sample_frame import SampleFrame
-
-
-def _has_sklearn_1_4() -> bool:
-    """Return True if scikit-learn >= 1.4 is available."""
-    try:
-        import sklearn
-
-        return tuple(int(x) for x in sklearn.__version__.split(".")[:2]) >= (1, 4)
-    except Exception:
-        return False
-
-
-_SKLEARN_1_4_AVAILABLE: bool = _has_sklearn_1_4()
+from balance.testutil import _SKLEARN_1_4_AVAILABLE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ipw.py
+++ b/tests/test_ipw.py
@@ -13,12 +13,15 @@ from __future__ import (
     unicode_literals,
 )
 
+import unittest
+
 import balance.testutil
 import numpy as np
 import pandas as pd
 import pytest
 from balance import util as balance_util
 from balance.sample_class import Sample
+from balance.testutil import _SKLEARN_1_4_AVAILABLE
 from balance.weighting_methods import ipw as balance_ipw
 from scipy.sparse import csr_matrix, issparse
 from sklearn.ensemble import HistGradientBoostingClassifier, RandomForestClassifier
@@ -336,6 +339,7 @@ class TestIPW(
             )
 
     @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    @unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires sklearn >= 1.4")
     def test_ipw_use_model_matrix_false_preserves_categoricals(self) -> None:
         """Raw-covariate IPW preserves categorical dtype for native sklearn categorical support."""
 
@@ -397,8 +401,6 @@ class TestIPW(
         )
         self.assertEqual(len(result_no_indicator["weight"]), len(sample))
 
-    # pyre-ignore[56]: Pyre cannot infer type of custom pytest mark
-    @pytest.mark.requires_sklearn_1_4
     def test_ipw_use_model_matrix_false_raises_on_old_sklearn(self) -> None:
         """ValueError is raised when sklearn < 1.4 and categorical columns are present."""
         from unittest.mock import patch
@@ -436,8 +438,8 @@ class TestIPW(
             self.assertIn("scikit-learn >= 1.4", str(ctx.exception))
             self.assertIn("1.3.2", str(ctx.exception))
 
-    # pyre-ignore[56]: Pyre cannot infer type of custom pytest mark
-    @pytest.mark.requires_sklearn_1_4
+    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    @unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires sklearn >= 1.4")
     def test_ipw_use_model_matrix_false_no_error_on_new_sklearn(self) -> None:
         """No version error when sklearn >= 1.4 and categorical columns are present."""
         from unittest.mock import patch

--- a/tests/test_util_data_transformation.py
+++ b/tests/test_util_data_transformation.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import re
 from unittest.mock import patch
 
 import balance.testutil
@@ -21,6 +22,7 @@ from balance.utils.data_transformation import (
     drop_na_rows,
     fct_lump,
     fct_lump_by,
+    NA_INDICATOR_TOKEN_PATTERN,
     qcut,
     quantize,
     row_pairwise_diffs,
@@ -30,6 +32,12 @@ from balance.utils.data_transformation import (
 class TestUtil(
     balance.testutil.BalanceTestCase,
 ):
+    def test_na_indicator_token_pattern_boundaries(self) -> None:
+        """Pattern should capture complete _is_na_ tokens and avoid partial matches."""
+        text = "x + _is_na_age + foo_is_na_city + _is_na_income_2020 + _is_na_z9x"
+        matches = re.findall(NA_INDICATOR_TOKEN_PATTERN, text)
+        self.assertEqual(matches, ["_is_na_age", "_is_na_income_2020", "_is_na_z9x"])
+
     def test_add_na_indicator(self) -> None:
         """Test addition of NA indicator columns to DataFrames.
 

--- a/tests/test_util_model_matrix.py
+++ b/tests/test_util_model_matrix.py
@@ -765,6 +765,72 @@ class TestBuildProjectedModelMatrix(
         )
         self.assertIsNotNone(result["fit_scaler"])
 
+    def test_build_design_matrix_warns_on_missing_projection_columns(self) -> None:
+        """Raw holdout projection should warn and zero-fill fit-time columns that are missing."""
+        sample_df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        target_df = pd.DataFrame({"a": [5.0, 6.0], "b": [7.0, 8.0]})
+        with self.assertLogs("balance", level="WARNING") as cm:
+            result = build_design_matrix(
+                sample_df,
+                target_df,
+                use_model_matrix=False,
+                na_action="add_indicator",
+                project_to_columns=["a", "b", "c"],
+            )
+
+        self.assertTrue(
+            any("zero-filling unseen columns" in msg for msg in cm.output),
+            f"Expected missing-column warning, got: {cm.output}",
+        )
+        combined_matrix = result["combined_matrix"]
+        self.assertIsInstance(combined_matrix, pd.DataFrame)
+        self.assertListEqual(result["columns"], ["a", "b", "c"])
+        self.assertTrue((combined_matrix["c"] == 0).all())
+
+    def test_build_design_matrix_missing_projection_warns_once_per_column(self) -> None:
+        """Missing-column warning should de-duplicate repeated requested columns."""
+        sample_df = pd.DataFrame({"a": [1.0], "b": [3.0]})
+        target_df = pd.DataFrame({"a": [5.0], "b": [7.0]})
+        with self.assertLogs("balance", level="WARNING") as cm:
+            build_design_matrix(
+                sample_df,
+                target_df,
+                use_model_matrix=False,
+                na_action="add_indicator",
+                project_to_columns=["a", "missing_x", "missing_x", "missing_y"],
+            )
+
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("missing 2 fit-time column(s)", cm.output[0])
+        self.assertIn("['missing_x', 'missing_y']", cm.output[0])
+
+    def test_build_design_matrix_no_warning_when_projection_columns_present(
+        self,
+    ) -> None:
+        """No warning should be emitted when all requested projection columns exist."""
+        sample_df = pd.DataFrame({"a": [1.0], "b": [3.0]})
+        target_df = pd.DataFrame({"a": [5.0], "b": [7.0]})
+        # assertNotWarns is implemented with assertLogs() in testutil.py, so it
+        # catches logger.warning(...) — not only warnings.warn(...). Using
+        # assertLogs/assertNotWarns (rather than assertNoLogs) keeps this test
+        # compatible with Python 3.9, where assertNoLogs is unavailable.
+        self.assertNotWarns(
+            build_design_matrix,
+            sample_df,
+            target_df,
+            use_model_matrix=False,
+            na_action="add_indicator",
+            project_to_columns=["a", "b"],
+        )
+        result = build_design_matrix(
+            sample_df,
+            target_df,
+            use_model_matrix=False,
+            na_action="add_indicator",
+            project_to_columns=["a", "b"],
+        )
+        self.assertListEqual(result["columns"], ["a", "b"])
+
     def test_build_design_matrix_penalty_rescaling_sparse(self) -> None:
         """Test penalty rescaling on sparse matrix (lines 842-844)."""
         sample_df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})


### PR DESCRIPTION
Summary:
Improves `build_design_matrix` diagnostics for the raw-covariate holdout projection path, consolidates the shared NA-indicator token parsing, and centralizes the `sklearn>=1.4` test-gating helper.

**`build_design_matrix` / holdout projection**

- Centralize NA-indicator token naming and parsing via `NA_INDICATOR_PREFIX` and `NA_INDICATOR_TOKEN_PATTERN` in `data_transformation.py`, and reuse that pattern in `model_matrix.py` formula parsing. Removes duplicated hard-coded regex.
- In raw-covariate holdout projection (`use_model_matrix=False` with `project_to_columns=...`), emit a logger warning listing fit-time columns missing from the holdout input *before* zero-fill reindexing, so unseen holdout features are explicit instead of silent.
- De-duplicate and order-preserve the reported missing columns so repeated requests don't produce redundant names.

**`sklearn>=1.4` test-helper centralization**

- Define `_has_sklearn_1_4()` and `_SKLEARN_1_4_AVAILABLE` once in `balance/testutil.py` and import from there in `test_ipw.py`, `test_balance_frame.py`, `test_e2e_from_tutorials.py`, and `conftest.py` (removes ~40 lines of duplicated boilerplate).
- The two-guard pattern (`pytest.mark.requires_sklearn_1_4` + `unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, ...)`) is preserved — the pytest marker deselects under pytest via `conftest.py`, and `skipUnless` is the fallback when the test suite is executed under a non-pytest (unittest) runner. The rationale is documented both on the helper in `testutil.py` and in `CLAUDE.md`.

**Tests**

- New `test_build_design_matrix_missing_projection_warns_once_per_column` asserts a single, de-duplicated warning is emitted (via `assertLogs("balance", level="WARNING")`).
- New `test_build_design_matrix_no_warning_when_projection_columns_present` uses the project's `assertNotWarns` helper, which is implemented on top of `assertLogs()` in `testutil.py` and therefore catches `logger.warning(...)` (not only `warnings.warn(...)`). `assertNotWarns` is used rather than Python 3.10's `assertNoLogs` so the test stays compatible with Python 3.9 (the minimum supported by `pyproject.toml`).
- CHANGELOG entry for the new projection diagnostics.

Differential Revision: D101225948


