### PR TITLE
Wire diagnostics `adjustment_failure` metadata (#429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.21.0 (Unreleased - TBD)
+
+## Code Quality & Refactoring
+
+- Diagnostics construction now wires `adjustment_failure` metadata from model
+  outputs when available (instead of hardcoding success), and supports an
+  optional `adjustment_failure_reason` diagnostics row for richer failure
+  reporting in downstream tooling.
+- Plotly distribution plotting now gracefully handles missing notebook mime
+  rendering dependencies (`nbformat`) by skipping the interactive plot with a
+  warning, avoiding runtime crashes in non-notebook/test environments.
+
 # 0.20.0 (2026-04-26)
 
 ## Breaking Changes

--- a/balance/stats_and_plots/weighted_comparisons_plots.py
+++ b/balance/stats_and_plots/weighted_comparisons_plots.py
@@ -57,6 +57,31 @@ class DataFrameWithWeight(TypedDict, total=False):
     weight: Optional[pd.Series]
 
 
+def _safe_plotly_iplot(fig: Any) -> None:
+    """Render Plotly figure in a way that is resilient to missing notebook deps.
+
+    In non-notebook environments, ``offline.iplot`` may raise a ``ValueError``
+    when Plotly's mime renderer cannot import ``nbformat``. In that case, log a
+    warning and skip the interactive plot so CLI/test workflows don't crash.
+    """
+
+    try:
+        offline.iplot(fig)
+    except ValueError as error:
+        error_message = str(error).lower()
+        is_nbformat_mime_error = "nbformat" in error_message and (
+            "mime type rendering requires" in error_message
+            or "mime rendering requires" in error_message
+            or "not installed" in error_message
+        )
+        if not is_nbformat_mime_error:
+            raise
+        logger.warning(
+            "Plotly notebook mime rendering unavailable; skipping interactive plot. Original error: %s",
+            error,
+        )
+
+
 ################################################################################
 #  seaborn plots below
 ################################################################################
@@ -898,7 +923,7 @@ def plotly_plot_qq(
         fig.update_layout(**kwargs)
         dict_of_qqs[variable] = fig
         if plot_it:
-            offline.iplot(fig)
+            _safe_plotly_iplot(fig)
     if return_dict_of_figures:
         return dict_of_qqs
 
@@ -1061,7 +1086,7 @@ def plotly_plot_density(
         fig.update_layout(**kwargs)
 
         if plot_it:
-            offline.iplot(fig)
+            _safe_plotly_iplot(fig)
 
     if return_dict_of_figures:
         return dict_of_density_plots
@@ -1183,7 +1208,7 @@ def plotly_plot_bar(
 
         dict_of_bars[variable] = fig
         if plot_it:
-            offline.iplot(fig)
+            _safe_plotly_iplot(fig)
     if return_dict_of_figures:
         return dict_of_bars
 
@@ -1223,7 +1248,7 @@ def plotly_plot_dist(
             If returned - the dictionary is of plots.
             Keys in this dictionary are the variable names for each plot.
             Values are plotly plot objects plotted like:
-                offline.iplot(dict_of_all_plots['age'])
+                plotly.offline.iplot(dict_of_all_plots['age'])
             Or simply:
                 dict_of_all_plots['age']
         ylim (Optional[Tuple[float, float]], optional): A tuple with two float values representing the lower and upper limits of the y-axis.

--- a/balance/summary_utils.py
+++ b/balance/summary_utils.py
@@ -28,6 +28,67 @@ from balance.util import _coerce_scalar
 logger: logging.Logger = logging.getLogger(__package__)
 
 
+_FAILURE_FALSE_STRINGS: frozenset[str] = frozenset(
+    {"", "0", "false", "no", "n", "success", "succeeded"}
+)
+_FAILURE_TRUE_STRINGS: frozenset[str] = frozenset(
+    {"1", "true", "yes", "y", "failure", "failed"}
+)
+
+
+def _coerce_failure_flag(raw_failure: Any) -> int:
+    """Coerce a raw ``adjustment_failure`` value to a 0/1 int.
+
+    Handles bool, int, float (including NaN), and str inputs explicitly so
+    callers don't need to dispatch on the source dtype themselves.
+    """
+    if isinstance(raw_failure, bool):
+        return int(raw_failure)
+    if isinstance(raw_failure, (int, np.integer)):
+        return int(raw_failure != 0)
+    if isinstance(raw_failure, (float, np.floating)):
+        if np.isnan(raw_failure):
+            return 0
+        return int(raw_failure != 0.0)
+    if isinstance(raw_failure, str):
+        normalized = raw_failure.strip().lower()
+        if normalized in _FAILURE_FALSE_STRINGS:
+            return 0
+        if normalized in _FAILURE_TRUE_STRINGS:
+            return 1
+        return int(bool(normalized))
+    return int(bool(raw_failure))
+
+
+def _resolve_adjustment_failure_metadata(
+    model_dict: dict[str, Any] | None,
+) -> tuple[int, str | None]:
+    """Normalize adjustment failure metadata from ``model_dict``.
+
+    Args:
+        model_dict: Adjustment model metadata dictionary.
+
+    Returns:
+        Tuple of ``(adjustment_failure, adjustment_failure_reason)`` where:
+            * ``adjustment_failure`` is always ``0`` or ``1``.
+            * ``adjustment_failure_reason`` is a stripped non-empty string only
+              when a failure is recorded, otherwise ``None``.
+    """
+    if model_dict is None:
+        return 0, None
+
+    failure = _coerce_failure_flag(model_dict.get("adjustment_failure", 0))
+    if failure != 1:
+        return failure, None
+
+    raw_reason = model_dict.get("adjustment_failure_reason")
+    if isinstance(raw_reason, str):
+        stripped_reason = raw_reason.strip()
+        if stripped_reason:
+            return failure, stripped_reason
+    return failure, None
+
+
 def _concat_metric_val_var(
     diagnostics: pd.DataFrame,
     metric: str,
@@ -545,13 +606,29 @@ def _build_diagnostics(
     # ----------------------------------------------------
     # Diagnostics if there was an adjustment_failure
     # ----------------------------------------------------
-    diagnostics = pd.concat(
-        (
-            diagnostics,
-            # TODO: wire adjustment_failure to actual adjustment outcome instead of hardcoding 0
-            pd.DataFrame({"metric": ("adjustment_failure",), "val": (0,)}),
-        )
+    (
+        resolved_adjustment_failure,
+        resolved_adjustment_failure_reason,
+    ) = _resolve_adjustment_failure_metadata(model_dict)
+
+    diagnostics = _concat_metric_val_var(
+        diagnostics,
+        "adjustment_failure",
+        [resolved_adjustment_failure],
+        [None],
     )
+
+    if resolved_adjustment_failure_reason is not None:
+        # Schema matches the CLI failure path in `balance/cli.py` (e.g. lines
+        # 713-716, 855-861): the reason text lives in the ``val`` column with
+        # ``var=None``, so downstream consumers see a consistent
+        # ``adjustment_failure_reason`` row regardless of source.
+        diagnostics = _concat_metric_val_var(
+            diagnostics,
+            "adjustment_failure_reason",
+            [resolved_adjustment_failure_reason],
+            [None],
+        )
 
     diagnostics = diagnostics.reset_index(drop=True)
 

--- a/tests/test_ascii_plots.py
+++ b/tests/test_ascii_plots.py
@@ -837,6 +837,78 @@ class TestAsciiComparativeHistEndToEnd(balance.testutil.BalanceTestCase):
         )
         self.assertEqual(result, "No data available.")
 
+    def test_blog_v0_20_0_comparative_hist_population_adjusted_sample(
+        self,
+    ) -> None:
+        """Mirrors the "Comparative ASCII plots" snippet from the v0.20.0
+        blog post (``website/blog/2026/04/26/balance-0-20-0.md``)."""
+        from balance.sample_class import Sample
+
+        # pyrefly: ignore [bad-argument-type]
+        np.random.seed(0)
+        sample_df = pd.DataFrame(
+            {
+                "id": list(range(1, 21)),
+                "age": np.random.choice([20, 25, 30, 35, 40], size=20),
+                "gender": np.random.choice(["F", "M"], size=20, p=[0.7, 0.3]),
+                "outcome": np.random.normal(2.0, 1.0, size=20),
+                "weight": [1.0] * 20,
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": list(range(101, 151)),
+                "age": np.random.choice([20, 25, 30, 35, 40], size=50),
+                "gender": np.random.choice(["F", "M"], size=50, p=[0.5, 0.5]),
+                "outcome": np.random.normal(2.5, 1.0, size=50),
+                "weight": [1.0] * 50,
+            }
+        )
+        sample = Sample.from_frame(
+            sample_df,
+            id_column="id",
+            weight_column="weight",
+            outcome_columns=["outcome"],
+        )
+        target = Sample.from_frame(
+            target_df,
+            id_column="id",
+            weight_column="weight",
+            outcome_columns=["outcome"],
+        )
+        adjusted = sample.adjust(target, method="ipw")
+
+        dfs: List[DataFrameWithWeight] = [
+            {"df": target.df[["age"]], "weight": target.df["weight"]},
+            {"df": adjusted.df[["age"]], "weight": adjusted.df["weight"]},
+            {"df": sample.df[["age"]], "weight": sample.df["weight"]},
+        ]
+        rendered = ascii_comparative_hist(
+            dfs,
+            names=["population", "adjusted", "sample"],
+            column="age",
+            n_bins=4,
+            bar_width=20,
+        )
+
+        self._assert_lines_equal(
+            rendered,
+            """\
+            === age (numeric, comparative) ===
+
+            Range          | population (%)         | adjusted (%)              | sample (%)
+            -----------------------------------------------------------------------------------------------
+            [20.00, 25.00) | ██████████ 20.0        | ██████████▒▒ 25.0         | ██████████▒▒ 25.0
+            [25.00, 30.00) | ████████ 16.0          | ████████▒▒▒▒ 25.0         | ████████▒▒▒▒ 25.0
+            [30.00, 35.00) | ███████████████ 30.0   | █████         ] 10.3      | █████         ] 10.0
+            [35.00, 40.00] | █████████████████ 34.0 | █████████████████▒▒▒ 39.7 | █████████████████▒▒▒ 40.0
+            -----------------------------------------------------------------------------------------------
+            Total          | 100.0                  | 100.0                     | 100.0
+
+            Key: █ = shared with population, ▒ = excess,    ] = deficit
+            """,
+        )
+
 
 class TestAsciiPlotsAdjustmentEndToEnd(balance.testutil.BalanceTestCase):
     """End-to-end test: adjust a biased sample and verify ASCII plot output."""

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -4017,6 +4017,425 @@ class TestBalanceFrameSklearnLikeApi(BalanceTestCase):
         with self.assertRaisesRegex(ValueError, "positive sample and target weight"):
             fitted.predict_weights(data=holdout_bf)
 
+    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    @unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires scikit-learn >= 1.4")
+    def test_blog_v0_20_0_fit_and_predict_weights_on_holdout(self) -> None:
+        """Mirrors the "Reusable fit/predict workflows" snippet from the
+        v0.20.0 blog post (``website/blog/2026/04/26/balance-0-20-0.md``).
+        Keeps the published numbers in sync with library behavior. Gated on
+        sklearn ≥ 1.4 because the snapshot was generated against the same
+        environment the blog was rendered with — older sklearn drifts in the
+        last decimal of the IPW weights.
+        """
+        from sklearn.linear_model import LogisticRegression
+
+        sample_df = pd.DataFrame(
+            {
+                "id": ["1", "2", "3", "4", "5", "6"],
+                "age": [20, 25, 30, 35, 40, 45],
+                "gender": ["F", "F", "M", "M", "F", "M"],
+                "weight": [1.0] * 6,
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": ["11", "12", "13", "14", "15", "16", "17", "18"],
+                "age": [22, 27, 32, 37, 42, 47, 52, 57],
+                "gender": ["F", "M", "F", "M", "F", "M", "F", "M"],
+                "weight": [1.0] * 8,
+            }
+        )
+        holdout_df = pd.DataFrame(
+            {
+                "id": ["101", "102", "103"],
+                "age": [29, 41, 53],
+                "gender": ["F", "M", "F"],
+                "weight": [1.0, 1.0, 1.0],
+            }
+        )
+
+        sf = SampleFrame.from_frame(
+            sample_df,
+            id_column="id",
+            weight_column="weight",
+            covar_columns=["age", "gender"],
+            standardize_types=False,
+        )
+        tf = SampleFrame.from_frame(
+            target_df,
+            id_column="id",
+            weight_column="weight",
+            covar_columns=["age", "gender"],
+            standardize_types=False,
+        )
+        hf = SampleFrame.from_frame(
+            holdout_df,
+            id_column="id",
+            weight_column="weight",
+            covar_columns=["age", "gender"],
+            standardize_types=False,
+        )
+
+        bf = BalanceFrame(sample=sf, target=tf)
+        fitted = bf.fit(
+            method="ipw",
+            model=LogisticRegression(random_state=0, max_iter=200),
+            inplace=False,
+        )
+        bf_holdout = BalanceFrame(sample=hf, target=tf)
+
+        fitted_weights = fitted.weights().df["weight"].round(3).tolist()
+        holdout_weights = fitted.predict_weights(data=bf_holdout).round(3).tolist()
+
+        self.assertEqual(fitted_weights, [1.689, 1.127, 1.479, 1.083, 1.539, 1.083])
+        self.assertEqual(holdout_weights, [2.709, 2.582, 2.709])
+
+    @pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+    @unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires scikit-learn >= 1.4")
+    def test_blog_v0_20_0_set_fitted_model_holdout_summary(self) -> None:
+        """Mirrors the ``bf_holdout.set_fitted_model(fitted)`` +
+        ``bf_holdout.summary()`` variant of the v0.20.0 blog snippet
+        (``website/blog/2026/04/26/balance-0-20-0.md``). Gated on sklearn
+        ≥ 1.4 because the snapshot's ASMD/KLD figures drift in the last
+        decimal under older sklearn."""
+        from sklearn.linear_model import LogisticRegression
+
+        sample_df = pd.DataFrame(
+            {
+                "id": ["1", "2", "3", "4", "5", "6"],
+                "age": [20, 25, 30, 35, 40, 45],
+                "gender": ["F", "F", "M", "M", "F", "M"],
+                "weight": [1.0] * 6,
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": ["11", "12", "13", "14", "15", "16", "17", "18"],
+                "age": [22, 27, 32, 37, 42, 47, 52, 57],
+                "gender": ["F", "M", "F", "M", "F", "M", "F", "M"],
+                "weight": [1.0] * 8,
+            }
+        )
+        holdout_df = pd.DataFrame(
+            {
+                "id": ["101", "102", "103"],
+                "age": [29, 41, 53],
+                "gender": ["F", "M", "F"],
+                "weight": [1.0, 1.0, 1.0],
+            }
+        )
+
+        sf = SampleFrame.from_frame(
+            sample_df,
+            id_column="id",
+            weight_column="weight",
+            covar_columns=["age", "gender"],
+            standardize_types=False,
+        )
+        tf = SampleFrame.from_frame(
+            target_df,
+            id_column="id",
+            weight_column="weight",
+            covar_columns=["age", "gender"],
+            standardize_types=False,
+        )
+        hf = SampleFrame.from_frame(
+            holdout_df,
+            id_column="id",
+            weight_column="weight",
+            covar_columns=["age", "gender"],
+            standardize_types=False,
+        )
+
+        bf = BalanceFrame(sample=sf, target=tf)
+        fitted = bf.fit(
+            method="ipw",
+            model=LogisticRegression(random_state=0, max_iter=200),
+            inplace=False,
+        )
+
+        bf_holdout = BalanceFrame(sample=hf, target=tf)
+        bf_holdout.set_fitted_model(fitted)
+
+        expected = (
+            "Adjustment details:\n"
+            "    method: ipw\n"
+            "    weight trimming mean ratio: 20\n"
+            "Covariate diagnostics:\n"
+            "    Covar ASMD reduction: -4.5%\n"
+            "    Covar ASMD (3 variables): 0.217 -> 0.227\n"
+            "    Covar mean KLD reduction: -4.4%\n"
+            "    Covar mean KLD (2 variables): 0.036 -> 0.037\n"
+            "Weight diagnostics:\n"
+            "    design effect (Deff): 1.001\n"
+            "    effective sample size proportion (ESSP): 0.999\n"
+            "    effective sample size (ESS): 3.0\n"
+            "Model performance: Model proportion deviance explained: 0.150"
+        )
+
+        actual_lines = [
+            line.rstrip() for line in bf_holdout.summary().rstrip().splitlines()
+        ]
+        expected_lines = [line.rstrip() for line in expected.rstrip().splitlines()]
+        self.assertEqual(actual_lines, expected_lines)
+
+
+@pytest.mark.requires_sklearn_1_4  # pyre-ignore[56]
+@unittest.skipUnless(_SKLEARN_1_4_AVAILABLE, "requires scikit-learn >= 1.4")
+class TestBlogV0_20_0SimDataHoldout(BalanceTestCase):
+    """End-to-end tests for the v0.20.0 blog snippets that share a single
+    ``bf_holdout`` built from ``load_data()`` (``sim_data_01``). One
+    ``setUpClass`` fits IPW once and reuses the resulting BalanceFrame across
+    all tests; each test mirrors a code block in
+    ``website/blog/2026/04/26/balance-0-20-0.md`` so the published outputs
+    stay in sync with library behavior.
+
+    The whole class is gated on sklearn ≥ 1.4 because the snapshots
+    (IPW weights, ASMD/KLD/r_indicator numbers, ASCII-plot percentages,
+    column-aligned summary tables) match the environment the blog was
+    rendered with. Older sklearn drifts in the last decimal across all of
+    them, which would falsely trip the strict snapshot contract.
+    """
+
+    bf_holdout: BalanceFrame
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        from balance import load_data
+        from sklearn.linear_model import LogisticRegression
+
+        target_df, sample_df = load_data()
+        assert target_df is not None and sample_df is not None
+        train_df = sample_df.iloc[:100].copy()
+        holdout_df = sample_df.iloc[100:].copy()
+        covar_cols = ["age_group", "gender", "income"]
+
+        train_sf = SampleFrame.from_frame(
+            train_df,
+            id_column="id",
+            covar_columns=covar_cols,
+            outcome_columns=["happiness"],
+            standardize_types=False,
+        )
+        target_sf = SampleFrame.from_frame(
+            target_df,
+            id_column="id",
+            covar_columns=covar_cols,
+            outcome_columns=["happiness"],
+            standardize_types=False,
+        )
+        holdout_sf = SampleFrame.from_frame(
+            holdout_df,
+            id_column="id",
+            covar_columns=covar_cols,
+            outcome_columns=["happiness"],
+            standardize_types=False,
+        )
+
+        bf_train = BalanceFrame(sample=train_sf, target=target_sf)
+        fitted = bf_train.fit(
+            method="ipw",
+            model=LogisticRegression(random_state=0, max_iter=200),
+            inplace=False,
+        )
+
+        bf_holdout = BalanceFrame(sample=holdout_sf, target=target_sf)
+        bf_holdout.set_fitted_model(fitted)
+        cls.bf_holdout = bf_holdout
+
+    def test_blog_v0_20_0_simdata_holdout_summary(self) -> None:
+        """Mirrors ``print(bf_holdout.summary())`` from the "Reusable
+        fit/predict workflows" section."""
+        expected = (
+            "Adjustment details:\n"
+            "    method: ipw\n"
+            "    weight trimming mean ratio: 20\n"
+            "Covariate diagnostics:\n"
+            "    Covar ASMD reduction: 5.4%\n"
+            "    Covar ASMD (7 variables): 0.336 -> 0.318\n"
+            "    Covar mean KLD reduction: 37.2%\n"
+            "    Covar mean KLD (3 variables): 0.188 -> 0.118\n"
+            "Weight diagnostics:\n"
+            "    design effect (Deff): 1.292\n"
+            "    effective sample size proportion (ESSP): 0.774\n"
+            "    effective sample size (ESS): 696.5\n"
+            "Outcome weighted means:\n"
+            "            happiness\n"
+            "source\n"
+            "self           50.330\n"
+            "target         56.278\n"
+            "unadjusted     48.487\n"
+            "Model performance: Model proportion deviance explained: 0.572"
+        )
+        actual_lines = [
+            line.rstrip() for line in self.bf_holdout.summary().rstrip().splitlines()
+        ]
+        expected_lines = [line.rstrip() for line in expected.rstrip().splitlines()]
+        self.assertEqual(actual_lines, expected_lines)
+
+    def test_blog_v0_20_0_simdata_holdout_outcomes_summary(self) -> None:
+        """Mirrors ``bf_holdout.outcomes().summary()`` from the "How much
+        bias do the weights actually remove" section."""
+        # pyrefly: ignore [missing-attribute]
+        summary = self.bf_holdout.outcomes().summary()
+        expected = (
+            "1 outcomes: ['happiness']\n"
+            "Mean outcomes (with 95% confidence intervals):\n"
+            "source      self  target  unadjusted           self_ci         target_ci     unadjusted_ci\n"
+            "happiness  50.33  56.278      48.487  (49.275, 51.384)  (55.961, 56.595)  (47.551, 49.424)\n"
+            "\n"
+            "Weights impact on outcomes (t_test):\n"
+            "           mean_yw0  mean_yw1  mean_diff  diff_ci_lower  diff_ci_upper  t_stat  p_value      n\n"
+            "outcome\n"
+            "happiness    48.487     50.33      1.842         -0.214          3.898   1.759    0.079  900.0\n"
+            "\n"
+            "Response rates (relative to number of respondents in sample):\n"
+            "   happiness\n"
+            "n      900.0\n"
+            "%      100.0\n"
+            "Response rates (relative to notnull rows in the target):\n"
+            "    happiness\n"
+            "n      900.0\n"
+            "%        9.0\n"
+            "Response rates (in the target):\n"
+            "    happiness\n"
+            "n    10000.0\n"
+            "%      100.0"
+        )
+        actual_lines = [line.rstrip() for line in summary.rstrip().splitlines()]
+        expected_lines = [line.rstrip() for line in expected.rstrip().splitlines()]
+        self.assertEqual(actual_lines, expected_lines)
+
+    def test_blog_v0_20_0_simdata_holdout_r_indicator(self) -> None:
+        """Mirrors ``bf_holdout.weights().r_indicator()`` from the
+        "r_indicator for representativeness" section."""
+        # pyrefly: ignore [missing-attribute]
+        value = float(self.bf_holdout.weights().r_indicator())
+        self.assertAlmostEqual(value, 0.5094452588289895, places=10)
+
+    def test_blog_v0_20_0_simdata_holdout_ascii_plot_full_output(self) -> None:
+        """Mirrors ``bf_holdout.covars().plot(library='balance',
+        dist_type='hist_ascii')`` from the "Comparative ASCII plots" section.
+        Asserts on the full multi-section output (age_group, gender, income)
+        the blog reproduces verbatim — using auto-binning (Sturges' rule)
+        for the income histogram."""
+        rendered = self.bf_holdout.covars().plot(
+            library="balance", dist_type="hist_ascii"
+        )
+        assert isinstance(rendered, str)
+
+        expected = (
+            "=== age_group (categorical) ===\n"
+            "\n"
+            "Category | population  adjusted  sample\n"
+            "         |\n"
+            "18-24    | ████████████████████████ (19.7%)\n"
+            "         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (28.6%)\n"
+            "         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (48.6%)\n"
+            "\n"
+            "25-34    | █████████████████████████████████████ (29.7%)\n"
+            "         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (36.9%)\n"
+            "         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (30.2%)\n"
+            "\n"
+            "35-44    | █████████████████████████████████████ (29.9%)\n"
+            "         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (18.6%)\n"
+            "         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (15.7%)\n"
+            "\n"
+            "45+      | █████████████████████████ (20.6%)\n"
+            "         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (15.8%)\n"
+            "         | ▐▐▐▐▐▐▐ (5.6%)\n"
+            "\n"
+            "Legend: █ population  ▒ adjusted  ▐ sample\n"
+            "Bar lengths are proportional to weighted frequency within each dataset.\n"
+            "\n"
+            "=== gender (categorical) ===\n"
+            "\n"
+            "Category | population  adjusted  sample\n"
+            "         |\n"
+            "Female   | ██████████████████████████████████████████ (50.0%)\n"
+            "         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (28.7%)\n"
+            "         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (29.2%)\n"
+            "\n"
+            "Male     | ██████████████████████████████████████████ (50.0%)\n"
+            "         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (71.3%)\n"
+            "         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (70.8%)\n"
+            "\n"
+            "Legend: █ population  ▒ adjusted  ▐ sample\n"
+            "Bar lengths are proportional to weighted frequency within each dataset.\n"
+            "\n"
+            "=== income (numeric, comparative) ===\n"
+            "\n"
+            "Range            | population (%) | adjusted (%)      | sample (%)\n"
+            "-------------------------------------------------------------------------\n"
+            "[0.00, 8.57)     | ████████ 49.0  | ████████▒▒▒▒ 72.6 | ████████▒▒▒▒ 73.4\n"
+            "[8.57, 17.14)    | ████ 23.1      | ███] 20.3         | ███] 19.1\n"
+            "[17.14, 25.71)   | ██ 13.2        | █] 5.0            | █] 5.1\n"
+            "[25.71, 34.28)   | █ 7.3          | ] 1.3             | ] 1.6\n"
+            "[34.28, 42.85)   | █ 3.9          | ] 0.4             | ] 0.4\n"
+            "[42.85, 51.41)   | 1.8            | 0.1               | 0.1\n"
+            "[51.41, 59.98)   | 0.9            | 0.3               | 0.2\n"
+            "[59.98, 68.55)   | 0.4            | 0.0               | 0.0\n"
+            "[68.55, 77.12)   | 0.2            | 0.0               | 0.0\n"
+            "[77.12, 85.69)   | 0.1            | 0.0               | 0.0\n"
+            "[85.69, 94.26)   | 0.0            | 0.0               | 0.0\n"
+            "[94.26, 102.83)  | 0.0            | 0.0               | 0.0\n"
+            "[102.83, 111.40) | 0.0            | 0.0               | 0.0\n"
+            "[111.40, 119.97) | 0.0            | 0.0               | 0.0\n"
+            "[119.97, 128.54] | 0.0            | 0.0               | 0.0\n"
+            "-------------------------------------------------------------------------\n"
+            "Total            | 100.0          | 100.0             | 100.0\n"
+            "\n"
+            "Key: █ = shared with population, ▒ = excess,    ] = deficit"
+        )
+
+        actual_lines = [line.rstrip() for line in rendered.rstrip().splitlines()]
+        expected_lines = [line.rstrip() for line in expected.rstrip().splitlines()]
+        self.assertEqual(actual_lines, expected_lines)
+
+    def test_blog_v0_20_0_simdata_holdout_covars_kld(self) -> None:
+        """Mirrors ``bf_holdout.covars().kld()`` from the "Distribution
+        distances on raw categoricals" section."""
+        # pyrefly: ignore [missing-attribute]
+        kld = self.bf_holdout.covars().kld().round(6)
+        self.assertEqual(list(kld.index), ["self", "unadjusted", "unadjusted - self"])
+        self.assertEqual(
+            list(kld.columns), ["age_group", "gender", "income", "mean(kld)"]
+        )
+        self.assertEqual(kld.loc["self", "age_group"], 0.056796)
+        self.assertEqual(kld.loc["self", "gender"], 0.188210)
+        self.assertEqual(kld.loc["self", "income"], 0.109138)
+        self.assertEqual(kld.loc["self", "mean(kld)"], 0.118048)
+        self.assertEqual(kld.loc["unadjusted", "age_group"], 0.268381)
+        self.assertEqual(kld.loc["unadjusted", "gender"], 0.183109)
+        self.assertEqual(kld.loc["unadjusted", "income"], 0.112641)
+        self.assertEqual(kld.loc["unadjusted", "mean(kld)"], 0.188044)
+        self.assertEqual(kld.loc["unadjusted - self", "age_group"], 0.211585)
+        self.assertEqual(kld.loc["unadjusted - self", "gender"], -0.005101)
+        self.assertEqual(kld.loc["unadjusted - self", "income"], 0.003503)
+        self.assertEqual(kld.loc["unadjusted - self", "mean(kld)"], 0.069996)
+
+    def test_blog_v0_20_0_simdata_holdout_chained_poststratify(self) -> None:
+        """Mirrors ``bf_holdout.adjust(method='poststratify',
+        formula='age_group:gender')`` + ``adj.summary()`` from the
+        "Sequential adjustments + formula support in poststratification"
+        section. Confirms compound adjustment improves overall ASMD/KLD
+        beyond IPW alone."""
+        adj = self.bf_holdout.adjust(method="poststratify", formula="age_group:gender")
+        summary = adj.summary()
+
+        self.assertIn("method: poststratify", summary)
+        self.assertIn("Covar ASMD reduction: 47.9%", summary)
+        self.assertIn("Covar ASMD (7 variables): 0.336 -> 0.175", summary)
+        self.assertIn("Covar mean KLD reduction: 67.2%", summary)
+        self.assertIn("Covar mean KLD (3 variables): 0.188 -> 0.062", summary)
+        self.assertIn("design effect (Deff): 2.395", summary)
+        self.assertIn("effective sample size proportion (ESSP): 0.417", summary)
+        self.assertIn("effective sample size (ESS): 375.7", summary)
+        # Outcome means in the expected order.
+        self.assertIn("self           55.453", summary)
+        self.assertIn("target         56.278", summary)
+        self.assertIn("unadjusted     48.487", summary)
+
 
 # =====================================================================
 # Coverage tests for uncovered lines in balance_frame.py

--- a/tests/test_balancedf.py
+++ b/tests/test_balancedf.py
@@ -550,6 +550,78 @@ class TestBalanceDFOutcomes(BalanceTestCase):
         summary = sample.outcomes().summary()
         self.assertIn("Weights impact on outcomes (t_test)", summary)
 
+    def test_blog_v0_20_0_outcomes_summary_full_output(self) -> None:
+        """Mirrors the "How much bias do the weights actually remove" snippet
+        from the v0.20.0 blog post
+        (``website/blog/2026/04/26/balance-0-20-0.md``). Asserts on the full
+        rendered summary so the published numbers stay in sync with library
+        behavior.
+        """
+        # pyrefly: ignore [bad-argument-type]
+        np.random.seed(0)
+        sample_df = pd.DataFrame(
+            {
+                "id": list(range(1, 21)),
+                "age": np.random.choice([20, 25, 30, 35, 40], size=20),
+                "gender": np.random.choice(["F", "M"], size=20, p=[0.7, 0.3]),
+                "outcome": np.random.normal(2.0, 1.0, size=20),
+                "weight": [1.0] * 20,
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": list(range(101, 151)),
+                "age": np.random.choice([20, 25, 30, 35, 40], size=50),
+                "gender": np.random.choice(["F", "M"], size=50, p=[0.5, 0.5]),
+                "outcome": np.random.normal(2.5, 1.0, size=50),
+                "weight": [1.0] * 50,
+            }
+        )
+        sample = Sample.from_frame(
+            sample_df,
+            id_column="id",
+            weight_column="weight",
+            outcome_columns=["outcome"],
+        )
+        target = Sample.from_frame(
+            target_df,
+            id_column="id",
+            weight_column="weight",
+            outcome_columns=["outcome"],
+        )
+        adjusted = sample.adjust(target, method="ipw")
+        # pyrefly: ignore [missing-attribute]
+        summary = adjusted.outcomes().summary()
+
+        expected = (
+            "1 outcomes: ['outcome']\n"
+            "Mean outcomes (with 95% confidence intervals):\n"
+            "source    self  target  unadjusted         self_ci       target_ci   unadjusted_ci\n"
+            "outcome  1.924   2.431       1.929  (1.434, 2.413)  (2.175, 2.686)  (1.438, 2.419)\n"
+            "\n"
+            "Weights impact on outcomes (t_test):\n"
+            "         mean_yw0  mean_yw1  mean_diff  diff_ci_lower  diff_ci_upper  t_stat  p_value     n\n"
+            "outcome\n"
+            "outcome     1.929     1.924     -0.005         -0.024          0.014  -0.539    0.596  20.0\n"
+            "\n"
+            "Response rates (relative to number of respondents in sample):\n"
+            "   outcome\n"
+            "n     20.0\n"
+            "%    100.0\n"
+            "Response rates (relative to notnull rows in the target):\n"
+            "    outcome\n"
+            "n     20.0\n"
+            "%     40.0\n"
+            "Response rates (in the target):\n"
+            "    outcome\n"
+            "n     50.0\n"
+            "%    100.0"
+        )
+
+        actual_lines = [line.rstrip() for line in summary.rstrip().splitlines()]
+        expected_lines = [line.rstrip() for line in expected.rstrip().splitlines()]
+        self.assertEqual(actual_lines, expected_lines)
+
 
 class TestBalanceDFCovars(BalanceTestCase):
     """Test cases for BalanceDFCovars class functionality."""

--- a/tests/test_poststratify.py
+++ b/tests/test_poststratify.py
@@ -469,6 +469,44 @@ class Testpoststratify(
             pd.Series([4.0, 4.0, 2.0, 6.0], name="w"),
         )
 
+    def test_blog_v0_20_0_poststratify_interaction_formula(self) -> None:
+        """Mirrors the "Formula support for poststratification" snippet from
+        the v0.20.0 blog post
+        (``website/blog/2026/04/26/balance-0-20-0.md``)."""
+        sample_df = pd.DataFrame(
+            {
+                "id": ["1", "2", "3", "4"],
+                "gender": ["F", "F", "M", "M"],
+                "age_group": ["18-34", "35+", "18-34", "35+"],
+                "weight": [1.0, 1.0, 1.0, 1.0],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": ["11", "12", "13", "14", "15", "16"],
+                "gender": ["F", "F", "F", "M", "M", "M"],
+                "age_group": ["18-34", "18-34", "35+", "18-34", "35+", "35+"],
+                "weight": [1.0] * 6,
+            }
+        )
+
+        sample = Sample.from_frame(
+            sample_df,
+            id_column="id",
+            weight_column="weight",
+            standardize_types=False,
+        )
+        target = Sample.from_frame(
+            target_df,
+            id_column="id",
+            weight_column="weight",
+            standardize_types=False,
+        )
+        adj = sample.adjust(target, method="poststratify", formula="gender:age_group")
+
+        weights = adj.weights().df["weight"].round(3).tolist()
+        self.assertEqual(weights, [2.0, 1.0, 1.0, 2.0])
+
     def test_poststratify_formula_edge_cases(self) -> None:
         s = pd.DataFrame(
             {

--- a/tests/test_sample_diagnostics_helper.py
+++ b/tests/test_sample_diagnostics_helper.py
@@ -5,6 +5,10 @@
 
 # pyre-strict
 
+from __future__ import annotations
+
+from typing import Any
+
 import numpy as np
 import pandas as pd
 from balance.sample_class import Sample
@@ -445,3 +449,162 @@ def test_build_diagnostics_model_dict_none_shows_unknown_method() -> None:
     method_rows = result[result["metric"] == "adjustment_method"]
     assert len(method_rows) == 1
     assert method_rows["var"].iloc[0] == "unknown"
+
+
+def test_build_diagnostics_uses_model_adjustment_failure_metadata() -> None:
+    """_build_diagnostics should propagate adjustment failure metadata from model_dict."""
+    sample = Sample.from_frame(
+        pd.DataFrame({"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}),
+        id_column="id",
+        weight_column="weight",
+        standardize_types=False,
+    )
+    target = Sample.from_frame(
+        pd.DataFrame({"id": ["3", "4"], "x": [0, 1], "weight": [1.0, 1.0]}),
+        id_column="id",
+        weight_column="weight",
+        standardize_types=False,
+    )
+    adjusted = sample.set_target(target).adjust(method="null")
+
+    model_dict = {
+        "method": "null",
+        "adjustment_failure": 1,
+        "adjustment_failure_reason": "boom",
+    }
+
+    result = _build_diagnostics(
+        covars_df=adjusted.covars().df,
+        # pyrefly: ignore [unsupported-operation]
+        target_covars_df=adjusted._links["target"].covars().df,
+        weights_summary=adjusted.weights().summary(),
+        model_dict=model_dict,
+        covars_asmd=adjusted.covars().asmd(),
+        covars_asmd_main=adjusted.covars().asmd(aggregate_by_main_covar=True),
+        outcome_columns=adjusted._outcome_columns,
+        weights_impact_on_outcome_method="t_test",
+        weights_impact_on_outcome_conf_level=0.95,
+        outcome_impact=None,
+    )
+
+    failure_rows = result[result["metric"] == "adjustment_failure"]
+    assert len(failure_rows) == 1
+    assert int(failure_rows["val"].iloc[0]) == 1
+
+    reason_rows = result[result["metric"] == "adjustment_failure_reason"]
+    assert len(reason_rows) == 1
+    # Schema matches CLI failure rows (balance/cli.py:713-716): reason in
+    # ``val``, ``var`` is None.
+    assert reason_rows["val"].iloc[0] == "boom"
+
+
+def test_build_diagnostics_omits_reason_when_failure_is_zero() -> None:
+    """Failure reason should not be emitted when adjustment_failure resolves to zero."""
+    sample = Sample.from_frame(
+        pd.DataFrame({"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}),
+        id_column="id",
+        weight_column="weight",
+        standardize_types=False,
+    )
+    target = Sample.from_frame(
+        pd.DataFrame({"id": ["3", "4"], "x": [0, 1], "weight": [1.0, 1.0]}),
+        id_column="id",
+        weight_column="weight",
+        standardize_types=False,
+    )
+    adjusted = sample.set_target(target).adjust(method="null")
+
+    model_dict = {
+        "method": "null",
+        "adjustment_failure": 0,
+        "adjustment_failure_reason": "should-not-appear",
+    }
+
+    result = _build_diagnostics(
+        covars_df=adjusted.covars().df,
+        # pyrefly: ignore [unsupported-operation]
+        target_covars_df=adjusted._links["target"].covars().df,
+        weights_summary=adjusted.weights().summary(),
+        model_dict=model_dict,
+        covars_asmd=adjusted.covars().asmd(),
+        covars_asmd_main=adjusted.covars().asmd(aggregate_by_main_covar=True),
+        outcome_columns=adjusted._outcome_columns,
+        weights_impact_on_outcome_method="t_test",
+        weights_impact_on_outcome_conf_level=0.95,
+        outcome_impact=None,
+    )
+
+    failure_rows = result[result["metric"] == "adjustment_failure"]
+    assert len(failure_rows) == 1
+    assert int(failure_rows["val"].iloc[0]) == 0
+    assert "adjustment_failure_reason" not in set(result["metric"].values)
+
+
+def _get_adjustment_failure_from_diagnostics(
+    model_dict: dict[str, Any] | None,
+) -> tuple[int, str | None]:
+    """Call _build_diagnostics with the given model_dict and return (failure, reason)."""
+    sample = Sample.from_frame(
+        pd.DataFrame({"id": ["1", "2"], "x": [0, 1], "weight": [1.0, 2.0]}),
+        id_column="id",
+        weight_column="weight",
+        standardize_types=False,
+    )
+    target = Sample.from_frame(
+        pd.DataFrame({"id": ["3", "4"], "x": [0, 1], "weight": [1.0, 1.0]}),
+        id_column="id",
+        weight_column="weight",
+        standardize_types=False,
+    )
+    adjusted = sample.set_target(target).adjust(method="null")
+
+    result = _build_diagnostics(
+        covars_df=adjusted.covars().df,
+        # pyrefly: ignore [unsupported-operation]
+        target_covars_df=adjusted._links["target"].covars().df,
+        weights_summary=adjusted.weights().summary(),
+        model_dict=model_dict,
+        covars_asmd=adjusted.covars().asmd(),
+        covars_asmd_main=adjusted.covars().asmd(aggregate_by_main_covar=True),
+        outcome_columns=adjusted._outcome_columns,
+        weights_impact_on_outcome_method="t_test",
+        weights_impact_on_outcome_conf_level=0.95,
+        outcome_impact=None,
+    )
+
+    failure_rows = result[result["metric"] == "adjustment_failure"]
+    failure_val = int(failure_rows["val"].iloc[0])
+    reason_rows = result[result["metric"] == "adjustment_failure_reason"]
+    # Reason lives in ``val`` (matches the CLI failure-row schema in
+    # balance/cli.py:713-716).
+    reason_val = reason_rows["val"].iloc[0] if len(reason_rows) > 0 else None
+    return failure_val, reason_val
+
+
+def test_build_diagnostics_adjustment_failure_edge_cases() -> None:
+    """_build_diagnostics should normalize varied adjustment_failure input shapes."""
+    assert _get_adjustment_failure_from_diagnostics(None) == (0, None)
+    assert _get_adjustment_failure_from_diagnostics({"method": "null"}) == (0, None)
+    assert _get_adjustment_failure_from_diagnostics(
+        {"method": "null", "adjustment_failure": True}
+    ) == (1, None)
+    assert _get_adjustment_failure_from_diagnostics(
+        {"method": "null", "adjustment_failure": "yes"}
+    ) == (1, None)
+    assert _get_adjustment_failure_from_diagnostics(
+        {
+            "method": "null",
+            "adjustment_failure": 1.0,
+            "adjustment_failure_reason": " boom ",
+        }
+    ) == (1, "boom")
+    assert _get_adjustment_failure_from_diagnostics(
+        {"method": "null", "adjustment_failure": float("nan")}
+    ) == (0, None)
+    assert _get_adjustment_failure_from_diagnostics(
+        {
+            "method": "null",
+            "adjustment_failure": 0,
+            "adjustment_failure_reason": "ignored",
+        }
+    ) == (0, None)

--- a/tests/test_stats_and_plots.py
+++ b/tests/test_stats_and_plots.py
@@ -1800,6 +1800,14 @@ class TestBalance_weighted_comparisons_stats(
         self.assertAlmostEqual(result, expected)
         self.assertIsInstance(result, np.float64)
 
+    def test_r_indicator_blog_v0_20_0_example(self) -> None:
+        """Mirrors the "r_indicator for representativeness" snippet from the
+        v0.20.0 blog post (``website/blog/2026/04/26/balance-0-20-0.md``)."""
+        sample_p = [0.2, 0.4, 0.6, 0.8]
+        target_p = [0.3, 0.5, 0.7, 0.9]
+        result = weighted_comparisons_stats.r_indicator(sample_p, target_p)
+        self.assertEqual(round(float(result), 6), 0.510102)
+
     def test_r_indicator_constant_propensities(self) -> None:
         """r_indicator should be 1.0 when all propensities are identical."""
         result = weighted_comparisons_stats.r_indicator([0.5, 0.5], [0.5, 0.5])

--- a/tests/test_weighted_comparisons_plots.py
+++ b/tests/test_weighted_comparisons_plots.py
@@ -1815,6 +1815,73 @@ class TestPlotlyPlotQQPlotIt(balance.testutil.BalanceTestCase):
             mock_iplot.assert_called()
 
 
+class TestPlotlyIplotNbformatFallback(balance.testutil.BalanceTestCase):
+    """Tests for notebook-dependency fallback via public plotly_plot_qq."""
+
+    def _make_qq_data(self) -> dict[str, pd.DataFrame]:
+        # pyrefly: ignore [bad-argument-type]
+        np.random.seed(42)
+        df = pd.DataFrame({"v1": np.random.randn(30), "weight": np.ones(30)})
+        return {"self": df, "target": df.copy()}
+
+    def test_plotly_plot_qq_skips_plot_when_nbformat_missing(self) -> None:
+        from balance.stats_and_plots.weighted_comparisons_plots import plotly_plot_qq
+
+        dict_of_dfs = self._make_qq_data()
+        with patch(
+            "plotly.offline.iplot",
+            side_effect=ValueError(
+                "Mime type rendering requires nbformat>=4.2.0 but it is not installed"
+            ),
+        ) as mock_iplot:
+            with self.assertLogs(
+                "balance.stats_and_plots", level="WARNING"
+            ) as log_context:
+                result = plotly_plot_qq(
+                    dict_of_dfs,
+                    variables=["v1"],
+                    plot_it=True,
+                    return_dict_of_figures=True,
+                )
+            mock_iplot.assert_called_once()
+            self.assertTrue(
+                any("skipping interactive plot" in line for line in log_context.output)
+            )
+        self.assertIsNotNone(result)
+        assert result is not None  # type narrowing for Pyre
+        self.assertIn("v1", result)
+
+    def test_plotly_plot_qq_skips_plot_for_generic_nbformat_mime_error(self) -> None:
+        from balance.stats_and_plots.weighted_comparisons_plots import plotly_plot_qq
+
+        dict_of_dfs = self._make_qq_data()
+        with patch(
+            "plotly.offline.iplot",
+            side_effect=ValueError("MIME rendering requires nbformat support"),
+        ) as mock_iplot:
+            with self.assertLogs("balance.stats_and_plots", level="WARNING"):
+                plotly_plot_qq(
+                    dict_of_dfs,
+                    variables=["v1"],
+                    plot_it=True,
+                    return_dict_of_figures=True,
+                )
+            mock_iplot.assert_called_once()
+
+    def test_plotly_plot_qq_reraises_other_value_errors(self) -> None:
+        from balance.stats_and_plots.weighted_comparisons_plots import plotly_plot_qq
+
+        dict_of_dfs = self._make_qq_data()
+        with patch("plotly.offline.iplot", side_effect=ValueError("other")):
+            with self.assertRaisesRegex(ValueError, "other"):
+                plotly_plot_qq(
+                    dict_of_dfs,
+                    variables=["v1"],
+                    plot_it=True,
+                    return_dict_of_figures=True,
+                )
+
+
 class TestPlotlyPlotDistNoSampleKey(balance.testutil.BalanceTestCase):
     """Test cases for plotly_plot_dist without 'sample' key."""
 

--- a/website/blog/2026/04/26/balance-0-20-0.md
+++ b/website/blog/2026/04/26/balance-0-20-0.md
@@ -1,0 +1,366 @@
+---
+title: Balance v0.20.0 - reusable fit/predict weighting workflows, richer diagnostics, and a refactored core
+
+authors:
+  - name: Soumyadip Sarkar
+    title: Independent Researcher
+    url: https://www.linkedin.com/in/neuralsorcerer
+  - name: Tal Galili
+    title: Machine Learning Engineer @ Meta
+    url: https://www.linkedin.com/in/tal-galili-5993085/
+
+tags: [python, open-source, survey-statistics, package-update]
+hide_table_of_contents: true
+---
+
+🎉 **balance v0.20.0 is out!**
+
+### What is balance?
+
+[**balance**](https://pypi.org/project/balance/) is a Python package (from Meta) for dealing with biased samples when estimating population-level quantities. It supports common survey-weighting workflows (e.g., IPW, CBPS, rake, poststratify), diagnostics, and CLI-based pipelines.
+
+### What's new since 0.15.0 -> 0.20.0?
+
+Highlights: **balance now offers a reusable, sklearn-style fit/predict workflow for survey weighting**: fit a weighting model once on one sample-and-target pair, then apply it to a different (e.g., larger or later-arriving) cohort with a single call. Under the hood, this is supported by a substantial architectural refactor — `Sample` is now a thin facade over two new classes (`SampleFrame` for data + column-role metadata, `BalanceFrame` for adjustment orchestration), all while keeping the existing `Sample` API fully backward compatible.
+
+Around that core change, this release line also brings stronger diagnostics (confidence intervals for the bias the weights manage to remove from an outcome, the `r_indicator` representativeness statistic, comparative ASCII plots for LLM/CLI workflows), formula support in places that previously only accepted variable lists, pandas 3.x compatibility, and a number of validation/robustness improvements.
+
+[![balance_logo_horizontal](https://raw.githubusercontent.com/facebookresearch/balance/main/website/static/img/balance_logo/PNG/Horizontal/balance_Logo_Horizontal_FullColor_RGB.png)](https://import-balance.org/)
+
+<!--truncate-->
+
+## Reusable fit/predict workflows
+
+Before 0.20.0, fitting weights and using them was a single act: you pointed `Sample.adjust(...)` at a sample/target pair and got back an adjusted object. If new responders arrived next week, or you wanted to score a holdout (often, much larger) cohort with the same model, you had to refit from scratch.
+
+The balance library now supports an explicit, reusable workflow - modeled after sklearn:
+
+- `fit(...)` — fit a weighting model (IPW, CBPS, or poststratify)
+- `predict_weights(data=...)` — generate weights on a separate `BalanceFrame` with the same covariate schema
+- Also:
+    - `set_fitted_model(fitted)` - for transferring a fitted model from one frame to another.
+    - `predict_proba(...)` — predicted propensities on training or new data
+    - `design_matrix(...)` — inspect the design matrix used for fitting/scoring
+
+Each fit stores everything needed to reconstruct weights on new data: training design weights, trimming options, CBPS coefficients, poststratify cell-ratio tables, NA handling, and so on.
+This is the workflow that was hardest to express before, and it is now a one-liner:
+
+For the rest of this post we'll use balance's bundled simulated data — `sim_data_01` — which contains a 1000-row biased sample and a 10000-row target with covariates (`age_group`, `gender`, `income`) and an outcome (`happiness`). We split the sample into a 100-row training slice and a 900-row holdout slice, fit the IPW model on training, and transfer it to the holdout. We'll keep `bf_holdout` around as our running example for every diagnostic in the rest of this post (you could equally use `Sample` here — the `BalanceFrame` API mirrors it):
+
+```python
+from sklearn.linear_model import LogisticRegression
+from balance import BalanceFrame, SampleFrame, load_data
+
+target_df, sample_df = load_data()
+train_df = sample_df.iloc[:100].copy()
+holdout_df = sample_df.iloc[100:].copy()
+
+covar_cols = ["age_group", "gender", "income"]
+train_sf   = SampleFrame.from_frame(train_df,   id_column="id", covar_columns=covar_cols, outcome_columns=["happiness"], standardize_types=False)
+target_sf  = SampleFrame.from_frame(target_df,  id_column="id", covar_columns=covar_cols, outcome_columns=["happiness"], standardize_types=False)
+holdout_sf = SampleFrame.from_frame(holdout_df, id_column="id", covar_columns=covar_cols, outcome_columns=["happiness"], standardize_types=False)
+
+bf_train = BalanceFrame(sample=train_sf, target=target_sf)
+fitted = bf_train.fit(method="ipw", model=LogisticRegression(random_state=0, max_iter=200), inplace=False)
+
+bf_holdout = BalanceFrame(sample=holdout_sf, target=target_sf)
+bf_holdout.set_fitted_model(fitted)
+
+print(bf_holdout.summary())
+# Can also use fitted.predict_weights(data=bf_holdout) to only get the weights for the holdout
+```
+
+Output:
+
+```text
+Adjustment details:
+    method: ipw
+    weight trimming mean ratio: 20
+Covariate diagnostics:
+    Covar ASMD reduction: 5.4%
+    Covar ASMD (7 variables): 0.336 -> 0.318
+    Covar mean KLD reduction: 37.2%
+    Covar mean KLD (3 variables): 0.188 -> 0.118
+Weight diagnostics:
+    design effect (Deff): 1.292
+    effective sample size proportion (ESSP): 0.774
+    effective sample size (ESS): 696.5
+Outcome weighted means:
+            happiness
+source
+self           50.330
+target         56.278
+unadjusted     48.487
+Model performance: Model proportion deviance explained: 0.572
+```
+
+## A refactored core (without breaking the old API)
+
+The fit/predict workflow above is possible because `Sample` was split internally into two foundational classes:
+
+- **`SampleFrame`** — a DataFrame container that explicitly tracks which columns are covariates, weights, outcomes, predicted outcomes, and ignored. Created via `SampleFrame.from_frame()`. Adds first-class weight-history management (`add_weight_column()`, `set_active_weight()`, `rename_weight_column()`, `set_weight_metadata()`).
+- **`BalanceFrame`** — an adjustment orchestrator that pairs a responder `SampleFrame` with a target `SampleFrame`. It owns `set_target()`, `adjust()`, `summary()`, `diagnostics()`, `covars()/weights()/outcomes()`, plus the new fit/predict surface.
+
+`Sample` now inherits from both (`Sample → BalanceFrame → SampleFrame → object`). **No public `Sample` API changes**: every existing call site continues to work. There are also bidirectional conversions (`Sample.to_sample_frame()`, `BalanceFrame.from_sample(...)`, `BalanceFrame.to_sample()`) so you can move between the convenience facade and the more composable classes as needed.
+
+A practical bonus of the refactor: `adjust()` can now be called multiple times on the same object, **compounding adjustments** (e.g., IPW first to fix broad imbalances, then rake on a specific marginal). The original unadjusted baseline is preserved for diagnostics like `asmd_improvement()`. There is also a new `set_as_pre_adjust()` to lock in the current state as a fresh pre-adjust baseline.
+
+For the deep dive into the architectural change (class hierarchy, `_links` graph, weight-history tracking), see the [0.19.0 architecture document](https://github.com/facebookresearch/balance/blob/main/docs/architecture/architecture_0_19_0.md).
+
+## Stronger diagnostics
+
+### How much bias do the weights actually remove from your outcome?
+
+ASMD tells you whether covariates are better balanced after weighting. It does *not* directly tell you how much the weights changed your outcome estimate, or whether that change is statistically meaningful. balance now exposes paired outcome-weight impact diagnostics — comparing `y * w_unadjusted` to `y * w_adjusted` — with p-value and confidence intervals, available through `BalanceDFOutcomes`, `Sample.diagnostics()`, and the CLI (`--weights_impact_on_outcome_method`):
+
+```python
+print(bf_holdout.outcomes().summary())
+```
+
+Output:
+
+```text
+1 outcomes: ['happiness']
+Mean outcomes (with 95% confidence intervals):
+source      self  target  unadjusted           self_ci         target_ci     unadjusted_ci
+happiness  50.33  56.278      48.487  (49.275, 51.384)  (55.961, 56.595)  (47.551, 49.424)
+
+Weights impact on outcomes (t_test):
+           mean_yw0  mean_yw1  mean_diff  diff_ci_lower  diff_ci_upper  t_stat  p_value      n
+outcome
+happiness    48.487     50.33      1.842         -0.214          3.898   1.759    0.079  900.0
+
+Response rates (relative to number of respondents in sample):
+   happiness
+n      900.0
+%      100.0
+Response rates (relative to notnull rows in the target):
+    happiness
+n      900.0
+%        9.0
+Response rates (in the target):
+    happiness
+n    10000.0
+%      100.0
+```
+
+The "Weights impact on outcomes" block is the new piece: `mean_yw0` and `mean_yw1` are the unweighted vs. weighted outcome means, `mean_diff` is their difference, with a CI and a paired-sample test on the per-row impact `y * (w1 − w0)`. Here the weights nudge `happiness` from 48.5 → 50.3 (closer to the target's 56.3), but the CI still includes zero and `p ≈ 0.08` — moderate but not statistically significant evidence that this propensity model meaningfully shifted the outcome estimate.
+
+### `r_indicator` for representativeness
+
+The R-indicator (Schouten et al.) is a single scalar summarizing how representative a sample is of a target, derived from the spread of estimated response propensities. balance now ships a validated `r_indicator(sample_p, target_p)` (Eq. 2.2.2 over concatenated propensity vectors, with input validation), plus a convenience `sample.weights().r_indicator()`:
+
+```python
+print(bf_holdout.weights().r_indicator())
+```
+
+```text
+0.5094452588289895
+```
+
+R takes values in `[0, 1]`: **1** means the sample is fully representative of the target (response propensities are identical for everyone — i.e., constant), and **0** is the worst case (maximum spread in propensities, indicating strong selection). The ~0.51 value here flags substantial non-response bias in this sample/target pair, consistent with the heavily skewed gender and age_group marginals shown elsewhere in this post.
+
+### Comparative ASCII plots (LLM- and terminal-friendly)
+
+Distribution diagnostics now have a proper text-based mode, available straight off `BalanceFrame.covars().plot(library="balance", dist_type="hist_ascii")`. Categorical variables render as grouped horizontal bars, numeric variables as a comparative histogram (population → adjusted → sample, with `█` shared with population, `▒` excess, `]` deficit). This makes it easy to inspect adjustments in plain text — particularly useful for CLI workflows, log captures, and LLM agents reading reports.
+
+```python
+print(bf_holdout.covars().plot(library="balance", dist_type="hist_ascii"))
+```
+
+Output (one section per covariate — categoricals as grouped bars, numeric `income` as a comparative histogram with auto-binning via Sturges' rule):
+
+```text
+=== age_group (categorical) ===
+
+Category | population  adjusted  sample
+         |
+18-24    | ████████████████████████ (19.7%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (28.6%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (48.6%)
+
+25-34    | █████████████████████████████████████ (29.7%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (36.9%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (30.2%)
+
+35-44    | █████████████████████████████████████ (29.9%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (18.6%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (15.7%)
+
+45+      | █████████████████████████ (20.6%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (15.8%)
+         | ▐▐▐▐▐▐▐ (5.6%)
+
+Legend: █ population  ▒ adjusted  ▐ sample
+Bar lengths are proportional to weighted frequency within each dataset.
+
+=== gender (categorical) ===
+
+Category | population  adjusted  sample
+         |
+Female   | ██████████████████████████████████████████ (50.0%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (28.7%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (29.2%)
+
+Male     | ██████████████████████████████████████████ (50.0%)
+         | ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ (71.3%)
+         | ▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐▐ (70.8%)
+
+Legend: █ population  ▒ adjusted  ▐ sample
+Bar lengths are proportional to weighted frequency within each dataset.
+
+=== income (numeric, comparative) ===
+
+Range            | population (%) | adjusted (%)      | sample (%)
+-------------------------------------------------------------------------
+[0.00, 8.57)     | ████████ 49.0  | ████████▒▒▒▒ 72.6 | ████████▒▒▒▒ 73.4
+[8.57, 17.14)    | ████ 23.1      | ███] 20.3         | ███] 19.1
+[17.14, 25.71)   | ██ 13.2        | █] 5.0            | █] 5.1
+[25.71, 34.28)   | █ 7.3          | ] 1.3             | ] 1.6
+[34.28, 42.85)   | █ 3.9          | ] 0.4             | ] 0.4
+[42.85, 51.41)   | 1.8            | 0.1               | 0.1
+[51.41, 59.98)   | 0.9            | 0.3               | 0.2
+[59.98, 68.55)   | 0.4            | 0.0               | 0.0
+[68.55, 77.12)   | 0.2            | 0.0               | 0.0
+[77.12, 85.69)   | 0.1            | 0.0               | 0.0
+[85.69, 94.26)   | 0.0            | 0.0               | 0.0
+[94.26, 102.83)  | 0.0            | 0.0               | 0.0
+[102.83, 111.40) | 0.0            | 0.0               | 0.0
+[111.40, 119.97) | 0.0            | 0.0               | 0.0
+[119.97, 128.54] | 0.0            | 0.0               | 0.0
+-------------------------------------------------------------------------
+Total            | 100.0          | 100.0             | 100.0
+
+Key: █ = shared with population, ▒ = excess,    ] = deficit
+```
+
+`age_group` gets a clear correction — the sample's `18-24` over-representation (48.6% vs 19.7% in the population) is pulled down to 28.6% post-adjustment. `gender` barely moves (sample 29.2% Female → adjusted 28.7%, vs target 50%). `income` is similar between sample and adjusted because the IPW model didn't lean on it. This is exactly the kind of "where did the weights actually help and where didn't they?" diagnosis that's hard to read off a single ASMD number.
+
+### Distribution distances on raw categoricals
+
+`KLD`/`EMD`/`CVMD`/`KS` on `BalanceDF.covars()` now operate directly on raw categorical variables (with NA indicators), rather than requiring one-hot encoding. This produces more faithful comparisons for categorical covariates, especially with missing values:
+
+```python
+print(bf_holdout.covars().kld())
+```
+
+```text
+                   age_group    gender    income  mean(kld)
+source
+self                0.056796  0.188210  0.109138   0.118048
+unadjusted          0.268381  0.183109  0.112641   0.188044
+unadjusted - self   0.211585 -0.005101  0.003503   0.069996
+```
+
+The `unadjusted - self` row is the per-variable improvement. Here, the IPW weights cut KLD on `age_group` from 0.27 → 0.06 (a substantial fix) but barely move `gender` or `income` — matching what we saw in the ASCII plot above. The same shape holds for `bf_holdout.covars().emd()`, `cvmd()`, and `ks()`.
+
+## More flexibility in the workflow
+
+### Sequential adjustments + formula support in poststratification
+
+Two related changes that pair naturally. First, `adjust()` is now compounding: calling it on an already-adjusted `BalanceFrame` uses the current weights as design weights for the next adjustment, so you can layer methods (e.g. IPW first to soak up broad imbalances, then poststratify on a specific marginal for fine-tuning). Second, `poststratify(...)` and `BalanceFrame.adjust(method="poststratify", ...)` now accept `formula=` as an alternative to `variables=`. Only interaction-style operators are supported — `:`, `.`, `-`, optional leading `~`. Additive `+` and `*` are explicitly rejected, because poststratification defines cells by the *joint* distribution: `a + b`, `a * b`, and `a:b` would all yield identical cells, and rejecting `+`/`*` prevents users from silently writing what looks like a main-effects model.
+
+Continuing from `bf_holdout` above (already IPW-adjusted), let's add a poststratify layer on the joint `age_group:gender` cells — the two covariates the IPW step left most imbalanced:
+
+```python
+adj = bf_holdout.adjust(method="poststratify", formula="age_group:gender")
+print(adj.summary())
+```
+
+Output:
+
+```text
+Adjustment details:
+    method: poststratify
+Covariate diagnostics:
+    Covar ASMD reduction: 47.9%
+    Covar ASMD (7 variables): 0.336 -> 0.175
+    Covar mean KLD reduction: 67.2%
+    Covar mean KLD (3 variables): 0.188 -> 0.062
+Weight diagnostics:
+    design effect (Deff): 2.395
+    effective sample size proportion (ESSP): 0.417
+    effective sample size (ESS): 375.7
+Outcome weighted means:
+            happiness
+source
+self           55.453
+target         56.278
+unadjusted     48.487
+```
+
+The compounded adjustment cuts ASMD from 0.336 → 0.175 (vs. IPW alone's 0.336 → 0.318) and brings the weighted `happiness` mean from 50.3 (IPW only) up to 55.5 — within reach of the target's 56.3. Note `asmd_improvement()` is computed against the original *unadjusted* baseline, so it reflects total improvement across both adjustment steps, not just the last one. The cost is a higher design effect (2.4 vs. 1.3) and a smaller ESS, the usual trade-off for tighter cell-level matching.
+
+Drilling into per-covariate balance:
+
+```python
+print(adj.covars().summary())
+```
+
+```text
+source                  self  target  unadjusted         self_ci         target_ci   unadjusted_ci
+age_group[T.25-34]     0.298   0.297       0.302   (0.26, 0.337)    (0.288, 0.306)  (0.272, 0.332)
+age_group[T.35-44]     0.299   0.299       0.157  (0.254, 0.343)     (0.29, 0.308)   (0.133, 0.18)
+age_group[T.45+]       0.208   0.206       0.056  (0.147, 0.269)    (0.198, 0.214)  (0.041, 0.071)
+gender[Female]         0.500   0.455       0.292  (0.449, 0.551)    (0.445, 0.465)  (0.263, 0.322)
+gender[Male]           0.500   0.455       0.708  (0.449, 0.551)    (0.445, 0.465)  (0.678, 0.737)
+income                 6.710  12.738       6.257  (5.981, 7.438)  (12.482, 12.993)  (5.791, 6.724)
+```
+
+`age_group` is now nearly perfectly aligned with the target (the joint poststratify cells did their job), while `income` — which was *not* in the formula — remains skewed toward the lower end. That's the intended behavior: poststratification only reweights the cells you ask it to, so combining it with IPW lets you choose where to be exact and where to settle for a propensity-score approximation.
+
+What about the `gender[Female] = 0.500` for `self` vs. `0.455` for `target`? It's a clean illustration of how poststratification handles missing cells. The simulated target has missing values in `gender` (`target_df["gender"].value_counts(dropna=False, normalize=True)` shows ~9% NaN: `Female 45.5% / Male 45.5% / NaN 9%`), but our holdout — `sample_df.iloc[100:]` — happens to contain none (the simulator only injects NaNs into rows 3–90 of `sample_df`, which sit in the *training* slice). Poststratify can only reweight cells that exist in the sample; with no NaN cell in the holdout, it allocates the full weight across just `Female` and `Male`, which produces `45.5% / 91% = 50%` for each — exactly matching the conditional Female/Male split *within* the non-NaN portion of the target. The 9% NaN mass in the target is unreachable from this sample, so the marginal stays at 45.5%/45.5% on the target side. (If your sample *does* contain NaNs, balance treats them as their own cell — see the `na_action` argument to `poststratify` for the modes.)
+
+### Raw-covariate IPW for sklearn estimators with native categorical support
+
+`Sample.adjust(method="ipw", use_model_matrix=False)` now fits propensity models directly on raw covariates (without building a one-hot model matrix). String/object/bool columns are converted to pandas `Categorical` so estimators like `HistGradientBoostingClassifier` (with `categorical_features="from_dtype"`) handle them natively. The categorical workflow requires scikit-learn ≥ 1.4 — under balance's current dependency pins (see [`pyproject.toml`](https://github.com/facebookresearch/balance/blob/main/pyproject.toml)), that's available by default on Python 3.12+; on Python 3.9–3.11 it requires opting into a newer sklearn. Keep `use_model_matrix=True` (the default) if you don't need raw-categorical fitting.
+
+## Robustness, pandas 3, and safer defaults
+
+- **Pandas 3.x compatibility** across the package — string/NA handling, dtype checks, and weight-dtype coercion were updated; tests now run cleanly on pandas 3.
+- **Hare–Niemeyer allocation in raking** — the old proportion-expansion path could hit memory blow-ups when the LCM of marginal lengths grew very large. Expansion is now capped (default 10,000 rows) using largest-remainder allocation, which preserves totals exactly with minimal rounding error.
+- **Consistent accessor naming** — `*_column` returns the column **name** (`str`), `*_series` returns the data (`pd.Series`), `df_*` returns a DataFrame view. In particular, `id_column` now returns the name (matching `weight_column`); use `id_series` for the data. The deprecated old behavior emits a `FutureWarning` until 2026-06-01.
+- **Stricter validation**:
+  - Unknown kwargs to `poststratify(...)` now raise `TypeError` instead of being silently ignored.
+  - Replacing the target on an already-adjusted `BalanceFrame` warns in-place, since it resets the adjustment.
+  - Weight diagnostics (`design_effect`, `nonparametric_skew`, `prop_above_and_below`, `weighted_median_breakdown_point`) raise `ValueError` if all weights are zero.
+  - CLI column-list arguments trim whitespace and reject empty entries (e.g., `"id,,weight"`).
+- **CLI default change** — columns not explicitly mentioned now flow to `ignore_columns` rather than being implicitly treated as outcomes.
+
+## Migration checklist (0.15.x → 0.20.0)
+
+- Replace removed `Sample` convenience methods (`design_effect`, `design_effect_prop`, `plot_weight_density`, `covar_means`, `outcome_sd_prop`, `outcome_variance_ratio`) with the `weights()/covars()/outcomes()` accessor flows.
+- Audit `id_column` usage — it now returns a name; use `id_series` for the data.
+- Review CLI assumptions: unmentioned columns now go to `ignore_columns`, not `outcome_columns`.
+- Validate `poststratify(...)` calls for typo'd kwargs and formula syntax.
+- Handle possible `ValueError` from weight diagnostics if all-zero weights are reachable in your pipeline.
+
+For the full version-by-version breakdown of every change, deprecation, and bug fix, see the [CHANGELOG](https://import-balance.org/docs/docs/changelog/).
+
+## Documentation to keep handy
+
+- New API tutorial (`SampleFrame` / `BalanceFrame`): https://import-balance.org/docs/tutorials/quickstart_new_api/
+- Quickstart tutorial: https://import-balance.org/docs/tutorials/quickstart/
+- CLI tutorial: https://import-balance.org/docs/tutorials/balance_cli_tutorial/
+- Architecture deep dive: https://github.com/facebookresearch/balance/blob/main/docs/architecture/architecture_0_19_0.md
+
+## Get Started with v0.20.0
+
+Upgrade today:
+
+    python -m pip install -U balance
+
+Resources:
+- **Website:** https://import-balance.org/
+- **GitHub:** https://github.com/facebookresearch/balance
+- **Documentation:** https://import-balance.org/docs/docs/general_framework/
+- **Tutorials:** https://import-balance.org/docs/tutorials/
+- **Blog:** https://import-balance.org/blog/
+- **Paper:** [balance – a Python package for balancing biased data samples](https://arxiv.org/abs/2307.06024)
+
+Need help?
+- **Ask questions:** https://github.com/facebookresearch/balance/issues/new?template=support_question.md
+- **Report bugs:** https://github.com/facebookresearch/balance/issues/new?template=bug_report.md
+- **Request features:** https://github.com/facebookresearch/balance/issues/new?template=feature_request.md
+
+Thanks to everyone using and improving balance. Contributions and feedback are always welcome.


### PR DESCRIPTION
Summary:


Test Plan:
Imported from GitHub, with the following local fixes:

**1. Pyre type errors** (fixed both flagged by CI):

\`\`\`
arc pyre check fbcode//core_stats/balance:balance
\`\`\`
{F1986810958}

Output: \`No type errors found\`

**2. Reviewer feedback** ([talsarig](https://www.internalfb.com/intern/profile/?username=talsarig) + AI reviewer):
- Modernized type hints in \`summary_utils.py\` (\`Optional\`/\`Tuple\` → \`| None\`/\`tuple[...]\`, dropped imports)
- Reduced cyclomatic complexity of \`_resolve_adjustment_failure_metadata\` (~12 → 4) by extracting \`_coerce_failure_flag\` helper

**3. Tests pass:**

\`\`\`
bash fbcode/core_stats/balance/run_balance_tests.sh test_sample_diagnostics_helper.py
bash fbcode/core_stats/balance/run_balance_tests.sh test_weighted_comparisons_plots.py -k TestPlotlyIplotNbformatFallback
\`\`\`

Results: 21 passed in test_sample_diagnostics_helper.py, 3 passed in TestPlotlyIplotNbformatFallback.

Differential Revision: D102560841

Pulled By: talgalili


