### PR TITLE
Strip unused pyre-fixme/pyre-ignore + add missing sklearn-1.4 skipUnless (#425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,27 @@
     is enabled, runtime annotation introspection changes (for example,
     `__annotations__` become postponed/stringized).
 
+- **Added poststratify fit metadata for weight reconstruction**
+  - `poststratify(..., store_fit_metadata=True)` now stores fit-time
+    artifacts in its returned model dictionary, including cell-ratio
+    tables, selected variables, NA handling mode, and training design
+    weights.
+  - Direct weighting-method calls keep the default
+    `store_fit_metadata=False` (minimal model payload), while
+    `BalanceFrame.fit(method="poststratify")` enables metadata storage
+    by default for `predict_weights()` workflows.
+  - `BalanceFrame.predict_weights()` now supports fitted
+    `method="poststratify"` models and reconstructs weights from stored
+    cell ratios with the same trimming behavior used at fit time.
+  - `store_fit_metadata` is now an explicit argument on
+    `poststratify(...)`; non-boolean values raise `TypeError`, and
+    unknown kwargs raise `TypeError` to prevent silent misconfiguration.
+  - When `store_fit_metadata=True`, `transformations` must be pickleable;
+    pass `store_fit_metadata=False` if using non-pickleable callables
+    such as lambdas.
+  - `poststratify(..., store_fit_metadata=False)` remains available for
+    minimal model payloads when weight reconstruction is not needed.
+
 ## Breaking Changes
 
 - **Changed `id_column` to return the column name (`str`)** on `SampleFrame`,
@@ -134,6 +155,19 @@
   - Explicitly setting `store_fit_metadata=True` with `na_action='drop'` now
     raises `ValueError` with guidance to use `na_action='add_indicator'`.
 
+- **`poststratify(..., store_fit_metadata)` defaults differ by entry point**
+  - Direct weighting-method calls now default to
+    `poststratify(..., store_fit_metadata=False)`, preserving the
+    historical minimal model payload.
+  - `BalanceFrame.fit(method="poststratify")` now sets
+    `store_fit_metadata=True` by default so `predict_weights()` can
+    reconstruct poststratify weights from fit artifacts.
+  - Unknown kwargs to `poststratify(...)` now raise `TypeError` (instead
+    of being ignored), and `store_fit_metadata` must be a boolean.
+  - **Migration:** if you rely on persisted poststratify model artifacts
+    from direct `poststratify(...)` calls, pass
+    `store_fit_metadata=True` explicitly.
+
 ## Tests
 
 - Added coverage for:
@@ -152,6 +186,10 @@
   - additional fitted-IPW workflow edge cases: default-model fit metadata
     storage, raw-covariate fit-matrix persistence (`use_model_matrix=False`),
     empty-input validation, and near-separation weight-stability checks.
+  - poststratify TODO scenarios: chained IPW->poststratify adjustment behavior,
+    transformations/transformations_drop interactions, explicit variables-vs-transformations
+    precedence, ASMD convergence on poststratification variables, outcome-shift
+    checks, and continuous-variable edge-case error handling.
 
 # 0.19.0 (2026-04-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,15 @@
   - Calling `predict_weights()` on CBPS models without fit metadata now raises
     actionable guidance to fit with metadata enabled.
 
+- **Cleaned up legacy Python 2 compatibility imports in weighting methods**
+  - Replaced obsolete `__future__` compatibility imports with
+    `from __future__ import annotations` in `adjust_null`, `cbps`,
+    `poststratify`, and `rake`.
+  - Removes dead compatibility scaffolding while preserving algorithmic
+    behavior; note that, on supported Python versions where this future import
+    is enabled, runtime annotation introspection changes (for example,
+    `__annotations__` become postponed/stringized).
+
 ## Breaking Changes
 
 - **Changed `id_column` to return the column name (`str`)** on `SampleFrame`,

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -32,6 +32,7 @@ from balance.typing import FilePathOrBuffer
 from balance.util import (
     _assert_type,
     _detect_high_cardinality_features,
+    _safe_fillna_and_infer,
     HighCardinalityFeature,
 )
 from balance.utils.file_utils import _to_download
@@ -1058,9 +1059,17 @@ class BalanceFrame:
             ``store_fit_metadata=True`` by default so ``predict_weights()``
             can reconstruct CBPS scoring artifacts.  Pass
             ``store_fit_metadata=False`` to opt out.
+            For the built-in poststratify method, ``fit()`` enables
+            ``store_fit_metadata=True`` by default so ``predict_weights()``
+            can reconstruct poststratification cell-ratio artifacts, while
+            direct ``adjust(method='poststratify')`` remains metadata-light
+            unless ``store_fit_metadata=True`` is passed explicitly.
         """
         from balance.weighting_methods.cbps import cbps as built_in_cbps
         from balance.weighting_methods.ipw import ipw as built_in_ipw
+        from balance.weighting_methods.poststratify import (
+            poststratify as built_in_poststratify,
+        )
 
         resolved_method = self._resolve_adjustment_function(method)
         if resolved_method is built_in_ipw:
@@ -1098,6 +1107,8 @@ class BalanceFrame:
                     stacklevel=2,
                 )
                 kwargs["store_fit_metadata"] = False
+        if resolved_method is built_in_poststratify:
+            kwargs.setdefault("store_fit_metadata", True)
 
         if isinstance(target, (SampleFrame, BalanceFrame)):
             result = self.set_target(target, inplace=False).adjust(
@@ -1345,6 +1356,7 @@ class BalanceFrame:
         data: pd.DataFrame | pd.Series,
         index: pd.Index,
         caller: str,
+        method_name: str = "ipw",
     ) -> pd.DataFrame | pd.Series:
         """Align a DataFrame or Series to the given index.
 
@@ -1356,16 +1368,17 @@ class BalanceFrame:
             if len(data.index) == len(index) and not data.index.equals(index):
                 if not (data.index.isin(index).all() and index.isin(data.index).all()):
                     raise ValueError(
-                        f"Stored IPW {caller} output index does not match the current "
-                        "data index. Re-fit with BalanceFrame.fit(method='ipw') or "
+                        f"Stored {method_name.upper()} {caller} output index does not "
+                        "match the current data index. Re-fit with "
+                        f"BalanceFrame.fit(method='{method_name}') or "
                         "attach a model trained on matching rows."
                     )
             return data.reindex(index)
         if len(data.index) != len(index):
             raise ValueError(
-                f"Stored IPW {caller} output cannot be aligned to the current "
-                "index because lengths differ. Re-fit with "
-                "BalanceFrame.fit(method='ipw') to refresh stored artifacts."
+                f"Stored {method_name.upper()} {caller} output cannot be aligned to "
+                "the current index because lengths differ. Re-fit with "
+                f"BalanceFrame.fit(method='{method_name}') to refresh stored artifacts."
             )
         return data.set_axis(index, axis=0)
 
@@ -1920,12 +1933,17 @@ class BalanceFrame:
           trimming, and design weights) to reproduce fitted responder weights.
         - **CBPS**: rebuilds the CBPS scoring artifacts from stored metadata
           and supports both in-place and ``data=...`` holdout scoring.
+        - **Poststratify**: reconstructs in-place responder weights from
+          stored cell-ratio metadata; ``data=...`` holdout scoring is not yet
+          supported for poststratify.
         - **Other methods**: not yet supported — will raise with guidance.
 
         Args:
             data: An optional BalanceFrame whose sample covariates are scored
                 using this object's stored model.  Must have matching covariate
-                column names and a target set.
+                column names and a target set. Supported for IPW and CBPS;
+                poststratify currently supports only in-place scoring
+                (``data=None``).
 
         Returns:
             A Series of predicted responder weights.
@@ -2026,36 +2044,13 @@ class BalanceFrame:
             return self._predict_weights_ipw(model)
         if method == "cbps":
             return self._predict_weights_cbps(model)
-
-        # TODO: Add predict_weights dispatch for other methods.
-        #
-        # Step 3 — Store fit artifacts in each weighting method:
-        #   - poststratify.py: Save the cell-ratio table
-        #     (`combined["weight"]` at line 194), the variable list, and
-        #     na_action in the returned model dict. Currently only
-        #     `{"method": "poststratify"}` is returned. ~15 lines.
-        #   - rake.py: Save the fitted contingency table (`m_fit`), the
-        #     variable lists, and category-to-index mappings. Currently
-        #     `m_fit` is discarded after per-row weight assignment.
-        #     More complex due to N-dimensional array indexing. ~25 lines.
-        #
-        # Step 4 — Implement _predict_weights_* for each method:
-        #   - _predict_weights_poststratify(model): Join current sample rows
-        #     on the stored cell-ratio table by cell variables, multiply
-        #     ratio by design weight, normalize to target total. ~20 lines.
-        #   - _predict_weights_rake(model): Look up each row's cell in the
-        #     stored fitted N-dimensional contingency table, compute weight
-        #     ratio (fitted_cell / original_cell), multiply by design
-        #     weight. Same logic as rake.py lines 229-239. ~30 lines.
-        #
-        # Note: shared preprocessing is already extracted into
-        # build_design_matrix() in utils/model_matrix.py, used by both
-        # _compute_ipw_matrices() and ipw().
+        if method == "poststratify":
+            return self._predict_weights_poststratify(model)
 
         raise ValueError(
             f"predict_weights() is not yet supported for method '{method}'. "
-            "Currently only 'ipw' and 'cbps' are supported. Use adjust() to obtain "
-            "weights directly for other methods."
+            "Currently only 'ipw', 'cbps', and 'poststratify' are supported. "
+            "Use adjust() to obtain weights directly for other methods."
         )
 
     def _resolve_ipw_link(self, model: dict[str, Any]) -> np.ndarray:
@@ -2441,6 +2436,177 @@ class BalanceFrame:
         weights = weights / original_sum * float(np.sum(target_weights))
         return pd.Series(weights, index=bf._sf_sample.df.index).rename(
             getattr(bf._sf_sample.weight_series, "name", None)
+        )
+
+    def _predict_weights_poststratify(self, model: dict[str, Any]) -> pd.Series:
+        """Poststratify-specific weight reconstruction from stored fit artifacts."""
+        required = (
+            "variables",
+            "variables_before_transformations",
+            "na_action",
+            "strict_matching",
+            "transformations",
+            "transformations_drop",
+            "weight_trimming_mean_ratio",
+            "weight_trimming_percentile",
+            "keep_sum_of_weights",
+            "cell_weight_ratio",
+        )
+        missing = [key for key in required if key not in model]
+        if missing:
+            raise ValueError(
+                "Poststratify model is missing fit-time metadata "
+                f"({missing}) for predict_weights(). "
+                "Call BalanceFrame.fit(method='poststratify') or run "
+                "poststratify(..., store_fit_metadata=True)."
+            )
+
+        variables = model.get("variables")
+        input_variables = model.get("variables_before_transformations")
+        if not isinstance(variables, list) or not all(
+            isinstance(v, str) for v in variables
+        ):
+            raise ValueError(
+                "Poststratify model has invalid 'variables' metadata for "
+                "predict_weights()."
+            )
+        if not isinstance(input_variables, list) or not all(
+            isinstance(v, str) for v in input_variables
+        ):
+            raise ValueError(
+                "Poststratify model has invalid "
+                "'variables_before_transformations' metadata for predict_weights()."
+            )
+
+        ratio_series = model.get("cell_weight_ratio")
+        if not isinstance(ratio_series, pd.Series):
+            raise ValueError(
+                "Poststratify model is missing cell-weight ratio metadata for "
+                "predict_weights()."
+            )
+
+        current_sample_weights = self._sf_sample.df_weights.iloc[:, 0]
+        current_target_weights = _assert_type(self._sf_target).df_weights.iloc[:, 0]
+
+        sample_weights = model.get("training_sample_weights")
+        if (
+            not isinstance(sample_weights, pd.Series)
+            or len(sample_weights) != len(current_sample_weights)
+            or not sample_weights.index.equals(current_sample_weights.index)
+        ):
+            raise ValueError(
+                "Poststratify predict_weights() requires compatible "
+                "fit-time sample design weights in model['training_sample_weights']. "
+                "Re-fit with BalanceFrame.fit(method='poststratify') and "
+                "store_fit_metadata=True."
+            )
+
+        target_weights = model.get("training_target_weights")
+        if (
+            not isinstance(target_weights, pd.Series)
+            or len(target_weights) != len(current_target_weights)
+            or not target_weights.index.equals(current_target_weights.index)
+        ):
+            raise ValueError(
+                "Poststratify predict_weights() requires compatible "
+                "fit-time target design weights in model['training_target_weights']. "
+                "Re-fit with BalanceFrame.fit(method='poststratify') and "
+                "store_fit_metadata=True."
+            )
+
+        sample_covars = self._sf_sample.df_covars
+        target_covars = _assert_type(self._sf_target).df_covars
+        for column in input_variables:
+            if (
+                column not in sample_covars.columns
+                or column not in target_covars.columns
+            ):
+                raise ValueError(
+                    "Poststratify predict_weights() cannot find required covariate "
+                    f"'{column}' in both sample and target."
+                )
+        sample_df = sample_covars.loc[:, input_variables]
+        target_df = target_covars.loc[:, input_variables]
+
+        na_action = cast(str, model.get("na_action", "add_indicator"))
+        if na_action == "drop":
+            sample_df, sample_weights = balance_util.drop_na_rows(
+                sample_df, sample_weights, "sample"
+            )
+            target_df, target_weights = balance_util.drop_na_rows(
+                target_df, target_weights, "target"
+            )
+        elif na_action == "add_indicator":
+            sample_df = pd.DataFrame(_safe_fillna_and_infer(sample_df, "__NaN__"))
+            target_df = pd.DataFrame(_safe_fillna_and_infer(target_df, "__NaN__"))
+        else:
+            raise ValueError(
+                "Poststratify model has invalid na_action metadata "
+                f"'{na_action}' for predict_weights()."
+            )
+
+        sample_df, _target_df = balance_adjustment.apply_transformations(
+            (sample_df, target_df),
+            transformations=model["transformations"],
+            drop=bool(model["transformations_drop"]),
+        )
+        for column in variables:
+            if column not in sample_df.columns:
+                raise ValueError(
+                    "Poststratify transform output is missing stored variable "
+                    f"'{column}' required for predict_weights()."
+                )
+        sample_df = sample_df.loc[:, variables]
+
+        ratio_name = "_cell_ratio"
+        while ratio_name in sample_df.columns:
+            ratio_name = f"{ratio_name}_tmp"
+        sample_with_ratio = sample_df.join(
+            ratio_series.rename(ratio_name), on=variables
+        )
+        missing_ratio = sample_with_ratio[ratio_name].isna()
+        if bool(missing_ratio.any()):
+            if bool(model.get("strict_matching", True)):
+                raise ValueError(
+                    "Poststratify predict_weights() found sample cells missing from "
+                    "stored fit-time cell ratios. Re-fit with compatible cells or "
+                    "fit with strict_matching=False."
+                )
+            logger.warning(
+                "Poststratify predict_weights() encountered sample cells missing from "
+                "stored fit-time cell ratios; assigning zero weights to those rows."
+            )
+            sample_with_ratio[ratio_name] = _safe_fillna_and_infer(
+                sample_with_ratio[ratio_name], 0
+            )
+
+        raw_weights = sample_with_ratio[ratio_name] * sample_weights
+        target_total = raw_weights.sum()
+        trimmed = balance_adjustment.trim_weights(
+            raw_weights,
+            target_sum_weights=target_total,
+            weight_trimming_mean_ratio=model["weight_trimming_mean_ratio"],
+            weight_trimming_percentile=model["weight_trimming_percentile"],
+            keep_sum_of_weights=bool(model["keep_sum_of_weights"]),
+        )
+        if na_action == "drop":
+            # Align back to the full fit-time sample index so rows dropped for
+            # missing covariates retain NaN weights, matching adjust() behavior.
+            full_index = current_sample_weights.index
+            trimmed_full = pd.Series(np.nan, index=full_index, dtype=float).rename(
+                trimmed.name
+            )
+            trimmed_full.loc[trimmed.index] = trimmed.to_numpy()
+            trimmed = trimmed_full
+        weight_name = getattr(_assert_type(self.weight_series), "name", None)
+        return cast(
+            pd.Series,
+            self._align_to_index(
+                trimmed,
+                self._sf_sample.df.index,
+                caller="predict_weights()",
+                method_name="poststratify",
+            ).rename(weight_name),
         )
 
     @property

--- a/balance/weighting_methods/adjust_null.py
+++ b/balance/weighting_methods/adjust_null.py
@@ -5,14 +5,7 @@
 
 # pyre-strict
 
-# TODO: remove dead Python 2 __future__ imports, keep only annotations
-from __future__ import (
-    absolute_import,
-    annotations,
-    division,
-    print_function,
-    unicode_literals,
-)
+from __future__ import annotations
 
 import logging
 

--- a/balance/weighting_methods/cbps.py
+++ b/balance/weighting_methods/cbps.py
@@ -5,14 +5,7 @@
 
 # pyre-strict
 
-# TODO: remove dead Python 2 __future__ imports, keep only annotations
-from __future__ import (
-    absolute_import,
-    annotations,
-    division,
-    print_function,
-    unicode_literals,
-)
+from __future__ import annotations
 
 import logging
 from typing import Any, cast

--- a/balance/weighting_methods/poststratify.py
+++ b/balance/weighting_methods/poststratify.py
@@ -5,8 +5,7 @@
 
 # pyre-strict
 
-# TODO: replace with "from __future__ import annotations" and remove dead Python 2 imports
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import annotations
 
 import logging
 import re

--- a/balance/weighting_methods/poststratify.py
+++ b/balance/weighting_methods/poststratify.py
@@ -8,8 +8,9 @@
 from __future__ import annotations
 
 import logging
+import pickle
 import re
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import pandas as pd
 from balance import adjustment as balance_adjustment, util as balance_util
@@ -19,20 +20,13 @@ from patsy.highlevel import ModelDesc
 logger: logging.Logger = logging.getLogger(__package__)
 
 
-# TODO: Add tests for all arguments of function
-# TODO: Store fit artifacts for predict_weights() support.
-# Save the cell-ratio table, the variable list, and na_action in the
-# returned model dict. Currently only {"method": "poststratify"} is
-# returned. Then implement `_predict_weights_poststratify()` in
-# balance_frame.py: join sample rows on stored cell-ratio table,
-# multiply ratio by design weight, normalize to target total. ~45 lines total.
 def poststratify(
     sample_df: pd.DataFrame,
     sample_weights: pd.Series,
     target_df: pd.DataFrame,
     target_weights: pd.Series,
     variables: Optional[List[str]] = None,
-    transformations: Optional[str] = "default",
+    transformations: Union[Dict[str, Callable[..., Any]], str, None] = "default",
     transformations_drop: bool = True,
     strict_matching: bool = True,
     na_action: str = "add_indicator",
@@ -41,8 +35,9 @@ def poststratify(
     keep_sum_of_weights: bool = True,
     *args: Any,
     formula: Optional[Union[str, List[str]]] = None,
+    store_fit_metadata: bool = False,
     **kwargs: Any,
-) -> Dict[str, Union[pd.Series, Dict[str, str]]]:
+) -> Dict[str, Any]:
     """
     Perform cell-based post-stratification to adjust sample weights so that the sample matches the joint distribution of, one or more, specified variables in the target population.
 
@@ -57,7 +52,11 @@ def poststratify(
         target_df (pd.DataFrame): DataFrame representing the target population.
         target_weights (pd.Series): Design weights for the target.
         variables (Optional[List[str]], optional): List of variables to define post-stratification cells. If None, uses the intersection of columns in sample_df and target_df.
-        transformations (str, optional): Transformations to apply to data before fitting the model. Default is "default". See `balance.adjustment.apply_transformations`.
+        transformations (Dict[str, Callable[..., Any]] | str | None, optional):
+            Transformations to apply to data before fitting the model.
+            Accepts the same forms as
+            :func:`balance.adjustment.apply_transformations`. Defaults to
+            ``"default"``.
         transformations_drop (bool, optional): If True, drops variables not affected by transformations. Default is True.
         strict_matching (bool, optional): If True, requires all sample cells to be present in the target. If False, cells missing in the target are assigned weight 0 (and a warning is raised). Default is True.
         na_action (str, optional): How to handle missing values. Use
@@ -95,12 +94,25 @@ def poststratify(
             not supported. Mutually exclusive with non-empty
             ``variables``.
         *args: Additional positional arguments (currently unused).
-        **kwargs: Additional keyword arguments (currently unused).
+        store_fit_metadata (bool, optional): Whether to include fit-time
+            artifacts in the returned model dictionary so
+            ``BalanceFrame.predict_weights()`` can reconstruct
+            poststratification weights. Defaults to ``False``.
+        **kwargs: Reserved for backward compatibility. Unknown keys raise
+            ``TypeError`` to avoid silently ignoring typos.
 
     Returns:
         dict:
-            weight (pd.Series): Final weights for the sample, summing to the target's total weight.
-            model (dict): Description of the adjustment method used.
+            weight (pd.Series): Final weights for the sample. With
+                ``strict_matching=True`` (the default), every sample cell is
+                also present in the target and the weights sum to the target's
+                total weight. With ``strict_matching=False``, sample rows
+                whose cell is absent from the target are assigned weight 0,
+                so the weights sum to the total target weight restricted to
+                cells that are present in the sample (i.e. target-only cells
+                are effectively excluded).
+            model (dict): Description of the adjustment method used, with
+                optional fit metadata when ``store_fit_metadata=True``.
 
     Raises:
         ValueError: If strict_matching is True and some sample cells are missing in the target.
@@ -171,15 +183,40 @@ def poststratify(
 
     if variables is not None and len(variables) == 0:
         variables = None
+    explicit_cell_selection = formula is not None or variables is not None
 
     if formula is not None and variables is not None:
         raise ValueError("Specify only one of `variables` or `formula`.")
+
+    if not isinstance(store_fit_metadata, bool):
+        raise TypeError("`store_fit_metadata` must be a bool.")
+    if kwargs:
+        unknown = ", ".join(sorted(kwargs.keys()))
+        raise TypeError(f"Unexpected keyword arguments: {unknown}")
+
+    original_sample_weights: Optional[pd.Series] = (
+        sample_weights.copy() if store_fit_metadata else None
+    )
+    original_target_weights: Optional[pd.Series] = (
+        target_weights.copy() if store_fit_metadata else None
+    )
 
     if formula is not None:
         variables = _variables_from_formula(sample_df, target_df, formula)
 
     variables = balance_util.choose_variables(sample_df, target_df, variables=variables)
+    variables_before_transformations = list(variables)
     logger.debug(f"Join variables for sample and target: {variables}")
+
+    transformations_to_apply = transformations
+    # When cell-definition variables are explicitly set (via `variables` or
+    # `formula`), ensure cell-definition precedence: only transformations on
+    # selected variables are applied. Transformations for out-of-scope keys are
+    # ignored so they cannot be treated as additions.
+    if explicit_cell_selection and isinstance(transformations_to_apply, dict):
+        selected = set(variables)
+        filtered = {k: v for k, v in transformations_to_apply.items() if k in selected}
+        transformations_to_apply = filtered if filtered else None
 
     sample_df = sample_df.loc[:, variables]
     target_df = target_df.loc[:, variables]
@@ -197,9 +234,14 @@ def poststratify(
     else:
         raise ValueError("`na_action` must be 'add_indicator' or 'drop'")
 
+    if store_fit_metadata and transformations_to_apply == "default":
+        transformations_to_apply = balance_adjustment.default_transformations(
+            (sample_df, target_df)
+        )
+
     sample_df, target_df = balance_adjustment.apply_transformations(
         (sample_df, target_df),
-        transformations=transformations,
+        transformations=transformations_to_apply,
         drop=transformations_drop,
     )
     variables = list(sample_df.columns)
@@ -244,9 +286,45 @@ def poststratify(
         keep_sum_of_weights=keep_sum_of_weights,
     ).rename(raw_weights.name)
 
+    model: Dict[str, Any] = {"method": "poststratify"}
+    if store_fit_metadata:
+        if original_sample_weights is None or original_target_weights is None:
+            raise RuntimeError("Unexpected missing stored training weights.")
+        # Persisting non-pickleable callables (e.g., lambdas/closures) breaks
+        # serialization workflows for fitted objects. Require picklable
+        # transformations when fit metadata storage is enabled.
+        try:
+            # @lint-ignore PYTHONPICKLEISBAD - serializability check only; no untrusted deserialization
+            pickle.dumps(transformations_to_apply)
+        except Exception as exc:
+            raise ValueError(
+                "`transformations` must be pickleable when "
+                "store_fit_metadata=True. Pass store_fit_metadata=False to "
+                "disable fit-artifact persistence for this run."
+            ) from exc
+        model.update(
+            {
+                "variables": variables,
+                "variables_before_transformations": variables_before_transformations,
+                "na_action": na_action,
+                "strict_matching": strict_matching,
+                "transformations": transformations_to_apply,
+                "transformations_drop": transformations_drop,
+                "weight_trimming_mean_ratio": weight_trimming_mean_ratio,
+                "weight_trimming_percentile": weight_trimming_percentile,
+                "keep_sum_of_weights": keep_sum_of_weights,
+                "cell_weight_ratio": combined["weight"].copy(),
+                "training_sample_weights": original_sample_weights,
+                "training_target_weights": original_target_weights,
+                "sample_index": sample_df.index.copy(),
+                "target_index": target_df.index.copy(),
+                "store_fit_metadata": True,
+            }
+        )
+
     return {
         "weight": w,
-        "model": {"method": "poststratify"},
+        "model": model,
     }
 
 

--- a/balance/weighting_methods/rake.py
+++ b/balance/weighting_methods/rake.py
@@ -5,8 +5,7 @@
 
 # pyre-strict
 
-# TODO: replace with "from __future__ import annotations" and remove dead Python 2 imports
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import annotations
 
 import itertools
 import logging

--- a/tests/test_adjustment.py
+++ b/tests/test_adjustment.py
@@ -88,7 +88,7 @@ class TestAdjustment(balance.testutil.BalanceTestCase):
             TypeError,
             "weights must be np.array, list, tuple, or pd.Series, are of type:.*",
         ):
-            # pyre-ignore[6]: Testing error handling with intentionally wrong type
+            # pyrefly: ignore [bad-argument-type]
             trim_weights("Strings don't get trimmed", weight_trimming_mean_ratio=1)
 
         list_weights = [0.0, 1.0, 2.0]
@@ -540,7 +540,7 @@ class TestAdjustment(balance.testutil.BalanceTestCase):
 
         # Test unknown adjustment method
         with self.assertRaisesRegex(ValueError, "Unknown adjustment method*"):
-            # pyre-ignore[6]: Testing error handling with intentionally wrong type
+            # pyrefly: ignore [bad-argument-type]
             balance.adjustment._find_adjustment_method("some_other_value")
 
     def test_validate_limit_none_input(self) -> None:
@@ -990,7 +990,7 @@ class TestAdjustment(balance.testutil.BalanceTestCase):
         ):
             trim_weights(
                 weights,
-                # pyre-ignore[6]: Intentionally passing wrong type to test error handling
+                # pyrefly: ignore [bad-argument-type]
                 weight_trimming_percentile=(0.1, 0.2, 0.3),  # 3 values - invalid
                 keep_sum_of_weights=False,
             )

--- a/tests/test_ascii_plots.py
+++ b/tests/test_ascii_plots.py
@@ -528,7 +528,8 @@ class TestPlotDistBalanceLibrary(balance.testutil.BalanceTestCase):
             {"df": df, "weight": pd.Series(np.ones(2))},
         ]
         with self.assertRaises(ValueError) as cm:
-            plot_dist(dfs, names=["self"], library="invalid")  # pyre-ignore[6]
+            # pyrefly: ignore [bad-argument-type]
+            plot_dist(dfs, names=["self"], library="invalid")
         self.assertIn("balance", str(cm.exception))
 
 

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -3545,6 +3545,371 @@ class TestBalanceFrameSklearnLikeApi(BalanceTestCase):
         self.assertTrue(np.all(np.isfinite(weights_via_data.to_numpy())))
         self.assertTrue(np.all(weights_via_data.to_numpy() >= 0))
 
+    def test_predict_weights_poststratify_fit_matches_weight_series(self) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(8)],
+                "weight": np.ones(8),
+                "age_group": [
+                    "young",
+                    "young",
+                    "young",
+                    "young",
+                    "old",
+                    "old",
+                    "old",
+                    "old",
+                ],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(8)],
+                "weight": np.ones(8),
+                "age_group": ["young", "old", "old", "old", "old", "old", "old", "old"],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+        )
+        predicted_weights = adjusted.predict_weights()
+        np.testing.assert_allclose(
+            predicted_weights.to_numpy(),
+            _assert_type(adjusted.weight_series).to_numpy(),
+            rtol=1e-6,
+            atol=1e-8,
+        )
+
+    def test_predict_weights_poststratify_requires_fit_metadata(self) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", "young", "old", "old"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", "old", "old", "old"],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+            store_fit_metadata=False,
+        )
+        with self.assertRaisesRegex(ValueError, "missing fit-time metadata"):
+            adjusted.predict_weights()
+
+    def test_predict_weights_poststratify_na_drop_reconstructs(self) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "age_group": ["young", "young", None, "old", "old", None],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "age_group": ["young", "old", "old", "old", None, None],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+            na_action="drop",
+            strict_matching=False,
+        )
+        predicted_weights = adjusted.predict_weights()
+        np.testing.assert_allclose(
+            predicted_weights.to_numpy(),
+            _assert_type(adjusted.weight_series).to_numpy(),
+            rtol=1e-6,
+            atol=1e-8,
+            equal_nan=True,
+        )
+
+    def test_predict_weights_poststratify_na_drop_restores_full_index_with_nans(
+        self,
+    ) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", None, "old", None],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", "old", None, None],
+            }
+        )
+
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+            na_action="drop",
+            strict_matching=False,
+        )
+        predicted_weights = adjusted.predict_weights()
+        self.assertEqual(
+            list(predicted_weights.index), list(adjusted._sf_sample.df.index)
+        )
+        self.assertEqual(int(predicted_weights.isna().sum()), 2)
+        expected_nan_rows = sample_df["age_group"].isna().to_numpy()
+        np.testing.assert_array_equal(
+            predicted_weights.isna().to_numpy(), expected_nan_rows
+        )
+
+    def test_predict_weights_poststratify_missing_cells_strict_matching_false(
+        self,
+    ) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "age_group": ["young", "young", "young", "old", "old", "old"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "age_group": ["young", "old", "old", "old", "old", "old"],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+            strict_matching=False,
+        )
+        model = _assert_type(adjusted.model)
+        ratio = _assert_type(model.get("cell_weight_ratio"))
+        if isinstance(ratio.index, pd.MultiIndex):
+            ratio = ratio.drop(index=("young",), errors="ignore")
+        else:
+            ratio = ratio.drop(index="young", errors="ignore")
+        model["cell_weight_ratio"] = ratio
+        predicted_weights = adjusted.predict_weights()
+        self.assertTrue(
+            np.all(
+                predicted_weights[adjusted._sf_sample.df["age_group"] == "young"] == 0
+            )
+        )
+
+    def test_predict_weights_poststratify_temp_ratio_name_collision(self) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "group": ["a", "a", "b", "b"],
+                "_cell_ratio": ["x", "x", "y", "y"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "group": ["a", "a", "b", "b"],
+                "_cell_ratio": ["x", "x", "y", "y"],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="poststratify",
+            variables=["group", "_cell_ratio"],
+            transformations=None,
+        )
+        predicted_weights = adjusted.predict_weights()
+        np.testing.assert_allclose(
+            predicted_weights.to_numpy(),
+            _assert_type(adjusted.weight_series).to_numpy(),
+            rtol=1e-6,
+            atol=1e-8,
+        )
+
+    def test_predict_weights_poststratify_missing_cells_strict_matching_true_raises(
+        self,
+    ) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", "young", "old", "old"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", "old", "old", "old"],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+            strict_matching=True,
+        )
+        model = _assert_type(adjusted.model)
+        ratio = _assert_type(model.get("cell_weight_ratio"))
+        if isinstance(ratio.index, pd.MultiIndex):
+            ratio = ratio.drop(index=("young",), errors="ignore")
+        else:
+            ratio = ratio.drop(index="young", errors="ignore")
+        model["cell_weight_ratio"] = ratio
+
+        with self.assertRaisesRegex(ValueError, "missing from stored fit-time cell"):
+            adjusted.predict_weights()
+
+    def test_predict_weights_poststratify_invalid_na_action_metadata_raises(
+        self,
+    ) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", "young", "old", "old"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", "old", "old", "old"],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+        )
+        model = _assert_type(adjusted.model)
+        model["na_action"] = "unknown_mode"
+
+        with self.assertRaisesRegex(ValueError, "invalid na_action metadata"):
+            adjusted.predict_weights()
+
+    def test_predict_weights_poststratify_missing_transform_metadata_raises(
+        self,
+    ) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", "young", "old", "old"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", "old", "old", "old"],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+        )
+        model = _assert_type(adjusted.model)
+        model.pop("transformations", None)
+        with self.assertRaisesRegex(ValueError, "missing fit-time metadata"):
+            adjusted.predict_weights()
+
+    def test_predict_weights_poststratify_missing_training_weights_raises(self) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", "young", "old", "old"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "age_group": ["young", "old", "old", "old"],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+        )
+        model = _assert_type(adjusted.model)
+        model.pop("training_sample_weights", None)
+        with self.assertRaisesRegex(
+            ValueError,
+            "fit-time sample design weights",
+        ):
+            adjusted.predict_weights()
+
+    def test_align_to_index_poststratify_error_message_is_method_specific(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "BalanceFrame.fit\\(method='poststratify'\\)",
+        ):
+            self.bf._align_to_index(
+                pd.Series([1.0, 2.0], index=pd.Index(["a", "b"])),
+                pd.Index(["a", "c"]),
+                caller="predict_weights()",
+                method_name="poststratify",
+            )
+
     def test_predict_weights_cbps_requires_fit_metadata(self) -> None:
         adjusted = self.bf.adjust(method="cbps", transformations=None)
         with self.assertRaisesRegex(ValueError, "store_fit_metadata=True"):

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -88,7 +88,8 @@ class TestBalanceFrameConstruction(BalanceTestCase):
     def test_non_sampleframe_responders_raises(self) -> None:
         with self.assertRaises(TypeError):
             BalanceFrame._create(
-                sample="not a SampleFrame",  # pyre-ignore[6]
+                # pyrefly: ignore [bad-argument-type]
+                sample="not a SampleFrame",
                 target=self.tgt_sf,
             )
 
@@ -96,7 +97,8 @@ class TestBalanceFrameConstruction(BalanceTestCase):
         with self.assertRaises(TypeError):
             BalanceFrame._create(
                 sample=self.resp_sf,
-                target=pd.DataFrame(),  # pyre-ignore[6]
+                # pyrefly: ignore [bad-argument-type]
+                target=pd.DataFrame(),
             )
 
 
@@ -518,7 +520,8 @@ class TestBalanceFrameAdjust(BalanceTestCase):
     def test_adjust_invalid_method_type_raises(self) -> None:
         """adjust() with a non-string, non-callable method raises ValueError."""
         with self.assertRaises(ValueError):
-            self.bf.adjust(method=42)  # pyre-ignore[6]
+            # pyrefly: ignore [bad-argument-type]
+            self.bf.adjust(method=42)
 
     def test_adjust_deepcopy_adjusted(self) -> None:
         """Deepcopy of an adjusted BalanceFrame preserves adjustment state."""
@@ -655,7 +658,8 @@ class TestBalanceFrameSetTarget(BalanceTestCase):
     def test_set_target_non_sampleframe_raises(self) -> None:
         bf = BalanceFrame(sample=self.resp_sf)
         with self.assertRaises(TypeError):
-            bf.set_target("not a SampleFrame")  # pyre-ignore[6]
+            # pyrefly: ignore [bad-argument-type]
+            bf.set_target("not a SampleFrame")
 
     def test_set_target_no_overlap_raises(self) -> None:
         bf = BalanceFrame(sample=self.resp_sf)
@@ -2966,7 +2970,7 @@ class TestBalanceFrameSklearnLikeApi(BalanceTestCase):
         )
         np.testing.assert_allclose(adjusted_weights, expected.to_numpy())
 
-    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    @pytest.mark.requires_sklearn_1_4
     @unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires scikit-learn >= 1.4")
     def test_use_model_matrix_false_recompute_matches_fit_preprocessing(self) -> None:
         from sklearn.ensemble import HistGradientBoostingClassifier
@@ -3203,6 +3207,7 @@ class TestBalanceFrameSklearnLikeApi(BalanceTestCase):
         self.assertTrue(isinstance(model.get("training_target_weights"), pd.Series))
 
     @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    @unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires scikit-learn >= 1.4")
     def test_store_fit_matrices_use_model_matrix_false(self) -> None:
         from sklearn.ensemble import HistGradientBoostingClassifier
 
@@ -4170,7 +4175,8 @@ class TestBalanceFrameSetFittedModelValidation(BalanceTestCase):
         """Line 1148: fitted model is not a dict."""
         fitted, resp_sf, tgt_sf = self._make_fitted()
 
-        fitted._adjustment_model = "not_a_dict"  # pyre-ignore[8]
+        # pyrefly: ignore [bad-assignment]
+        fitted._adjustment_model = "not_a_dict"
         holdout = BalanceFrame(
             sample=SampleFrame.from_frame(resp_sf._df.copy()),
             target=SampleFrame.from_frame(tgt_sf._df.copy()),

--- a/tests/test_balancedf.py
+++ b/tests/test_balancedf.py
@@ -218,7 +218,8 @@ class TestBalanceDFOutcomes(BalanceTestCase):
         self.assertTrue(isinstance(BalanceDFOutcomes.df, property))
         # We can no longer call .df() as if it was a function:
         with self.assertRaisesRegex(TypeError, "'DataFrame' object is not callable"):
-            o.df()  # pyre-ignore[29]: Testing property call error
+            # pyrefly: ignore [not-callable]
+            o.df()
         # Here is how we can call it as a function:
         # pyrefly: ignore [not-callable]
         self.assertEqual(BalanceDFOutcomes.df.fget(o), o.df)
@@ -568,7 +569,8 @@ class TestBalanceDFCovars(BalanceTestCase):
         self.assertEqual(BalanceDFOutcomes.df.fget(c), c.df)
         # We can no longer call .df() as if it was a function:
         with self.assertRaisesRegex(TypeError, "'DataFrame' object is not callable"):
-            c.df()  # pyre-ignore[29]: Testing property call error
+            # pyrefly: ignore [not-callable]
+            c.df()
         # NOTE: while the original datatype had integers, the stored df has only floats:
         self.assertEqual(
             c.df,
@@ -611,12 +613,14 @@ class TestBalanceDFWeights(BalanceTestCase):
         # Verify that the @property decorator works properly.
         self.assertTrue(isinstance(BalanceDFWeights.df, property))
         self.assertEqual(
-            BalanceDFWeights.df.fget(w),  # pyre-ignore[29]: Testing property getter
+            # pyrefly: ignore [not-callable]
+            BalanceDFWeights.df.fget(w),
             w.df,
         )
         # We can no longer call .df() as if it was a function:
         with self.assertRaisesRegex(TypeError, "'DataFrame' object is not callable"):
-            w.df()  # pyre-ignore[29]: Testing property call error
+            # pyrefly: ignore [not-callable]
+            w.df()
         # Check values are as expected:
         self.assertEqual(w.df, pd.DataFrame({"w": (0.5, 2, 1, 1)}))
 
@@ -2582,7 +2586,8 @@ class TestBalanceDF(BalanceTestCase):
     def test_check_if_not_balancedf(self) -> None:
         with self.assertRaisesRegex(ValueError, "number must be balancedf_class"):
             BalanceDF._check_if_not_balancedf(
-                5,  # pyre-ignore[6]: Testing error handling with wrong type
+                # pyrefly: ignore [bad-argument-type]
+                5,
                 "number",
             )
         self.assertTrue(BalanceDF._check_if_not_balancedf(s3.covars()) is None)
@@ -3741,7 +3746,8 @@ class TestBalanceDFOutcomes_no_outcome_columns(BalanceTestCase):
             weight_column="w",
         )
         with self.assertRaisesRegex(ValueError, "no outcome columns are defined"):
-            BalanceDFOutcomes(sample=sample_no_outcomes)  # pyre-ignore[6]
+            # pyrefly: ignore [bad-argument-type]
+            BalanceDFOutcomes(sample=sample_no_outcomes)
 
 
 class TestBalanceDFWeights_design_effect_prop_type_error(BalanceTestCase):

--- a/tests/test_cbps.py
+++ b/tests/test_cbps.py
@@ -310,7 +310,7 @@ class Testcbps(
     def test__standardize_model_matrix(self) -> None:
         # numpy array as input
         mat = np.array([[1, 2], [3, 4]])
-        # pyre-fixme[6]: Testing with ndarray is valid
+        # pyrefly: ignore [bad-argument-type]
         res = balance_cbps._standardize_model_matrix(mat, ["a", "b"])
         self.assertEqual(res["model_matrix"], np.array([[-1.0, -1.0], [1.0, 1.0]]))
         self.assertEqual(res["model_matrix_columns_names"], ["a", "b"])
@@ -318,7 +318,7 @@ class Testcbps(
         self.assertEqual(res["model_matrix_std"], np.array([1.0, 1.0]))
         # check when column is constant
         mat = np.array([[1, 2], [1, 4]])
-        # pyre-fixme[6]: Testing with ndarray is valid
+        # pyrefly: ignore [bad-argument-type]
         res = balance_cbps._standardize_model_matrix(mat, ["a", "b"])
         self.assertEqual(res["model_matrix"], np.array([[-1.0], [1.0]]))
         self.assertEqual(res["model_matrix_columns_names"], ["b"])
@@ -327,7 +327,7 @@ class Testcbps(
 
         # pandas dataframe as input
         mat = pd.DataFrame({"a": (1, 3), "b": (2, 4)}).values
-        # pyre-fixme[6]: Testing with ndarray is valid
+        # pyrefly: ignore [bad-argument-type]
         res = balance_cbps._standardize_model_matrix(mat, ["a", "b"])
         self.assertEqual(res["model_matrix"], np.array([[-1.0, -1.0], [1.0, 1.0]]))
         self.assertEqual(res["model_matrix_columns_names"], ["a", "b"])
@@ -335,7 +335,7 @@ class Testcbps(
         self.assertEqual(res["model_matrix_std"], np.array([1.0, 1.0]))
         # check when column is constant
         mat = pd.DataFrame({"a": (1, 1), "b": (2, 4)}).values
-        # pyre-fixme[6]: Testing with ndarray is valid
+        # pyrefly: ignore [bad-argument-type]
         res = balance_cbps._standardize_model_matrix(mat, ["a", "b"])
         self.assertEqual(res["model_matrix"], np.array([[-1.0], [1.0]]))
         self.assertEqual(res["model_matrix_columns_names"], ["b"])
@@ -843,9 +843,7 @@ class Testcbps(
         target_df, sample_df = load_data("sim_data_cbps")
 
         # Create Sample objects with outcome columns
-        # pyre-ignore[6]: Optional DataFrame is checked in load_data
         sample = Sample.from_frame(sample_df, outcome_columns=["y", "cbps_weights"])
-        # pyre-ignore[6]: Optional DataFrame is checked in load_data
         target = Sample.from_frame(target_df, outcome_columns=["y", "cbps_weights"])
         sample_target = sample.set_target(target)
 
@@ -1342,9 +1340,9 @@ class TestCbpsEdgeCases(balance.testutil.BalanceTestCase):
         result = balance_cbps.gmm_function(
             beta,
             X,
-            # pyre-ignore[6]: Series is accepted at runtime via conversion
+            # pyrefly: ignore [bad-argument-type]
             design_weights,
-            # pyre-ignore[6]: Series is accepted at runtime via conversion
+            # pyrefly: ignore [bad-argument-type]
             in_pop,
         )
 

--- a/tests/test_e2e_from_tutorials.py
+++ b/tests/test_e2e_from_tutorials.py
@@ -615,7 +615,7 @@ happiness  53.295  56.278      48.559  (52.096, 54.495)  (55.961, 56.595)  (47.6
     # -----------------------------------------------------------------------
     # 15. Comparing adjustment methods: HGB
     # -----------------------------------------------------------------------
-    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    @pytest.mark.requires_sklearn_1_4
     @unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires sklearn >= 1.4")
     def test_adjust_hgb_native_categorical(self) -> None:
         from sklearn.ensemble import HistGradientBoostingClassifier

--- a/tests/test_ipw.py
+++ b/tests/test_ipw.py
@@ -342,7 +342,7 @@ class TestIPW(
                 use_model_matrix=False,
             )
 
-    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    @pytest.mark.requires_sklearn_1_4
     @unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires sklearn >= 1.4")
     def test_ipw_use_model_matrix_false_preserves_categoricals(self) -> None:
         """Raw-covariate IPW preserves categorical dtype for native sklearn categorical support."""
@@ -442,7 +442,7 @@ class TestIPW(
             self.assertIn("scikit-learn >= 1.4", str(ctx.exception))
             self.assertIn("1.3.2", str(ctx.exception))
 
-    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    @pytest.mark.requires_sklearn_1_4
     @unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires sklearn >= 1.4")
     def test_ipw_use_model_matrix_false_no_error_on_new_sklearn(self) -> None:
         """No version error when sklearn >= 1.4 and categorical columns are present."""
@@ -1420,7 +1420,8 @@ class TestIpwEdgeCases(balance.testutil.BalanceTestCase):
                 sample_weights,
                 target,
                 target_weights,
-                model=123,  # pyre-ignore[6]: Intentionally testing invalid model type
+                # pyrefly: ignore [bad-argument-type]
+                model=123,
             )
 
     def test_ipw_single_value_sample_indicator(self) -> None:

--- a/tests/test_poststratify.py
+++ b/tests/test_poststratify.py
@@ -18,6 +18,7 @@ import numpy as np
 import pandas as pd
 from balance import adjustment as balance_adjustment
 from balance.sample_class import Sample
+from balance.util import _assert_type
 from balance.weighting_methods.poststratify import poststratify
 
 
@@ -181,6 +182,161 @@ class Testpoststratify(
         ).rename(baseline.name)
 
         pd.testing.assert_series_equal(trimmed, expected)
+
+    def test_poststratify_stores_fit_metadata_when_enabled(self) -> None:
+        sample_df = pd.DataFrame({"a": ["x", "y", "x"], "b": ["u", "u", "v"]})
+        target_df = pd.DataFrame({"a": ["x", "y", "x"], "b": ["u", "u", "v"]})
+        s_weights = pd.Series([1.0, 1.0, 1.0])
+        t_weights = pd.Series([1.0, 1.0, 1.0])
+
+        result = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            variables=["a", "b"],
+            transformations=None,
+            store_fit_metadata=True,
+        )
+        model = result["model"]
+        assert isinstance(model, dict)
+        self.assertEqual(model["method"], "poststratify")
+        self.assertIn("cell_weight_ratio", model)
+        self.assertIn("training_sample_weights", model)
+        self.assertIn("training_target_weights", model)
+        self.assertIn("variables", model)
+        self.assertTrue(bool(model.get("store_fit_metadata")))
+
+    def test_poststratify_stores_resolved_default_transformations_in_metadata(
+        self,
+    ) -> None:
+        sample_df = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": ["x", "y", "x"]})
+        target_df = pd.DataFrame({"a": [1.0, 2.0, 3.0], "b": ["x", "y", "x"]})
+        s_weights = pd.Series([1.0, 1.0, 1.0])
+        t_weights = pd.Series([1.0, 1.0, 1.0])
+
+        result = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            variables=["a", "b"],
+            transformations="default",
+            store_fit_metadata=True,
+        )
+        model = result["model"]
+        assert isinstance(model, dict)
+        self.assertIsInstance(model.get("transformations"), dict)
+        self.assertEqual(set(model["transformations"].keys()), {"a", "b"})
+
+    def test_poststratify_defaults_to_minimal_model_payload(self) -> None:
+        sample_df = pd.DataFrame({"a": ["x", "y", "x"]})
+        target_df = pd.DataFrame({"a": ["x", "x", "y"]})
+        weights = pd.Series([1.0, 1.0, 1.0])
+        result = poststratify(
+            sample_df=sample_df,
+            sample_weights=weights,
+            target_df=target_df,
+            target_weights=weights,
+            variables=["a"],
+            transformations=None,
+        )
+        model = result["model"]
+        assert isinstance(model, dict)
+        self.assertEqual(model, {"method": "poststratify"})
+
+    def test_poststratify_can_disable_fit_metadata_storage(self) -> None:
+        sample_df = pd.DataFrame({"a": ["x", "y", "x"]})
+        target_df = pd.DataFrame({"a": ["x", "x", "y"]})
+        s_weights = pd.Series([1.0, 1.0, 1.0])
+        t_weights = pd.Series([1.0, 1.0, 1.0])
+
+        result = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            variables=["a"],
+            transformations=None,
+            store_fit_metadata=False,
+        )
+        model = result["model"]
+        assert isinstance(model, dict)
+        self.assertEqual(model, {"method": "poststratify"})
+
+    def test_poststratify_na_drop_stores_full_training_weight_indices(self) -> None:
+        sample_df = pd.DataFrame({"a": ["x", "y", None], "b": ["u", "v", "u"]})
+        target_df = pd.DataFrame({"a": ["x", "y", None], "b": ["u", "v", "v"]})
+        s_weights = pd.Series([1.0, 2.0, 3.0], index=["s0", "s1", "s2"])
+        t_weights = pd.Series([1.0, 1.0, 1.0], index=["t0", "t1", "t2"])
+        sample_df.index = s_weights.index
+        target_df.index = t_weights.index
+
+        result = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            variables=["a"],
+            transformations=None,
+            na_action="drop",
+            strict_matching=False,
+            store_fit_metadata=True,
+        )
+        model = result["model"]
+        assert isinstance(model, dict)
+        stored_sample = _assert_type(model.get("training_sample_weights"))
+        stored_target = _assert_type(model.get("training_target_weights"))
+        self.assertTrue(stored_sample.index.equals(s_weights.index))
+        self.assertTrue(stored_target.index.equals(t_weights.index))
+
+    def test_poststratify_rejects_non_bool_store_fit_metadata(self) -> None:
+        sample_df = pd.DataFrame({"a": ["x", "y"]})
+        target_df = pd.DataFrame({"a": ["x", "y"]})
+        weights = pd.Series([1.0, 1.0])
+        with self.assertRaisesRegex(TypeError, "store_fit_metadata"):
+            poststratify(
+                sample_df=sample_df,
+                sample_weights=weights,
+                target_df=target_df,
+                target_weights=weights,
+                variables=["a"],
+                transformations=None,
+                store_fit_metadata="False",  # type: ignore[arg-type]
+            )
+
+    def test_poststratify_rejects_unknown_kwargs(self) -> None:
+        sample_df = pd.DataFrame({"a": ["x", "y"]})
+        target_df = pd.DataFrame({"a": ["x", "y"]})
+        weights = pd.Series([1.0, 1.0])
+        with self.assertRaisesRegex(TypeError, "Unexpected keyword arguments: typo"):
+            poststratify(
+                sample_df=sample_df,
+                sample_weights=weights,
+                target_df=target_df,
+                target_weights=weights,
+                variables=["a"],
+                transformations=None,
+                typo=True,
+            )
+
+    def test_poststratify_rejects_unpickleable_transformations_when_storing_metadata(
+        self,
+    ) -> None:
+        sample_df = pd.DataFrame({"a": ["x", "y", "x"]})
+        target_df = pd.DataFrame({"a": ["x", "y", "y"]})
+        weights = pd.Series([1.0, 1.0, 1.0])
+
+        with self.assertRaisesRegex(ValueError, "must be pickleable"):
+            poststratify(
+                sample_df=sample_df,
+                sample_weights=weights,
+                target_df=target_df,
+                target_weights=weights,
+                variables=["a"],
+                transformations={"a": lambda x: x},
+                store_fit_metadata=True,
+            )
 
     def test_poststratify_variables_arg(self) -> None:
         s = pd.DataFrame(
@@ -410,6 +566,36 @@ class Testpoststratify(
         pd.testing.assert_series_equal(
             result_with_triple_interaction, result_with_all_vars
         )
+
+    def test_poststratify_formula_filters_out_of_scope_transformations(self) -> None:
+        s = pd.DataFrame(
+            {
+                "a": (0, 0, 1, 1),
+                "b": ("x", "y", "x", "y"),
+            }
+        )
+        s_weights = pd.Series([1.0, 1.0, 1.0, 1.0])
+        t = s.copy()
+        t_weights = pd.Series([1.0, 1.0, 3.0, 3.0])
+
+        expected = poststratify(
+            sample_df=s,
+            sample_weights=s_weights,
+            target_df=t,
+            target_weights=t_weights,
+            formula="a",
+            transformations=None,
+        )["weight"]
+
+        transformed = poststratify(
+            sample_df=s,
+            sample_weights=s_weights,
+            target_df=t,
+            target_weights=t_weights,
+            formula="a",
+            transformations={"b": lambda x: x},
+        )["weight"]
+        pd.testing.assert_series_equal(transformed, expected)
 
     def test_poststratify_formula_keeps_positional_argument_compatibility(self) -> None:
         s = pd.DataFrame(
@@ -773,38 +959,274 @@ class Testpoststratify(
                 formula="a + . - c",
             )
 
-    # TODO: test chained adjustment (IPW → poststratify) — the two-stage pattern
-    #   from balance notebook v03:
-    #       sample_with_target = sample.set_target(target)
-    #       adjust_stage_1 = sample_with_target.adjust(method="ipw")
-    #       adjust_stage_2 = adjust_stage_1.adjust(method="poststratify")
-    #   Verify ASMD improves at each stage.
+    def test_chained_adjustment_ipw_then_poststratify_improves_poststrat_covars(
+        self,
+    ) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(8)],
+                "w": np.ones(8),
+                "signal": [0, 0, 0, 1, 1, 1, 1, 1],
+                "age_group": [
+                    "young",
+                    "young",
+                    "young",
+                    "young",
+                    "old",
+                    "old",
+                    "old",
+                    "old",
+                ],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(8)],
+                "w": np.ones(8),
+                "signal": [0, 1, 0, 1, 0, 1, 0, 1],
+                "age_group": ["young", "old", "old", "old", "old", "old", "old", "old"],
+            }
+        )
+        sample = Sample.from_frame(sample_df, id_column="id", weight_column="w")
+        target = Sample.from_frame(target_df, id_column="id", weight_column="w")
 
-    # TODO: test transformations as a dict with identity lambdas — verify only
-    #   the named column is used for cell definition (others are dropped when
-    #   transformations_drop=True, the default).
-    #   Example from balance notebook v03:
-    #       transformations = {"age_group": lambda x: x}
-    #       adjusted = ipw_adjusted.adjust(method="poststratify",
-    #                                      transformations=transformations)
+        stage_1 = sample.adjust(
+            target,
+            method="ipw",
+            variables=["signal"],
+            transformations=None,
+            num_lambdas=1,
+        )
+        stage_2 = stage_1.adjust(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+        )
 
-    # TODO: test transformations_drop=False — verify that columns NOT in the
-    #   transformations dict are kept (not dropped) when this flag is set.
+        stage_1_asmd = stage_1.covars().asmd()
+        stage_2_asmd = stage_2.covars().asmd()
+        self.assertLessEqual(
+            float(stage_2_asmd.loc["self", "age_group[young]"]),
+            float(stage_1_asmd.loc["self", "age_group[young]"]),
+        )
+        self.assertAlmostEqual(
+            float(stage_2_asmd.loc["self", "age_group[young]"]),
+            0.0,
+            places=10,
+        )
 
-    # TODO: test interaction between variables= and transformations= — what
-    #   happens when both are provided? Which takes precedence?
+    def test_transformations_identity_only_uses_transformed_columns(self) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "age_group": ["young", "young", "old", "old"],
+                "region": ["east", "west", "east", "west"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "age_group": ["young", "young", "old", "old"],
+                "region": ["east", "west", "east", "west"],
+            }
+        )
+        s_weights = pd.Series([1.0, 1.0, 1.0, 1.0])
+        t_weights = pd.Series([1.0, 1.0, 1.0, 1.0])
 
-    # TODO: test ASMD after poststratify — verify that ASMD on the PS variables
-    #   reaches 0 (or near 0) after adjustment.
-    #   Example pattern from balance notebook v03:
-    #       adjusted.covars().asmd().T
+        transformed_only = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            transformations={"age_group": lambda x: x},
+            store_fit_metadata=False,
+        )["weight"]
+        via_variables = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            variables=["age_group"],
+            transformations=None,
+        )["weight"]
 
-    # TODO: test outcomes after poststratify — verify outcome distributions
-    #   shift appropriately when accessed via .outcomes().
-    #   Example pattern from balance notebook v03:
-    #       adjusted.outcomes().plot()
+        pd.testing.assert_series_equal(transformed_only, via_variables)
 
-    # TODO: test poststratify with continuous (non-categorical) variables —
-    #   what happens when you PS on a numeric column without binning? The
-    #   default transformations handle this via quantize/fct_lump, but explicit
-    #   tests for this edge case are missing.
+    def test_transformations_drop_false_keeps_untransformed_columns(self) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "age_group": ["young", "young", "old", "old"],
+                "region": ["east", "west", "east", "west"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "age_group": ["young", "young", "old", "old"],
+                "region": ["east", "west", "east", "west"],
+            }
+        )
+        s_weights = pd.Series([1.0, 1.0, 1.0, 1.0])
+        t_weights = pd.Series([1.0, 1.0, 1.0, 1.0])
+
+        transformed_keep_rest = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            transformations={"age_group": lambda x: x},
+            transformations_drop=False,
+            store_fit_metadata=False,
+        )["weight"]
+        via_both_variables = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            variables=["age_group", "region"],
+            transformations=None,
+        )["weight"]
+
+        pd.testing.assert_series_equal(transformed_keep_rest, via_both_variables)
+
+    def test_variables_and_transformations_prioritize_explicit_variables(self) -> None:
+        def _must_not_run(_: object) -> object:
+            raise AssertionError(
+                "Transformation outside explicit variables should not run."
+            )
+
+        sample_df = pd.DataFrame(
+            {
+                "age_group": ["young", "young", "old", "old"],
+                "region": ["east", "west", "east", "west"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "age_group": ["young", "old", "old", "old"],
+                "region": ["west", "east", "east", "east"],
+            }
+        )
+        s_weights = pd.Series([1.0, 1.0, 1.0, 1.0])
+        t_weights = pd.Series([1.0, 1.0, 1.0, 1.0])
+
+        mixed_arguments = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            variables=["region"],
+            transformations={"age_group": _must_not_run},
+            store_fit_metadata=False,
+        )["weight"]
+        via_region = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            variables=["region"],
+            transformations=None,
+        )["weight"]
+
+        pd.testing.assert_series_equal(mixed_arguments, via_region)
+
+    def test_poststratify_drives_asmd_to_zero_on_poststrat_variables(self) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": ["1", "2", "3", "4"],
+                "w": [1.0, 1.0, 1.0, 1.0],
+                "age_group": ["young", "young", "old", "old"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": ["5", "6", "7", "8"],
+                "w": [1.0, 1.0, 1.0, 1.0],
+                "age_group": ["young", "old", "old", "old"],
+            }
+        )
+        sample = Sample.from_frame(sample_df, id_column="id", weight_column="w")
+        target = Sample.from_frame(target_df, id_column="id", weight_column="w")
+        adjusted = sample.adjust(
+            target,
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+        )
+
+        asmd = adjusted.covars().asmd()
+        self.assertAlmostEqual(
+            float(asmd.loc["self", "age_group[young]"]), 0.0, places=10
+        )
+        self.assertAlmostEqual(
+            float(asmd.loc["self", "age_group[old]"]), 0.0, places=10
+        )
+
+    def test_poststratify_updates_outcome_distribution_toward_target(self) -> None:
+        sample = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["1", "2", "3", "4"],
+                    "w": [1.0, 1.0, 1.0, 1.0],
+                    "age_group": ["young", "young", "old", "old"],
+                    "y": [1.0, 1.0, 10.0, 10.0],
+                }
+            ),
+            id_column="id",
+            weight_column="w",
+            outcome_columns=["y"],
+        )
+        target = Sample.from_frame(
+            pd.DataFrame(
+                {
+                    "id": ["5", "6", "7", "8"],
+                    "w": [1.0, 1.0, 1.0, 1.0],
+                    "age_group": ["young", "old", "old", "old"],
+                    "y": [1.0, 10.0, 10.0, 10.0],
+                }
+            ),
+            id_column="id",
+            weight_column="w",
+            outcome_columns=["y"],
+        )
+
+        adjusted = sample.adjust(
+            target,
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+        )
+        means = _assert_type(adjusted.outcomes()).mean()
+        self.assertAlmostEqual(
+            float(means.loc["self", "y"]), float(means.loc["target", "y"])
+        )
+        self.assertNotAlmostEqual(
+            float(means.loc["self", "y"]),
+            float(means.loc["unadjusted", "y"]),
+        )
+
+    def test_poststratify_on_continuous_variable_with_default_transformations(
+        self,
+    ) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "x": [10.0, 20.0, 30.0, 40.0],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "x": [12.0, 18.0, 33.0, 45.0],
+            }
+        )
+        s_weights = pd.Series([1.0, 1.0, 1.0, 1.0])
+        t_weights = pd.Series([1.0, 1.0, 1.0, 1.0])
+
+        with self.assertRaisesRegex(
+            ValueError, "Cannot normalise weights because their sum is zero"
+        ):
+            poststratify(
+                sample_df=sample_df,
+                sample_weights=s_weights,
+                target_df=target_df,
+                target_weights=t_weights,
+                variables=["x"],
+                transformations="default",
+                strict_matching=False,
+            )

--- a/tests/test_rake.py
+++ b/tests/test_rake.py
@@ -825,7 +825,7 @@ class Testrake(
 
         # float max_length rejected
         with self.assertRaises(ValueError):
-            # pyre-ignore[6]: Deliberately testing invalid type
+            # pyrefly: ignore [bad-argument-type]
             _realize_dicts_of_proportions(simple, 10000.0)
 
         # max_length < 1 rejected
@@ -985,7 +985,7 @@ class Testrake(
 
         # np.float64 proportions — the common case from Series.to_dict()
         result = _hare_niemeyer_allocation(
-            # pyre-ignore[6]: Testing numpy scalar compatibility
+            # pyrefly: ignore [bad-argument-type]
             {"a": np.float64(0.2), "b": np.float64(0.8)},
             5,
         )
@@ -993,13 +993,13 @@ class Testrake(
         self.assertEqual(len(result), 5)
 
         # np.int64 proportions (unnormalized counts)
-        # pyre-ignore[6]: Testing numpy scalar compatibility
+        # pyrefly: ignore [bad-argument-type]
         result2 = _hare_niemeyer_allocation({"x": np.int64(2), "y": np.int64(8)}, 10)
         self.assertEqual(result2.count("x"), 2)
         self.assertEqual(result2.count("y"), 8)
 
         # Mixed Python float and np.float64
-        # pyre-ignore[6]: Testing numpy scalar compatibility
+        # pyrefly: ignore [bad-argument-type]
         result3 = _hare_niemeyer_allocation({"p": 0.3, "q": np.float64(0.7)}, 10)
         self.assertEqual(len(result3), 10)
 
@@ -1614,4 +1614,5 @@ class TestRakeValidation(
                 return 0
 
         with self.assertRaisesRegex(ValueError, "convertible to float"):
-            _realize_dicts_of_proportions({"var": {"cat": BadReal()}})  # pyre-ignore[6]
+            # pyrefly: ignore [bad-argument-type]
+            _realize_dicts_of_proportions({"var": {"cat": BadReal()}})

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -376,7 +376,7 @@ class TestSample(
             )
 
         with self.assertRaisesRegex(ValueError, "not in df columns"):
-            # pyre-ignore[6]: Intentionally passing int to test validation
+            # pyrefly: ignore [bad-argument-type]
             Sample.from_frame(df, ignored_columns=["a", 3])
 
         with self.assertRaisesRegex(ValueError, "not in df columns"):
@@ -503,7 +503,7 @@ class TestSample(
             ValueError,
             "'method' must be a string naming a weighting method or a callable",
         ):
-            # pyre-ignore[6]: Intentionally passing None to test exception handling
+            # pyrefly: ignore [bad-argument-type]
             s1.set_target(s2).adjust(method=None)
 
 
@@ -544,7 +544,7 @@ class TestSample_base_and_adjust_methods(
 
         # Test that df cannot be called as function
         with self.assertRaisesRegex(TypeError, "'DataFrame' object is not callable"):
-            # pyre-ignore[29]: Intentionally calling DataFrame to test exception
+            # pyrefly: ignore [not-callable]
             s1.df()
 
         # Test s2 DataFrame structure and type conversion
@@ -735,7 +735,7 @@ class TestSample_base_and_adjust_methods(
             TypeError,
             "set_unadjusted must be called with a BalanceFrame argument",
         ):
-            # pyre-ignore[6]: Intentionally passing str to test exception handling
+            # pyrefly: ignore [bad-argument-type]
             s1.set_unadjusted("Not a Sample object")
 
     def test_Sample_is_adjusted(self) -> None:
@@ -777,7 +777,7 @@ class TestSample_base_and_adjust_methods(
             TypeError,
             "A target, a Sample object, must be specified",
         ):
-            # pyre-ignore[6]: Intentionally passing str to test exception handling
+            # pyrefly: ignore [bad-argument-type]
             s1.set_target("Not a Sample object")
 
     def test_Sample_has_target(self) -> None:
@@ -2313,7 +2313,7 @@ class TestSampleFromFrameGuessIdColumnCandidates(balance.testutil.BalanceTestCas
         ):
             Sample.from_frame(
                 pd.DataFrame({"user_id": [1, 2, 3], "a": [1, 2, 3]}),
-                # pyre-ignore[6]: Intentionally passing invalid type to test error handling
+                # pyrefly: ignore [bad-argument-type]
                 id_column_candidates=["user_id", 1],
             )
 

--- a/tests/test_sample_frame.py
+++ b/tests/test_sample_frame.py
@@ -1137,7 +1137,7 @@ class TestSampleFrameFromSample(BalanceTestCase):
 
     def test_from_sample_type_error(self) -> None:
         with self.assertRaises(TypeError):
-            SampleFrame.from_sample("not a sample")  # pyre-ignore[6]
+            SampleFrame.from_sample("not a sample")
 
     def test_from_sample_roundtrip_covars_match(self) -> None:
         df = pd.DataFrame(
@@ -1270,7 +1270,8 @@ class TestSampleFrameUncoveredLines(BalanceTestCase):
         )
         sf = SampleFrame.from_frame(df)
         with self.assertRaises(TypeError) as ctx:
-            sf.set_weights(np.array([1.0, 2.0, 3.0]), use_index=True)  # pyre-ignore[6]
+            # pyrefly: ignore [bad-argument-type]
+            sf.set_weights(np.array([1.0, 2.0, 3.0]), use_index=True)
         self.assertIn("use_index=True requires a pandas Series", str(ctx.exception))
 
     def test_rename_weight_column_bad_old_name(self) -> None:

--- a/tests/test_stats_and_plots.py
+++ b/tests/test_stats_and_plots.py
@@ -3652,6 +3652,5 @@ class TestEmptyCategoriesError(balance.testutil.BalanceTestCase):
         sample_df = pd.DataFrame({"a": [1.0, 2.0, 3.0]})
         target_df = pd.DataFrame({"a": [4.0, 5.0, 6.0]})
         with self.assertRaisesRegex(ValueError, "std_type must be in"):
-            weighted_comparisons_stats.asmd(
-                sample_df, target_df, std_type="invalid"  # pyre-ignore[6]
-            )
+            # pyrefly: ignore [bad-argument-type]
+            weighted_comparisons_stats.asmd(sample_df, target_df, std_type="invalid")

--- a/tests/test_testutil.py
+++ b/tests/test_testutil.py
@@ -296,13 +296,13 @@ class TestNoneThrows(
         """Test that _assert_type accepts value when it matches one of multiple types."""
         # Test with string (first type in tuple)
         str_value = "test"
-        # pyre-fixme[6]: Tuple types work at runtime but overloads don't support union narrowing
+        # pyrefly: ignore [no-matching-overload]
         result_str = balance.testutil._assert_type(str_value, (str, int))
         self.assertEqual(result_str, "test")
 
         # Test with int (second type in tuple)
         int_value = 42
-        # pyre-fixme[6]: Tuple types work at runtime but overloads don't support union narrowing
+        # pyrefly: ignore [no-matching-overload]
         result_int = balance.testutil._assert_type(int_value, (str, int))
         self.assertEqual(result_int, 42)
 
@@ -310,7 +310,7 @@ class TestNoneThrows(
         """Test that _assert_type raises TypeError when value doesn't match any type in tuple."""
         value = 3.14  # float, not in (str, int)
         with self.assertRaises(TypeError) as context:
-            # pyre-fixme[6]: Tuple types work at runtime but overloads don't support union narrowing
+            # pyrefly: ignore [no-matching-overload]
             balance.testutil._assert_type(value, (str, int))
         self.assertIn("Expected type", str(context.exception))
         self.assertIn("float", str(context.exception))

--- a/tests/test_util_input_validation.py
+++ b/tests/test_util_input_validation.py
@@ -140,7 +140,7 @@ class TestUtil(
         ):
             guess_id_column(
                 df,
-                # pyre-ignore[6]: Intentionally passing invalid type to test error handling
+                # pyrefly: ignore [bad-argument-type]
                 possible_id_columns=["user_id", 1],
             )
         with self.assertRaisesRegex(
@@ -149,7 +149,7 @@ class TestUtil(
         ):
             guess_id_column(
                 df,
-                # pyre-ignore[6]: Intentionally passing invalid type to test error handling
+                # pyrefly: ignore [bad-argument-type]
                 possible_id_columns=1,
             )
 
@@ -393,7 +393,6 @@ class TestUtil(
         # NOTE: pd.FloatingArray were only added in pandas version 1.2.0.
         # Before that, they were called PandasArray. For details, see:
         # https://pandas.pydata.org/docs/dev/reference/api/pandas.arrays.FloatingArray.html
-        # pyre-ignore[16]: Module `pandas` has no attribute `__version__`.
         if pd.__version__ < "1.2.0":
             expected_floating_types = [
                 numpy_array_type,
@@ -602,7 +601,7 @@ class TestUtil(
 
         for value, expected_type, description in success_cases:
             with self.subTest(description=description):
-                # pyre-ignore[6]: Testing runtime behavior with various types
+                # pyrefly: ignore [no-matching-overload]
                 result = _assert_type(value, expected_type)
                 self.assertEqual(result, value)
 
@@ -623,7 +622,7 @@ class TestUtil(
         for value, expected_type, expected_exception, description in error_cases:
             with self.subTest(description=description):
                 with self.assertRaises(expected_exception):
-                    # pyre-ignore[6]: Testing runtime behavior with various types
+                    # pyrefly: ignore [no-matching-overload]
                     _assert_type(value, expected_type)
 
     def test__float_or_none(self) -> None:

--- a/tests/test_util_model_matrix.py
+++ b/tests/test_util_model_matrix.py
@@ -80,8 +80,8 @@ class TestUtil(
         self.assertEqual(
             f1.rhs_termlist,
             [
-                Term([EvalFactor("a"), EvalFactor("b")]),  # pyre-ignore[16]
-                Term([EvalFactor("a"), EvalFactor("aab")]),  # pyre-ignore[16]
+                Term([EvalFactor("a"), EvalFactor("b")]),
+                Term([EvalFactor("a"), EvalFactor("aab")]),
             ],
         )
 
@@ -89,22 +89,16 @@ class TestUtil(
         self.assertEqual(
             f2.rhs_termlist,
             [
-                Term(  # pyre-ignore[16]
+                Term(
                     [
-                        EvalFactor(  # pyre-ignore[16]
-                            "C(a, one_hot_encoding_greater_2)"
-                        ),
-                        EvalFactor(  # pyre-ignore[16]
-                            "C(b, one_hot_encoding_greater_2)"
-                        ),
+                        EvalFactor("C(a, one_hot_encoding_greater_2)"),
+                        EvalFactor("C(b, one_hot_encoding_greater_2)"),
                     ]
                 ),
-                Term(  # pyre-ignore[16]
+                Term(
                     [
-                        EvalFactor(  # pyre-ignore[16]
-                            "C(a, one_hot_encoding_greater_2)"
-                        ),
-                        EvalFactor("aab"),  # pyre-ignore[16]
+                        EvalFactor("C(a, one_hot_encoding_greater_2)"),
+                        EvalFactor("aab"),
                     ]
                 ),
             ],
@@ -625,10 +619,7 @@ class TestUtil(
         - Work correctly with patsy's dmatrix function
         """
         from balance.util import one_hot_encoding_greater_2  # noqa
-        from patsy import (  # pyre-ignore[21]: Import `patsy.dmatrix` is not defined as a type.
-            # pyrefly: ignore [missing-module-attribute]
-            dmatrix,
-        )
+        from patsy import dmatrix  # pyrefly: ignore [missing-module-attribute]
 
         d = {
             "a": ["a1", "a2", "a1", "a1"],
@@ -637,9 +628,7 @@ class TestUtil(
         }
         df = pd.DataFrame(data=d)
 
-        res = dmatrix(  # pyre-ignore[16]: Module `patsy` has no attribute `dmatrix`.
-            "C(a, one_hot_encoding_greater_2)", df, return_type="dataframe"
-        )
+        res = dmatrix("C(a, one_hot_encoding_greater_2)", df, return_type="dataframe")
         expected = {
             "Intercept": [1.0, 1.0, 1.0, 1.0],
             "C(a, one_hot_encoding_greater_2)[a2]": [0.0, 1.0, 0.0, 0.0],
@@ -647,9 +636,7 @@ class TestUtil(
         expected = pd.DataFrame(data=expected)
         self.assertEqual(res, expected)
 
-        res = dmatrix(  # pyre-ignore[16]: Module `patsy` has no attribute `dmatrix`.
-            "C(b, one_hot_encoding_greater_2)", df, return_type="dataframe"
-        )
+        res = dmatrix("C(b, one_hot_encoding_greater_2)", df, return_type="dataframe")
         expected = {
             "Intercept": [1.0, 1.0, 1.0, 1.0],
             "C(b, one_hot_encoding_greater_2)[b1]": [1.0, 0.0, 0.0, 0.0],
@@ -659,9 +646,7 @@ class TestUtil(
         expected = pd.DataFrame(data=expected)
         self.assertEqual(res, expected)
 
-        res = dmatrix(  # pyre-ignore[16]: Module `patsy` has no attribute `dmatrix`.
-            "C(c, one_hot_encoding_greater_2)", df, return_type="dataframe"
-        )
+        res = dmatrix("C(c, one_hot_encoding_greater_2)", df, return_type="dataframe")
         expected = {
             "Intercept": [1.0, 1.0, 1.0, 1.0],
             "C(c, one_hot_encoding_greater_2)[c1]": [1.0, 1.0, 1.0, 1.0],

--- a/tests/test_weighted_comparisons_plots.py
+++ b/tests/test_weighted_comparisons_plots.py
@@ -1896,7 +1896,7 @@ class TestPlotlyPlotDistUnsupportedDistType(balance.testutil.BalanceTestCase):
             plotly_plot_dist(
                 dict_of_dfs,
                 variables=["v1"],
-                # pyre-ignore[6]: Testing invalid dist_type intentionally
+                # pyrefly: ignore [bad-argument-type]
                 dist_type="unknown_type",
                 plot_it=False,
                 return_dict_of_figures=True,


### PR DESCRIPTION
Summary:

## What this diff does

1. **Pyre cleanup** — strips 60 unused `# pyre-fixme[XX]` / `# pyre-ignore[XX]`
   comments across 15 test files in `core_stats/balance/parent_balance/tests/`.
   Pyre's "Unused ignore [0]" warning fires when a suppression comment isn't
   suppressing any error of code `[XX]`; pyre-ptt (the IDE LSP) flags these
   in the editor.

   Production source files (`balance_frame.py`, `sample_frame.py`,
   `utils/model_matrix.py`, `utils/pandas_utils.py`,
   `weighting_methods/ipw.py`) were left alone — those `pyre-fixme` comments
   were verified to still be doing real work under buck-resolved imports
   (`pyre --target fbcode//core_stats/balance:balance check`); removing
   them surfaces real `[13]`, `[16]`, `[58]` errors.

2. **Missing skipUnless** — added the matching
   `unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, ...)` to
   `test_store_fit_matrices_use_model_matrix_false`
   (`test_balance_frame.py:3205`), which had only the `pytest.mark.requires_sklearn_1_4`
   marker. Without the unittest decorator, the test would have ERRORED on
   `balance_tests_pss2` (sklearn < 1.4) instead of skipping, because
   fbcode's testpilot/unittest runner does NOT honor pytest markers.

## Stacked on D102502529.

## Notes on Copilot review feedback

Copilot suggested dropping `unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, ...)`
from sklearn-1.4-gated tests, claiming `pytest.mark.requires_sklearn_1_4`
plus `conftest.py`'s `pytest_collection_modifyitems` already handles it.
That's true under raw pytest, but **not** under fbcode's testpilot runner
(`python_test_matrix` → testpilot/unittest-style discovery), which does not
invoke pytest collection hooks. Without `unittest.skipUnless`, the
sklearn-1.4-only tests would FAIL on `balance_tests_pss2` (sklearn < 1.4),
not skip silently.

We also explored eliminating the "Warning skipped=1" status on pss2 by
using a `_sklearn_1_4_only` decorator that returns `None` when sklearn < 1.4
(so `unittest.TestLoader.getTestCaseNames`'s `callable()` check would filter
it out). That worked for `getTestCaseNames`, but testpilot's adapter
(`testinfra/testpilot/integration/python/adapters/unittest.py`) reaches for
the test by name via `loadTestsFromName`, which raises
`TypeError: don't know how to make test from: None` instead of falling back
to filtering. So we kept `unittest.skipUnless`. The "Warning"-status skip
entries on pss2 are the cost of running these tests on both PSS targets;
eliminating them would require BUCK-level test filtering (excluding the
sklearn-1.4-gated tests from the pss2 src glob), which is out of scope for
this pyre-comment cleanup.

Differential Revision: D102509321
