### PR TITLE
Extract rake predict_weights logic into weighting_methods/rake.py (#436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # 0.21.0 (Unreleased - TBD)
 
+## Breaking Changes
+
+- **`BalanceFrame.fit(method="rake")` now requires pickleable `transformations`.**
+  The new default `store_fit_metadata=True` (see *New Features* below)
+  persists the transformations dict in the fitted model, and rake now
+  raises `ValueError` at fit time if the transformations are not
+  pickleable (for example lambdas or closures). This mirrors the
+  existing behaviour of `poststratify(..., store_fit_metadata=True)`
+  and protects downstream `pickle.dumps(adjusted_bf)` workflows from
+  silently breaking. **Migration**: convert any lambda/closure
+  transformations to top-level functions or
+  `functools.partial(...)` of top-level functions, or pass
+  `store_fit_metadata=False` to opt out of fit-metadata persistence
+  for that call.
+
 ## Bug Fixes
 
 - **`rake()` now correctly incorporates per-row design weights in final weights.**
@@ -10,6 +25,25 @@
   distribution when design weights are non-uniform. The fix is a no-op when
   design weights are uniform (the common case), so existing behaviour is
   preserved.
+
+## New Features
+
+- **Rake now supports fit-time metadata persistence and `predict_weights()` reconstruction.**
+  - `rake(..., store_fit_metadata=True)` now stores contingency-table artifacts
+    and fit-time metadata required to rebuild weights later.
+  - `BalanceFrame.fit(method="rake")` now enables `store_fit_metadata=True` by
+    default so fitted rake models can be reused with
+    `BalanceFrame.predict_weights()` without refitting.
+  - **In-place replay** (`predict_weights()` with no `data=`) works with
+    any transformations, including the rake default
+    `transformations="default"`.
+  - **Transfer scoring** (`predict_weights(data=...)`) requires
+    deterministic transformations: it raises `ValueError` for models
+    fitted with `transformations="default"` and for explicit dicts that
+    directly reference known data-dependent helpers (`quantize`,
+    `fct_lump`). To enable transfer scoring, pass deterministic
+    transformations at fit time (e.g. wrappers built around stored
+    fit-time bin edges) or re-fit rake on the scoring data.
 
 ## Code Quality & Refactoring
 

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -1064,12 +1064,31 @@ class BalanceFrame:
             can reconstruct poststratification cell-ratio artifacts, while
             direct ``adjust(method='poststratify')`` remains metadata-light
             unless ``store_fit_metadata=True`` is passed explicitly.
+            For the built-in rake method, ``fit()`` enables
+            ``store_fit_metadata=True`` by default so ``predict_weights()``
+            can replay/transfer fitted rake artifacts. This may increase
+            memory usage because contingency tables and fit metadata are
+            stored; pass ``store_fit_metadata=False`` to opt out. When
+            metadata is stored, ``transformations`` must be pickleable
+            (lambdas/closures are rejected at fit time so the resulting
+            ``BalanceFrame`` remains serializable).
+            Note: in-place ``predict_weights()`` works for any rake fit,
+            including the default ``transformations='default'``. Transfer
+            scoring (``predict_weights(data=...)``), however, rejects
+            models fitted with ``transformations='default'`` or with
+            explicit dicts containing known data-dependent helpers
+            (``quantize``, ``fct_lump``) because those transformations
+            recompute bins/levels from each scoring sample, which would
+            silently invalidate the stored cell ratios. To use rake's
+            ``data=...`` transfer path, pass deterministic transformations
+            at fit time or re-fit rake on the scoring data.
         """
         from balance.weighting_methods.cbps import cbps as built_in_cbps
         from balance.weighting_methods.ipw import ipw as built_in_ipw
         from balance.weighting_methods.poststratify import (
             poststratify as built_in_poststratify,
         )
+        from balance.weighting_methods.rake import rake as built_in_rake
 
         resolved_method = self._resolve_adjustment_function(method)
         if resolved_method is built_in_ipw:
@@ -1108,6 +1127,8 @@ class BalanceFrame:
                 )
                 kwargs["store_fit_metadata"] = False
         if resolved_method is built_in_poststratify:
+            kwargs.setdefault("store_fit_metadata", True)
+        if resolved_method is built_in_rake:
             kwargs.setdefault("store_fit_metadata", True)
 
         if isinstance(target, (SampleFrame, BalanceFrame)):
@@ -1153,8 +1174,10 @@ class BalanceFrame:
             holdout_bf.set_fitted_model(fitted)
             holdout_bf.summary()
 
-        Currently supports IPW models.  Other methods (CBPS, rake,
-        poststratify) will be supported once they store fit-time artifacts.
+        Currently ``set_fitted_model`` applies fitted IPW models directly.
+        Other methods may have fit artifacts but are routed through their
+        dedicated ``predict_weights(data=...)`` workflows instead of this
+        method-specific application path.
 
         Args:
             fitted: A BalanceFrame already adjusted with a supported method.
@@ -1936,13 +1959,16 @@ class BalanceFrame:
         - **Poststratify**: reconstructs in-place responder weights from
           stored cell-ratio metadata; ``data=...`` holdout scoring is not yet
           supported for poststratify.
+        - **Rake**: replays fitted cell-ratio artifacts in-place and supports
+          ``data=...`` transfer scoring. See :func:`balance.weighting_methods.rake.rake`
+          Notes for validity constraints and interpretation.
         - **Other methods**: not yet supported — will raise with guidance.
 
         Args:
             data: An optional BalanceFrame whose sample covariates are scored
                 using this object's stored model.  Must have matching covariate
-                column names and a target set. Supported for IPW and CBPS;
-                poststratify currently supports only in-place scoring
+                column names and a target set. Supported for IPW, CBPS, and
+                rake. Poststratify is supported only for in-place scoring
                 (``data=None``).
 
         Returns:
@@ -1982,10 +2008,33 @@ class BalanceFrame:
             method = model.get("method")
             if method == "cbps":
                 return self._predict_weights_cbps(model, source=data)
+            if method == "rake":
+                return self._predict_weights_rake(model, source=data)
+            # TODO: add predict_weights(data=...) support for 'poststratify'.
+            # Sketch of approach (mirrors the rake transfer path):
+            #   1. In poststratify(), when store_fit_metadata=True, persist the
+            #      same artifacts already stored for in-place replay
+            #      (variables, variables_before_transformations, categories,
+            #      m_fit, m_sample, na_action, transformations, transformations_origin,
+            #      training_target_weights, weight_trimming_*).
+            #   2. Add a `_predict_weights_poststratify(model, source=data)`
+            #      branch that, like _predict_weights_rake, applies the stored
+            #      transformations to data._sf_sample, maps each row to its
+            #      stored joint cell index, multiplies the row's design weight
+            #      by the cell ratio (m_fit / m_sample), validates joint
+            #      support, then renormalizes to data target weight sum.
+            #   3. Reject `transformations_origin == "default"` for transfer
+            #      scoring (data-dependent transforms aren't replayable),
+            #      mirroring the rake guard.
+            #   4. Unlike rake, poststratify cell ratios are exact responder
+            #      weights (no IPF), so transfer is a single multiply — no
+            #      iteration. The transfer-validity caveat still applies; see
+            #      the rake path's unconditional transfer warning for the
+            #      pattern to follow.
             if method != "ipw":
                 raise ValueError(
                     f"predict_weights(data=...) is not yet supported for method '{method}'. "
-                    "Currently only 'ipw' and 'cbps' are supported."
+                    "Currently only 'ipw', 'cbps', and 'rake' are supported."
                 )
             from balance.weighting_methods.ipw import link_transform, weights_from_link
 
@@ -2046,11 +2095,268 @@ class BalanceFrame:
             return self._predict_weights_cbps(model)
         if method == "poststratify":
             return self._predict_weights_poststratify(model)
+        if method == "rake":
+            return self._predict_weights_rake(model)
 
         raise ValueError(
             f"predict_weights() is not yet supported for method '{method}'. "
-            "Currently only 'ipw', 'cbps', and 'poststratify' are supported. "
+            "Currently only 'ipw', 'cbps', 'poststratify', and 'rake' are supported. "
             "Use adjust() to obtain weights directly for other methods."
+        )
+
+    def _predict_weights_rake(
+        self,
+        model: dict[str, Any],
+        source: BalanceFrame | None = None,
+    ) -> pd.Series:
+        required = (
+            "variables",
+            "variables_before_transformations",
+            "categories",
+            "m_fit",
+            "m_sample",
+            "na_action",
+            "transformations",
+        )
+        if source is None:
+            required = required + ("training_sample_weights", "training_target_weights")
+        missing = [key for key in required if key not in model]
+        if missing:
+            raise ValueError(
+                "Rake model is missing fit-time metadata "
+                f"({missing}) for predict_weights(). "
+                "Call BalanceFrame.fit(method='rake') or run rake(..., "
+                "store_fit_metadata=True)."
+            )
+
+        variables = model.get("variables")
+        input_variables = model.get("variables_before_transformations")
+        categories = model.get("categories")
+        m_fit = model.get("m_fit")
+        m_sample = model.get("m_sample")
+        transformations_origin = model.get("transformations_origin")
+        if (
+            not isinstance(variables, list)
+            or not isinstance(input_variables, list)
+            or not isinstance(categories, list)
+        ):
+            raise ValueError("Rake model metadata is malformed for predict_weights().")
+        if not isinstance(m_fit, np.ndarray) or not isinstance(m_sample, np.ndarray):
+            raise ValueError("Rake model is missing stored contingency tables.")
+
+        bf = source if source is not None else self
+        if source is not None and bf._sf_target is None:
+            raise ValueError(
+                "data must have a target set for rake predict_weights(data=...)."
+            )
+        if source is not None and transformations_origin == "default":
+            raise ValueError(
+                "Rake predict_weights(data=...) is unsupported for models fitted "
+                "with transformations='default' because those transformations are "
+                "data-dependent and not replayable across new samples. Re-fit on "
+                "the scoring data or fit with explicit deterministic transformations."
+            )
+        if source is not None and isinstance(transformations_origin, dict):
+            # Best-effort guard: reject explicit dicts that directly
+            # reference balance's known data-dependent helpers
+            # (quantize, fct_lump). These recompute bins/levels from the
+            # scoring data, so stored cell ratios no longer line up with
+            # the transformed scoring cells and transfer would silently
+            # return incorrect weights.
+            #
+            # This guard does NOT catch indirect uses such as
+            # ``functools.partial(fct_lump, prop=0.1)``, top-level wrapper
+            # functions, or user-defined data-dependent transformations.
+            # The general invariant is: any callable whose output for a
+            # row depends on other rows in the input is unsafe to replay
+            # on a different sample. Users supplying such transformations
+            # are responsible for either (a) wrapping them as
+            # deterministic functions of stored fit-time parameters or
+            # (b) re-fitting rake on the scoring data.
+            from balance.utils.data_transformation import fct_lump, quantize
+
+            data_dependent_helpers = {quantize, fct_lump}
+            offenders = sorted(
+                {
+                    getattr(fn, "__name__", repr(fn))
+                    for fn in transformations_origin.values()
+                    if fn in data_dependent_helpers
+                }
+            )
+            if offenders:
+                raise ValueError(
+                    "Rake predict_weights(data=...) is unsupported for models "
+                    f"fitted with data-dependent transformations ({', '.join(offenders)}). "
+                    "These recompute bins/levels from the scoring data, so "
+                    "stored cell ratios no longer line up with the transformed "
+                    "cells. Re-fit on the scoring data or fit with deterministic "
+                    "transformations."
+                )
+        sample_covars = bf._sf_sample.df_covars
+        target_covars = _assert_type(bf._sf_target).df_covars
+        for column in input_variables:
+            if (
+                column not in sample_covars.columns
+                or column not in target_covars.columns
+            ):
+                raise ValueError(
+                    "Rake predict_weights() cannot find required covariate "
+                    f"'{column}' in both sample and target."
+                )
+        sample_df = sample_covars.loc[:, input_variables]
+        target_df = target_covars.loc[:, input_variables]
+        sample_weights_full = bf._sf_sample.df_weights.iloc[:, 0]
+        training_sample_weights = model.get("training_sample_weights")
+        sample_weights = sample_weights_full
+        na_action = cast(str, model.get("na_action", "add_indicator"))
+
+        sample_df, target_df = balance_adjustment.apply_transformations(
+            (sample_df, target_df), transformations=model.get("transformations")
+        )
+        for column in variables:
+            if column not in sample_df.columns:
+                raise ValueError(
+                    "Rake transform output is missing stored variable "
+                    f"'{column}' required for predict_weights()."
+                )
+        sample_df = sample_df.loc[:, variables]
+        target_df = target_df.loc[:, variables]
+
+        if source is None:
+            if isinstance(training_sample_weights, pd.Series):
+                if na_action == "drop":
+                    sample_weights = training_sample_weights
+                elif training_sample_weights.index.equals(sample_weights_full.index):
+                    sample_weights = training_sample_weights
+                else:
+                    raise ValueError(
+                        "Rake predict_weights() requires compatible fit-time sample design "
+                        "weights for in-place replay. This can happen because "
+                        "store_fit_metadata is missing/incompatible, or because you're "
+                        "scoring a different sample; use predict_weights(data=...) "
+                        "for different samples."
+                    )
+            else:
+                raise ValueError(
+                    "Rake predict_weights() requires compatible fit-time sample design "
+                    "weights for in-place replay. This can happen because "
+                    "store_fit_metadata is missing/incompatible, or because you're "
+                    "scoring a different sample; use predict_weights(data=...) "
+                    "for different samples."
+                )
+
+        dropped_target_weights: pd.Series | None = None
+        if na_action == "drop":
+            sample_df, sample_weights = balance_util.drop_na_rows(
+                sample_df, sample_weights, "sample"
+            )
+            target_df, dropped_target_weights = balance_util.drop_na_rows(
+                target_df,
+                _assert_type(bf._sf_target).df_weights.iloc[:, 0],
+                "target",
+            )
+        elif na_action == "add_indicator":
+            sample_df = pd.DataFrame(_safe_fillna_and_infer(sample_df, "__NaN__"))
+            target_df = pd.DataFrame(_safe_fillna_and_infer(target_df, "__NaN__"))
+        else:
+            raise ValueError(
+                f"Rake model has invalid na_action metadata '{na_action}' for predict_weights()."
+            )
+        sample_df = sample_df.astype(str)
+        if m_fit.shape != m_sample.shape:
+            raise ValueError(
+                "Rake model metadata has incompatible fitted and sample table shapes."
+            )
+
+        category_maps = [{cat: i for i, cat in enumerate(cats)} for cats in categories]
+        code_columns = []
+        for column, cat_map in zip(variables, category_maps):
+            codes = sample_df[column].map(cat_map)
+            if bool(codes.isna().any()):
+                raise ValueError(
+                    "Rake predict_weights() found rows that do not map to stored fit-time "
+                    "categories. Re-fit with compatible covariates."
+                )
+            code_columns.append(codes.astype(int).to_numpy())
+        code_index = tuple(code_columns)
+
+        if source is not None:
+            logger.warning(
+                "Rake predict_weights(data=...): replaying fitted rake "
+                "artifacts on a different sample is a transfer operation, "
+                "not an exact fit. The stored cell-ratio surface "
+                "(m_fit / m_sample) encodes the *training* target's "
+                "marginal distribution; applying it to a new sample only "
+                "produces weights calibrated to that *training* target, "
+                "rescaled to the new target's total weight. The new "
+                "target's marginals are NOT re-balanced. Predictions are "
+                "therefore only valid when (a) the scoring sample's joint "
+                "distribution over the rake variables is similar to the "
+                "training sample's, AND (b) the scoring target's marginal "
+                "distribution is similar to the training target's. "
+                "Re-fit rake on the scoring sample/target for exact "
+                "marginal matching."
+            )
+        m_sample_at_cells = m_sample[code_index]
+        if bool((m_sample_at_cells <= 0).any()):
+            raise ValueError(
+                "Rake predict_weights() encountered sample rows in joint cells with "
+                "zero fit-time sample mass (m_sample==0). Re-fit rake on data with "
+                "compatible joint support."
+            )
+        # Compute ratios only for the scored cells. Avoids materializing a
+        # dense array the size of the full contingency table on every call
+        # (relevant for high-cardinality rakes).
+        cell_ratios = m_fit[code_index] / m_sample_at_cells
+        raw = pd.Series(
+            sample_weights.to_numpy() * cell_ratios,
+            index=sample_weights.index,
+            dtype=float,
+        )
+        target_weights = model.get("training_target_weights")
+        if source is None and not isinstance(target_weights, pd.Series):
+            raise ValueError(
+                "Rake predict_weights() requires compatible fit-time target design "
+                "weights for in-place replay. This can happen because "
+                "store_fit_metadata is missing/incompatible, or because you're "
+                "scoring a different sample; use predict_weights(data=...) "
+                "for different samples."
+            )
+        if source is not None:
+            if na_action == "drop" and isinstance(dropped_target_weights, pd.Series):
+                target_sum = float(dropped_target_weights.sum())
+            else:
+                target_sum = float(
+                    _assert_type(bf._sf_target).df_weights.iloc[:, 0].sum()
+                )
+        elif isinstance(target_weights, pd.Series):
+            target_sum = float(target_weights.sum())
+        elif na_action == "drop" and isinstance(dropped_target_weights, pd.Series):
+            target_sum = float(dropped_target_weights.sum())
+        else:
+            target_sum = float(_assert_type(bf._sf_target).df_weights.iloc[:, 0].sum())
+        predicted = balance_adjustment.trim_weights(
+            raw,
+            target_sum_weights=target_sum,
+            weight_trimming_mean_ratio=model.get("weight_trimming_mean_ratio"),
+            weight_trimming_percentile=model.get("weight_trimming_percentile"),
+            keep_sum_of_weights=bool(model.get("keep_sum_of_weights", True)),
+        )
+        weight_name = getattr(_assert_type(bf.weight_series), "name", None)
+        if na_action == "drop":
+            predicted_full = pd.Series(
+                np.nan, index=sample_weights_full.index, dtype=float
+            ).rename(predicted.name)
+            predicted_full.loc[predicted.index] = predicted.to_numpy()
+            predicted = predicted_full
+        return cast(
+            pd.Series,
+            self._align_to_index(
+                predicted.rename(weight_name),
+                bf._sf_sample.df.index,
+                caller="predict_weights()",
+                method_name="rake",
+            ),
         )
 
     def _resolve_ipw_link(self, model: dict[str, Any]) -> np.ndarray:

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -2109,246 +2109,25 @@ class BalanceFrame:
         model: dict[str, Any],
         source: BalanceFrame | None = None,
     ) -> pd.Series:
-        required = (
-            "variables",
-            "variables_before_transformations",
-            "categories",
-            "m_fit",
-            "m_sample",
-            "na_action",
-            "transformations",
-        )
-        if source is None:
-            required = required + ("training_sample_weights", "training_target_weights")
-        missing = [key for key in required if key not in model]
-        if missing:
-            raise ValueError(
-                "Rake model is missing fit-time metadata "
-                f"({missing}) for predict_weights(). "
-                "Call BalanceFrame.fit(method='rake') or run rake(..., "
-                "store_fit_metadata=True)."
-            )
-
-        variables = model.get("variables")
-        input_variables = model.get("variables_before_transformations")
-        categories = model.get("categories")
-        m_fit = model.get("m_fit")
-        m_sample = model.get("m_sample")
-        transformations_origin = model.get("transformations_origin")
-        if (
-            not isinstance(variables, list)
-            or not isinstance(input_variables, list)
-            or not isinstance(categories, list)
-        ):
-            raise ValueError("Rake model metadata is malformed for predict_weights().")
-        if not isinstance(m_fit, np.ndarray) or not isinstance(m_sample, np.ndarray):
-            raise ValueError("Rake model is missing stored contingency tables.")
+        from balance.weighting_methods.rake import predict_weights_from_model
 
         bf = source if source is not None else self
         if source is not None and bf._sf_target is None:
             raise ValueError(
                 "data must have a target set for rake predict_weights(data=...)."
             )
-        if source is not None and transformations_origin == "default":
-            raise ValueError(
-                "Rake predict_weights(data=...) is unsupported for models fitted "
-                "with transformations='default' because those transformations are "
-                "data-dependent and not replayable across new samples. Re-fit on "
-                "the scoring data or fit with explicit deterministic transformations."
-            )
-        if source is not None and isinstance(transformations_origin, dict):
-            # Best-effort guard: reject explicit dicts that directly
-            # reference balance's known data-dependent helpers
-            # (quantize, fct_lump). These recompute bins/levels from the
-            # scoring data, so stored cell ratios no longer line up with
-            # the transformed scoring cells and transfer would silently
-            # return incorrect weights.
-            #
-            # This guard does NOT catch indirect uses such as
-            # ``functools.partial(fct_lump, prop=0.1)``, top-level wrapper
-            # functions, or user-defined data-dependent transformations.
-            # The general invariant is: any callable whose output for a
-            # row depends on other rows in the input is unsafe to replay
-            # on a different sample. Users supplying such transformations
-            # are responsible for either (a) wrapping them as
-            # deterministic functions of stored fit-time parameters or
-            # (b) re-fitting rake on the scoring data.
-            from balance.utils.data_transformation import fct_lump, quantize
 
-            data_dependent_helpers = {quantize, fct_lump}
-            offenders = sorted(
-                {
-                    getattr(fn, "__name__", repr(fn))
-                    for fn in transformations_origin.values()
-                    if fn in data_dependent_helpers
-                }
-            )
-            if offenders:
-                raise ValueError(
-                    "Rake predict_weights(data=...) is unsupported for models "
-                    f"fitted with data-dependent transformations ({', '.join(offenders)}). "
-                    "These recompute bins/levels from the scoring data, so "
-                    "stored cell ratios no longer line up with the transformed "
-                    "cells. Re-fit on the scoring data or fit with deterministic "
-                    "transformations."
-                )
-        sample_covars = bf._sf_sample.df_covars
-        target_covars = _assert_type(bf._sf_target).df_covars
-        for column in input_variables:
-            if (
-                column not in sample_covars.columns
-                or column not in target_covars.columns
-            ):
-                raise ValueError(
-                    "Rake predict_weights() cannot find required covariate "
-                    f"'{column}' in both sample and target."
-                )
-        sample_df = sample_covars.loc[:, input_variables]
-        target_df = target_covars.loc[:, input_variables]
-        sample_weights_full = bf._sf_sample.df_weights.iloc[:, 0]
-        training_sample_weights = model.get("training_sample_weights")
-        sample_weights = sample_weights_full
-        na_action = cast(str, model.get("na_action", "add_indicator"))
-
-        sample_df, target_df = balance_adjustment.apply_transformations(
-            (sample_df, target_df), transformations=model.get("transformations")
+        target_frame = _assert_type(bf._sf_target)
+        predicted = predict_weights_from_model(
+            model=model,
+            sample_df=bf._sf_sample.df_covars,
+            sample_weights_full=bf._sf_sample.df_weights.iloc[:, 0],
+            target_df=target_frame.df_covars,
+            target_weights=target_frame.df_weights.iloc[:, 0],
+            is_transfer=source is not None,
         )
-        for column in variables:
-            if column not in sample_df.columns:
-                raise ValueError(
-                    "Rake transform output is missing stored variable "
-                    f"'{column}' required for predict_weights()."
-                )
-        sample_df = sample_df.loc[:, variables]
-        target_df = target_df.loc[:, variables]
 
-        if source is None:
-            if isinstance(training_sample_weights, pd.Series):
-                if na_action == "drop":
-                    sample_weights = training_sample_weights
-                elif training_sample_weights.index.equals(sample_weights_full.index):
-                    sample_weights = training_sample_weights
-                else:
-                    raise ValueError(
-                        "Rake predict_weights() requires compatible fit-time sample design "
-                        "weights for in-place replay. This can happen because "
-                        "store_fit_metadata is missing/incompatible, or because you're "
-                        "scoring a different sample; use predict_weights(data=...) "
-                        "for different samples."
-                    )
-            else:
-                raise ValueError(
-                    "Rake predict_weights() requires compatible fit-time sample design "
-                    "weights for in-place replay. This can happen because "
-                    "store_fit_metadata is missing/incompatible, or because you're "
-                    "scoring a different sample; use predict_weights(data=...) "
-                    "for different samples."
-                )
-
-        dropped_target_weights: pd.Series | None = None
-        if na_action == "drop":
-            sample_df, sample_weights = balance_util.drop_na_rows(
-                sample_df, sample_weights, "sample"
-            )
-            target_df, dropped_target_weights = balance_util.drop_na_rows(
-                target_df,
-                _assert_type(bf._sf_target).df_weights.iloc[:, 0],
-                "target",
-            )
-        elif na_action == "add_indicator":
-            sample_df = pd.DataFrame(_safe_fillna_and_infer(sample_df, "__NaN__"))
-            target_df = pd.DataFrame(_safe_fillna_and_infer(target_df, "__NaN__"))
-        else:
-            raise ValueError(
-                f"Rake model has invalid na_action metadata '{na_action}' for predict_weights()."
-            )
-        sample_df = sample_df.astype(str)
-        if m_fit.shape != m_sample.shape:
-            raise ValueError(
-                "Rake model metadata has incompatible fitted and sample table shapes."
-            )
-
-        category_maps = [{cat: i for i, cat in enumerate(cats)} for cats in categories]
-        code_columns = []
-        for column, cat_map in zip(variables, category_maps):
-            codes = sample_df[column].map(cat_map)
-            if bool(codes.isna().any()):
-                raise ValueError(
-                    "Rake predict_weights() found rows that do not map to stored fit-time "
-                    "categories. Re-fit with compatible covariates."
-                )
-            code_columns.append(codes.astype(int).to_numpy())
-        code_index = tuple(code_columns)
-
-        if source is not None:
-            logger.warning(
-                "Rake predict_weights(data=...): replaying fitted rake "
-                "artifacts on a different sample is a transfer operation, "
-                "not an exact fit. The stored cell-ratio surface "
-                "(m_fit / m_sample) encodes the *training* target's "
-                "marginal distribution; applying it to a new sample only "
-                "produces weights calibrated to that *training* target, "
-                "rescaled to the new target's total weight. The new "
-                "target's marginals are NOT re-balanced. Predictions are "
-                "therefore only valid when (a) the scoring sample's joint "
-                "distribution over the rake variables is similar to the "
-                "training sample's, AND (b) the scoring target's marginal "
-                "distribution is similar to the training target's. "
-                "Re-fit rake on the scoring sample/target for exact "
-                "marginal matching."
-            )
-        m_sample_at_cells = m_sample[code_index]
-        if bool((m_sample_at_cells <= 0).any()):
-            raise ValueError(
-                "Rake predict_weights() encountered sample rows in joint cells with "
-                "zero fit-time sample mass (m_sample==0). Re-fit rake on data with "
-                "compatible joint support."
-            )
-        # Compute ratios only for the scored cells. Avoids materializing a
-        # dense array the size of the full contingency table on every call
-        # (relevant for high-cardinality rakes).
-        cell_ratios = m_fit[code_index] / m_sample_at_cells
-        raw = pd.Series(
-            sample_weights.to_numpy() * cell_ratios,
-            index=sample_weights.index,
-            dtype=float,
-        )
-        target_weights = model.get("training_target_weights")
-        if source is None and not isinstance(target_weights, pd.Series):
-            raise ValueError(
-                "Rake predict_weights() requires compatible fit-time target design "
-                "weights for in-place replay. This can happen because "
-                "store_fit_metadata is missing/incompatible, or because you're "
-                "scoring a different sample; use predict_weights(data=...) "
-                "for different samples."
-            )
-        if source is not None:
-            if na_action == "drop" and isinstance(dropped_target_weights, pd.Series):
-                target_sum = float(dropped_target_weights.sum())
-            else:
-                target_sum = float(
-                    _assert_type(bf._sf_target).df_weights.iloc[:, 0].sum()
-                )
-        elif isinstance(target_weights, pd.Series):
-            target_sum = float(target_weights.sum())
-        elif na_action == "drop" and isinstance(dropped_target_weights, pd.Series):
-            target_sum = float(dropped_target_weights.sum())
-        else:
-            target_sum = float(_assert_type(bf._sf_target).df_weights.iloc[:, 0].sum())
-        predicted = balance_adjustment.trim_weights(
-            raw,
-            target_sum_weights=target_sum,
-            weight_trimming_mean_ratio=model.get("weight_trimming_mean_ratio"),
-            weight_trimming_percentile=model.get("weight_trimming_percentile"),
-            keep_sum_of_weights=bool(model.get("keep_sum_of_weights", True)),
-        )
         weight_name = getattr(_assert_type(bf.weight_series), "name", None)
-        if na_action == "drop":
-            predicted_full = pd.Series(
-                np.nan, index=sample_weights_full.index, dtype=float
-            ).rename(predicted.name)
-            predicted_full.loc[predicted.index] = predicted.to_numpy()
-            predicted = predicted_full
         return cast(
             pd.Series,
             self._align_to_index(

--- a/balance/weighting_methods/rake.py
+++ b/balance/weighting_methods/rake.py
@@ -11,6 +11,7 @@ import itertools
 import logging
 import math
 import numbers
+import pickle
 from fractions import Fraction
 from functools import reduce
 from typing import Any, Callable, Dict, List, Tuple, Union
@@ -110,13 +111,6 @@ def _run_ipf_numpy(
     return table, converged, iterations_df
 
 
-# TODO: Store fit artifacts for predict_weights() support.
-# Save the fitted contingency table (`m_fit`), variable lists, and
-# category-to-index mappings in the returned model dict. Currently
-# `m_fit` is discarded after per-row weight assignment. Then implement
-# `_predict_weights_rake()` in balance_frame.py: look up each row's cell
-# in the stored N-dimensional table, compute weight ratio, multiply by
-# design weight. ~80 lines total.
 def rake(
     sample_df: pd.DataFrame,
     sample_weights: pd.Series,
@@ -132,6 +126,7 @@ def rake(
     weight_trimming_percentile: Union[float, None] = None,
     keep_sum_of_weights: bool = True,
     *args: Any,
+    store_fit_metadata: bool = False,
     **kwargs: Any,
 ) -> Dict[str, Any]:
     """
@@ -167,6 +162,10 @@ def rake(
                                    Delegated to :func:`balance.adjustment.trim_weights`.
     keep_sum_of_weights --- (bool, optional) preserve the sum of weights during trimming before
                             rescaling to the target total. Defaults to True.
+    store_fit_metadata --- (bool, optional, keyword-only)
+                           when True, persist fit-time artifacts in
+                           ``model`` for `BalanceFrame.predict_weights()`
+                           replay/transfer workflows. Defaults to False.
 
     Returns:
     A dictionary including:
@@ -174,6 +173,24 @@ def rake(
     "model" --- parameters of the model: iterations (dataframe with iteration numbers and
                 convergence rate information at all steps), converged (Flag with the output
                 status: 0 for failure and 1 for success).
+                When ``store_fit_metadata=True`` it also includes fit-time
+                artifacts for ``BalanceFrame.predict_weights()`` reconstruction.
+
+    Notes:
+    ``BalanceFrame.predict_weights()`` for rake reuses the fitted cell-ratio
+    surface from this function (effectively ``m_fit / m_sample`` per joint
+    cell) and applies it to design weights in the scoring sample. This is
+    exact in-place replay (same sample rows as fit), but for ``data=...`` it is
+    a transfer operation whose validity depends on the new sample having a
+    similar joint distribution over rake variables as the training sample.
+    If the joint distribution diverges, transferred rake weights can fail to
+    recover target marginals even though the same fitted model artifacts are
+    used. In that case, re-fit rake on the new sample against the same target.
+    For this reason, balance emits an unconditional warning on transferred
+    scoring (``predict_weights(data=...)``) when the fit is otherwise
+    replayable, and raises for known unreplayable cases — currently
+    ``transformations='default'`` and explicit dicts containing the known
+    data-dependent helpers (``quantize``, ``fct_lump``).
 
     Examples:
     .. code-block:: python
@@ -191,6 +208,8 @@ def rake(
     assert (
         "weight" not in sample_df.columns.values
     ), "weight shouldn't be a name for covariate in the sample data"
+    if not isinstance(store_fit_metadata, bool):
+        raise TypeError("`store_fit_metadata` must be a bool.")
     assert (
         "weight" not in target_df.columns.values
     ), "weight shouldn't be a name for covariate in the target data"
@@ -228,8 +247,14 @@ def rake(
         f"Currently have variables={variables} only"
     )
 
+    transformations_to_apply = transformations
+    if transformations == "default":
+        transformations_to_apply = balance_adjustment.default_transformations(
+            (sample_df, target_df)
+        )
+
     sample_df, target_df = balance_adjustment.apply_transformations(
-        (sample_df, target_df), transformations
+        (sample_df, target_df), transformations_to_apply
     )
 
     # TODO: separate into a function that handles NA (for rake, ipw, poststratify)
@@ -372,16 +397,46 @@ def rake(
         weight_trimming_percentile=weight_trimming_percentile,
         keep_sum_of_weights=keep_sum_of_weights,
     ).rename("rake_weight")
-    return {
-        "weight": w,
-        "model": {
-            "method": "rake",
-            "iterations": iterations,
-            "converged": converged,
-            "perf": {"prop_dev_explained": np.array([np.nan])},
-            # TODO: fix functions that use the perf and remove it from here
-        },
+    model: Dict[str, Any] = {
+        "method": "rake",
+        "iterations": iterations,
+        "converged": converged,
+        "perf": {"prop_dev_explained": np.array([np.nan])},
+        # TODO: fix functions that use the perf and remove it from here
     }
+    if store_fit_metadata:
+        # Persisting non-pickleable callables (e.g., lambdas/closures) breaks
+        # serialization workflows for fitted objects. Require pickleable
+        # transformations when fit metadata storage is enabled (matches the
+        # pattern used in poststratify).
+        try:
+            # @lint-ignore PYTHONPICKLEISBAD - serializability check only; no untrusted deserialization
+            pickle.dumps(transformations_to_apply)
+        except Exception as exc:
+            raise ValueError(
+                "`transformations` must be pickleable when "
+                "store_fit_metadata=True. Pass store_fit_metadata=False to "
+                "disable fit-artifact persistence for this run."
+            ) from exc
+        model.update(
+            {
+                "store_fit_metadata": True,
+                "variables": alphabetized_variables,
+                "variables_before_transformations": list(variables),
+                "categories": categories,
+                "m_fit": m_fit,
+                "m_sample": m_sample,
+                "na_action": na_action,
+                "transformations": transformations_to_apply,
+                "transformations_origin": transformations,
+                "training_sample_weights": sample_weights.copy(),
+                "training_target_weights": target_weights.copy(),
+                "weight_trimming_mean_ratio": weight_trimming_mean_ratio,
+                "weight_trimming_percentile": weight_trimming_percentile,
+                "keep_sum_of_weights": keep_sum_of_weights,
+            }
+        )
+    return {"weight": w, "model": model}
 
 
 def _lcm(a: int, b: int) -> int:

--- a/balance/weighting_methods/rake.py
+++ b/balance/weighting_methods/rake.py
@@ -14,11 +14,12 @@ import numbers
 import pickle
 from fractions import Fraction
 from functools import reduce
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, cast, Dict, List, Tuple, Union
 
 import numpy as np
 import pandas as pd
 from balance import adjustment as balance_adjustment, util as balance_util
+from balance.util import _safe_fillna_and_infer
 
 logger: logging.Logger = logging.getLogger(__package__)
 
@@ -437,6 +438,295 @@ def rake(
             }
         )
     return {"weight": w, "model": model}
+
+
+# TODO: decompose into smaller helpers (validate metadata, apply stored
+# transformations, NA handling, code mapping, cell-ratio compute, target-sum
+# determination, na_action='drop' index restoration). Best done alongside
+# the cbps / poststratify / ipw extractions, where the same helpers can be
+# shared across all four methods to reduce duplication.
+def predict_weights_from_model(
+    model: Dict[str, Any],
+    sample_df: pd.DataFrame,
+    sample_weights_full: pd.Series,
+    target_df: pd.DataFrame,
+    target_weights: pd.Series,
+    is_transfer: bool,
+) -> pd.Series:
+    """Reconstruct rake weights from a stored fit-time model dict.
+
+    This is the pure-math/model-driven core of
+    ``BalanceFrame.predict_weights()`` for rake. It takes plain DataFrames
+    and Series for the scoring sample and target, plus the ``model`` dict
+    persisted by :func:`rake` when ``store_fit_metadata=True``, and replays
+    the cell-ratio surface (``m_fit / m_sample``) on the scoring sample.
+
+    Two modes:
+    - ``is_transfer=False`` (in-place replay): the scoring frames must be
+      the same rows that were fit; ``training_sample_weights`` and
+      ``training_target_weights`` from ``model`` are used as the canonical
+      fit-time weights.
+    - ``is_transfer=True`` (``data=...`` transfer): the scoring frames are
+      a different sample/target. A warning is emitted unconditionally
+      because transferred rake weights are only guaranteed to recover
+      target marginals when the new sample's joint distribution over the
+      rake variables is similar to the training sample's.
+
+    Args:
+        model: Fitted rake model dict produced with ``store_fit_metadata=True``.
+        sample_df: Scoring sample's covariate frame (full index, pre-transform).
+            Must contain every column listed in
+            ``model['variables_before_transformations']``.
+        sample_weights_full: Scoring sample's design weights aligned to
+            ``sample_df``'s full index.
+        target_df: Scoring target's covariate frame (pre-transform).
+            Must contain every column listed in
+            ``model['variables_before_transformations']``.
+        target_weights: Scoring target's design weights aligned to
+            ``target_df``'s full index.
+        is_transfer: ``True`` when called from
+            ``BalanceFrame.predict_weights(data=...)``; ``False`` for
+            in-place replay (``data=None``).
+
+    Returns:
+        Predicted weights as a ``pd.Series`` with ``sample_weights_full``'s
+        index. For ``na_action='drop'`` rake models, rows dropped during
+        scoring are returned as ``NaN``.
+
+    Raises:
+        ValueError: If model metadata is missing/malformed, if the scoring
+            frames are missing required covariates, if scoring rows fall in
+            joint cells with zero fit-time sample mass, or if in-place
+            replay is requested without compatible fit-time design weights.
+    """
+    required = (
+        "variables",
+        "variables_before_transformations",
+        "categories",
+        "m_fit",
+        "m_sample",
+        "na_action",
+        "transformations",
+    )
+    if not is_transfer:
+        required = required + ("training_sample_weights", "training_target_weights")
+    missing = [key for key in required if key not in model]
+    if missing:
+        raise ValueError(
+            "Rake model is missing fit-time metadata "
+            f"({missing}) for predict_weights(). "
+            "Call BalanceFrame.fit(method='rake') or run rake(..., "
+            "store_fit_metadata=True)."
+        )
+
+    variables = model.get("variables")
+    input_variables = model.get("variables_before_transformations")
+    categories = model.get("categories")
+    m_fit = model.get("m_fit")
+    m_sample = model.get("m_sample")
+    transformations_origin = model.get("transformations_origin")
+    if (
+        not isinstance(variables, list)
+        or not isinstance(input_variables, list)
+        or not isinstance(categories, list)
+    ):
+        raise ValueError("Rake model metadata is malformed for predict_weights().")
+    if not isinstance(m_fit, np.ndarray) or not isinstance(m_sample, np.ndarray):
+        raise ValueError("Rake model is missing stored contingency tables.")
+    if is_transfer and transformations_origin == "default":
+        raise ValueError(
+            "Rake predict_weights(data=...) is unsupported for models fitted "
+            "with transformations='default' because those transformations are "
+            "data-dependent and not replayable across new samples. Re-fit on "
+            "the scoring data or fit with explicit deterministic transformations."
+        )
+    if is_transfer and isinstance(transformations_origin, dict):
+        # Best-effort guard: reject explicit dicts that directly
+        # reference balance's known data-dependent helpers
+        # (quantize, fct_lump). These recompute bins/levels from the
+        # scoring data, so stored cell ratios no longer line up with
+        # the transformed scoring cells and transfer would silently
+        # return incorrect weights.
+        #
+        # This guard does NOT catch indirect uses such as
+        # ``functools.partial(fct_lump, prop=0.1)``, top-level wrapper
+        # functions, or user-defined data-dependent transformations.
+        # The general invariant is: any callable whose output for a
+        # row depends on other rows in the input is unsafe to replay
+        # on a different sample. Users supplying such transformations
+        # are responsible for either (a) wrapping them as
+        # deterministic functions of stored fit-time parameters or
+        # (b) re-fitting rake on the scoring data.
+        from balance.utils.data_transformation import fct_lump, quantize
+
+        data_dependent_helpers = {quantize, fct_lump}
+        offenders = sorted(
+            {
+                getattr(fn, "__name__", repr(fn))
+                for fn in transformations_origin.values()
+                if fn in data_dependent_helpers
+            }
+        )
+        if offenders:
+            raise ValueError(
+                "Rake predict_weights(data=...) is unsupported for models "
+                f"fitted with data-dependent transformations ({', '.join(offenders)}). "
+                "These recompute bins/levels from the scoring data, so "
+                "stored cell ratios no longer line up with the transformed "
+                "cells. Re-fit on the scoring data or fit with deterministic "
+                "transformations."
+            )
+
+    for column in input_variables:
+        if column not in sample_df.columns or column not in target_df.columns:
+            raise ValueError(
+                "Rake predict_weights() cannot find required covariate "
+                f"'{column}' in both sample and target."
+            )
+    sample_df = sample_df.loc[:, input_variables]
+    target_df = target_df.loc[:, input_variables]
+
+    na_action = cast(str, model.get("na_action", "add_indicator"))
+
+    sample_df, target_df = balance_adjustment.apply_transformations(
+        (sample_df, target_df), transformations=model.get("transformations")
+    )
+    for column in variables:
+        if column not in sample_df.columns:
+            raise ValueError(
+                "Rake transform output is missing stored variable "
+                f"'{column}' required for predict_weights()."
+            )
+    sample_df = sample_df.loc[:, variables]
+    target_df = target_df.loc[:, variables]
+
+    sample_weights = sample_weights_full
+    if not is_transfer:
+        training_sample_weights = model.get("training_sample_weights")
+        if isinstance(training_sample_weights, pd.Series):
+            if na_action == "drop":
+                sample_weights = training_sample_weights
+            elif training_sample_weights.index.equals(sample_weights_full.index):
+                sample_weights = training_sample_weights
+            else:
+                raise ValueError(
+                    "Rake predict_weights() requires compatible fit-time sample design "
+                    "weights for in-place replay. This can happen because "
+                    "store_fit_metadata is missing/incompatible, or because you're "
+                    "scoring a different sample; use predict_weights(data=...) "
+                    "for different samples."
+                )
+        else:
+            raise ValueError(
+                "Rake predict_weights() requires compatible fit-time sample design "
+                "weights for in-place replay. This can happen because "
+                "store_fit_metadata is missing/incompatible, or because you're "
+                "scoring a different sample; use predict_weights(data=...) "
+                "for different samples."
+            )
+
+    dropped_target_weights: pd.Series | None = None
+    if na_action == "drop":
+        sample_df, sample_weights = balance_util.drop_na_rows(
+            sample_df, sample_weights, "sample"
+        )
+        target_df, dropped_target_weights = balance_util.drop_na_rows(
+            target_df, target_weights, "target"
+        )
+    elif na_action == "add_indicator":
+        sample_df = pd.DataFrame(_safe_fillna_and_infer(sample_df, "__NaN__"))
+        target_df = pd.DataFrame(_safe_fillna_and_infer(target_df, "__NaN__"))
+    else:
+        raise ValueError(
+            f"Rake model has invalid na_action metadata '{na_action}' for predict_weights()."
+        )
+    sample_df = sample_df.astype(str)
+    if m_fit.shape != m_sample.shape:
+        raise ValueError(
+            "Rake model metadata has incompatible fitted and sample table shapes."
+        )
+
+    category_maps = [{cat: i for i, cat in enumerate(cats)} for cats in categories]
+    code_columns = []
+    for column, cat_map in zip(variables, category_maps):
+        codes = sample_df[column].map(cat_map)
+        if bool(codes.isna().any()):
+            raise ValueError(
+                "Rake predict_weights() found rows that do not map to stored fit-time "
+                "categories. Re-fit with compatible covariates."
+            )
+        code_columns.append(codes.astype(int).to_numpy())
+    code_index = tuple(code_columns)
+
+    if is_transfer:
+        logger.warning(
+            "Rake predict_weights(data=...): replaying fitted rake "
+            "artifacts on a different sample is a transfer operation, "
+            "not an exact fit. The stored cell-ratio surface "
+            "(m_fit / m_sample) encodes the *training* target's "
+            "marginal distribution; applying it to a new sample only "
+            "produces weights calibrated to that *training* target, "
+            "rescaled to the new target's total weight. The new "
+            "target's marginals are NOT re-balanced. Predictions are "
+            "therefore only valid when (a) the scoring sample's joint "
+            "distribution over the rake variables is similar to the "
+            "training sample's, AND (b) the scoring target's marginal "
+            "distribution is similar to the training target's. "
+            "Re-fit rake on the scoring sample/target for exact "
+            "marginal matching."
+        )
+    m_sample_at_cells = m_sample[code_index]
+    if bool((m_sample_at_cells <= 0).any()):
+        raise ValueError(
+            "Rake predict_weights() encountered sample rows in joint cells with "
+            "zero fit-time sample mass (m_sample==0). Re-fit rake on data with "
+            "compatible joint support."
+        )
+    # Compute ratios only for the scored cells. Avoids materializing a
+    # dense array the size of the full contingency table on every call
+    # (relevant for high-cardinality rakes).
+    cell_ratios = m_fit[code_index] / m_sample_at_cells
+    raw = pd.Series(
+        sample_weights.to_numpy() * cell_ratios,
+        index=sample_weights.index,
+        dtype=float,
+    )
+
+    training_target_weights = model.get("training_target_weights")
+    if not is_transfer and not isinstance(training_target_weights, pd.Series):
+        raise ValueError(
+            "Rake predict_weights() requires compatible fit-time target design "
+            "weights for in-place replay. This can happen because "
+            "store_fit_metadata is missing/incompatible, or because you're "
+            "scoring a different sample; use predict_weights(data=...) "
+            "for different samples."
+        )
+    if is_transfer:
+        if na_action == "drop" and isinstance(dropped_target_weights, pd.Series):
+            target_sum = float(dropped_target_weights.sum())
+        else:
+            target_sum = float(target_weights.sum())
+    elif isinstance(training_target_weights, pd.Series):
+        target_sum = float(training_target_weights.sum())
+    elif na_action == "drop" and isinstance(dropped_target_weights, pd.Series):
+        target_sum = float(dropped_target_weights.sum())
+    else:
+        target_sum = float(target_weights.sum())
+
+    predicted = balance_adjustment.trim_weights(
+        raw,
+        target_sum_weights=target_sum,
+        weight_trimming_mean_ratio=model.get("weight_trimming_mean_ratio"),
+        weight_trimming_percentile=model.get("weight_trimming_percentile"),
+        keep_sum_of_weights=bool(model.get("keep_sum_of_weights", True)),
+    )
+    if na_action == "drop":
+        predicted_full = pd.Series(
+            np.nan, index=sample_weights_full.index, dtype=float
+        ).rename(predicted.name)
+        predicted_full.loc[predicted.index] = predicted.to_numpy()
+        predicted = predicted_full
+    return predicted
 
 
 def _lcm(a: int, b: int) -> int:

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -3619,6 +3619,373 @@ class TestBalanceFrameSklearnLikeApi(BalanceTestCase):
         with self.assertRaisesRegex(ValueError, "missing fit-time metadata"):
             adjusted.predict_weights()
 
+    def test_predict_weights_rake_fit_matches_weight_series(self) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(8)],
+                "weight": [1.0, 2.0, 1.5, 2.5, 1.0, 1.2, 0.8, 1.1],
+                "age_group": [
+                    "young",
+                    "young",
+                    "old",
+                    "old",
+                    "young",
+                    "old",
+                    "young",
+                    "old",
+                ],
+                "sex": ["f", "m", "f", "m", "f", "f", "m", "m"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(8)],
+                "weight": np.ones(8),
+                "age_group": [
+                    "young",
+                    "young",
+                    "old",
+                    "old",
+                    "old",
+                    "old",
+                    "young",
+                    "old",
+                ],
+                "sex": ["f", "m", "f", "m", "f", "m", "f", "m"],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="rake",
+            variables=["age_group", "sex"],
+            transformations=None,
+        )
+        predicted_weights = adjusted.predict_weights()
+        np.testing.assert_allclose(
+            predicted_weights.to_numpy(),
+            _assert_type(adjusted.weight_series).to_numpy(),
+            rtol=1e-6,
+            atol=1e-8,
+        )
+        self.assertIsNone(_assert_type(adjusted.model).get("transformations"))
+
+    def test_predict_weights_rake_default_transformations_transfer_rejected(
+        self,
+    ) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(10)],
+                "weight": np.ones(10),
+                "group": ["g1", "g2", "g3", "g1", "g2", "g3", "g1", "g2", "g3", "g1"],
+                "sex": ["f", "m"] * 5,
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(10)],
+                "weight": np.ones(10),
+                "group": ["g1", "g2", "g3", "g1", "g2", "g3", "g1", "g2", "g3", "g1"],
+                "sex": ["f", "m"] * 5,
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        ).fit(method="rake", variables=["group", "sex"])
+        self.assertIsInstance(_assert_type(fitted.model).get("transformations"), dict)
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df.copy()),
+            target=SampleFrame.from_frame(target_df.copy()),
+        )
+        with self.assertRaisesRegex(ValueError, "transformations='default'"):
+            fitted.predict_weights(data=holdout)
+
+    def test_predict_weights_rake_explicit_data_dependent_transforms_transfer_rejected(
+        self,
+    ) -> None:
+        # Explicit dict containing a known data-dependent helper (here:
+        # `quantize`) should be rejected for transfer scoring even though
+        # transformations_origin != "default".
+        from balance.utils.data_transformation import quantize
+
+        # Identical sample/target data so fit() succeeds. The guard fires
+        # at predict_weights(data=...) time based on the model's stored
+        # transformations_origin, regardless of the holdout's contents.
+        df = pd.DataFrame(
+            {
+                "id": [f"i{i}" for i in range(20)],
+                "weight": np.ones(20),
+                "x": np.linspace(0.0, 1.0, 20),
+                "y": np.linspace(0.0, 1.0, 20),
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(df.copy()),
+            target=SampleFrame.from_frame(df.copy()),
+        ).fit(
+            method="rake",
+            variables=["x", "y"],
+            transformations={"x": quantize, "y": quantize},
+        )
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(df.copy()),
+            target=SampleFrame.from_frame(df.copy()),
+        )
+        with self.assertRaisesRegex(ValueError, "data-dependent transformations"):
+            fitted.predict_weights(data=holdout)
+
+    def test_predict_weights_rake_requires_fit_metadata(self) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "age_group": ["young", "young", "old", "old", "young", "old"],
+                "sex": ["f", "m", "f", "m", "f", "m"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "age_group": ["young", "old", "old", "old", "young", "old"],
+                "sex": ["f", "m", "f", "m", "f", "m"],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="rake",
+            variables=["age_group", "sex"],
+            transformations=None,
+            store_fit_metadata=False,
+        )
+        with self.assertRaisesRegex(ValueError, "missing fit-time metadata"):
+            adjusted.predict_weights()
+
+    def test_predict_weights_rake_na_drop_restores_full_index_with_nans(self) -> None:
+        sample_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "age_group": ["young", None, "old", "old", "young", None],
+                "sex": ["f", "m", "f", "m", "f", "m"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "age_group": ["young", "old", "old", "old", None, "young"],
+                "sex": ["f", "m", "f", "m", "f", "m"],
+            }
+        )
+        bf = BalanceFrame(
+            sample=SampleFrame.from_frame(sample_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        adjusted = bf.fit(
+            method="rake",
+            variables=["age_group", "sex"],
+            transformations=None,
+            na_action="drop",
+        )
+        predicted_weights = adjusted.predict_weights()
+        # ``weight_series`` is ``pd.Series | None`` on the BalanceFrame
+        # interface; ``_assert_type`` narrows for Pyre (matches the style
+        # used on line ~3767 below and balance/CLAUDE.md's
+        # "Type annotation style" guidance: prefer ``_assert_type`` over
+        # ``cast``/``none_throws``).
+        self.assertTrue(
+            predicted_weights.isna().equals(_assert_type(adjusted.weight_series).isna())
+        )
+        np.testing.assert_allclose(
+            predicted_weights.dropna().to_numpy(),
+            _assert_type(adjusted.weight_series).dropna().to_numpy(),
+            rtol=1e-6,
+            atol=1e-8,
+        )
+        self.assertTrue(np.all(np.isfinite(predicted_weights.dropna().to_numpy())))
+        self.assertTrue(np.all(predicted_weights.dropna().to_numpy() >= 0))
+
+    def test_predict_weights_rake_data_argument_always_warns(self) -> None:
+        train_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(8)],
+                "weight": np.ones(8),
+                "a": ["A", "A", "A", "A", "B", "B", "B", "B"],
+                "b": ["X", "X", "Y", "Y", "X", "X", "Y", "Y"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(8)],
+                "weight": np.ones(8),
+                "a": ["A", "A", "B", "B", "A", "B", "A", "B"],
+                "b": ["X", "Y", "X", "Y", "X", "Y", "X", "Y"],
+            }
+        )
+        train_bf = BalanceFrame(
+            sample=SampleFrame.from_frame(train_df),
+            target=SampleFrame.from_frame(target_df),
+        )
+        # Use the same data for fit and scoring — even with no joint shift,
+        # transferred rake is a transfer operation by definition and should
+        # warn unconditionally.
+        eval_bf = BalanceFrame(
+            sample=SampleFrame.from_frame(train_df.copy()),
+            target=SampleFrame.from_frame(target_df.copy()),
+        )
+        fitted = train_bf.fit(method="rake", variables=["a", "b"], transformations=None)
+        with self.assertLogs("balance", level="WARNING") as cm:
+            weights = fitted.predict_weights(data=eval_bf)
+        self.assertEqual(len(weights), len(train_df))
+        self.assertIn("transfer operation", " ".join(cm.output))
+
+    def test_predict_weights_rake_data_requires_target(self) -> None:
+        train_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "a": ["A", "A", "B", "B", "A", "B"],
+                "b": ["X", "Y", "X", "Y", "X", "Y"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "a": ["A", "A", "A", "B", "B", "B"],
+                "b": ["X", "Y", "X", "X", "Y", "Y"],
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(train_df),
+            target=SampleFrame.from_frame(target_df),
+        ).fit(method="rake", variables=["a", "b"], transformations=None)
+        no_target_bf = BalanceFrame(sample=SampleFrame.from_frame(train_df.copy()))
+        with self.assertRaisesRegex(ValueError, "data must have a target set"):
+            fitted.predict_weights(data=no_target_bf)
+
+    def test_predict_weights_rake_data_rejects_mismatched_target_covariates(
+        self,
+    ) -> None:
+        train_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "a": ["A", "A", "B", "B", "A", "B"],
+                "b": ["X", "Y", "X", "Y", "X", "Y"],
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "a": ["A", "A", "A", "B", "B", "B"],
+                "b": ["X", "Y", "X", "X", "Y", "Y"],
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(train_df),
+            target=SampleFrame.from_frame(target_df),
+        ).fit(method="rake", variables=["a", "b"], transformations=None)
+
+        # Build scoring frame whose target is missing covariate 'b' that the
+        # fitted model needs. The public predict_weights(data=...) path runs
+        # _validate_data_covariates first, which catches the mismatch.
+        bad_target = target_df.drop(columns=["b"])
+        bad_bf = BalanceFrame(
+            sample=SampleFrame.from_frame(train_df.copy()),
+            target=SampleFrame.from_frame(bad_target),
+        )
+        with self.assertRaisesRegex(
+            ValueError, "matching target covariate column names"
+        ):
+            fitted.predict_weights(data=bad_bf)
+
+    def test_predict_weights_rake_data_na_drop_uses_dropped_target_sum(self) -> None:
+        train_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(8)],
+                "weight": np.ones(8),
+                "a": ["A", "A", "A", "B", "B", "B", "A", "B"],
+                "b": ["X", "Y", "X", "Y", "X", "Y", "X", "Y"],
+            }
+        )
+        train_target = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(8)],
+                "weight": np.ones(8),
+                "a": ["A", "A", "B", "B", "A", None, "A", "B"],
+                "b": ["X", "Y", "X", "Y", "X", "Y", "X", None],
+            }
+        )
+        eval_df = train_df.copy()
+        eval_target = train_target.copy()
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(train_df),
+            target=SampleFrame.from_frame(train_target),
+        ).fit(
+            method="rake", variables=["a", "b"], transformations=None, na_action="drop"
+        )
+        scored = fitted.predict_weights(
+            data=BalanceFrame(
+                sample=SampleFrame.from_frame(eval_df),
+                target=SampleFrame.from_frame(eval_target),
+            )
+        )
+        expected_target_sum = (
+            SampleFrame.from_frame(eval_target)
+            .df_weights.iloc[:, 0][eval_target[["a", "b"]].notna().all(axis=1)]
+            .sum()
+        )
+        self.assertAlmostEqual(
+            float(scored.sum()), float(expected_target_sum), places=6
+        )
+
+    def test_predict_weights_rake_data_raises_on_zero_fit_support_cell(self) -> None:
+        train_df = pd.DataFrame(
+            {
+                "id": [f"s{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "a": ["A", "A", "A", "B", "B", "B"],
+                "b": ["X", "X", "X", "Y", "Y", "Y"],  # only A:X and B:Y
+            }
+        )
+        target_df = pd.DataFrame(
+            {
+                "id": [f"t{i}" for i in range(8)],
+                "weight": np.ones(8),
+                "a": ["A", "A", "B", "B", "A", "B", "A", "B"],
+                "b": ["X", "Y", "X", "Y", "X", "Y", "X", "Y"],
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(train_df),
+            target=SampleFrame.from_frame(target_df),
+        ).fit(method="rake", variables=["a", "b"], transformations=None)
+
+        # Scoring contains unseen joint cells A:Y and B:X (present in target levels).
+        score_df = pd.DataFrame(
+            {
+                "id": [f"h{i}" for i in range(4)],
+                "weight": np.ones(4),
+                "a": ["A", "A", "B", "B"],
+                "b": ["Y", "Y", "X", "X"],
+            }
+        )
+        score_bf = BalanceFrame(
+            sample=SampleFrame.from_frame(score_df),
+            target=SampleFrame.from_frame(target_df.copy()),
+        )
+        with self.assertRaisesRegex(ValueError, "zero fit-time sample mass"):
+            fitted.predict_weights(data=score_bf)
+
     def test_predict_weights_poststratify_na_drop_reconstructs(self) -> None:
         sample_df = pd.DataFrame(
             {

--- a/tests/test_rake.py
+++ b/tests/test_rake.py
@@ -1735,3 +1735,94 @@ class TestRakeValidation(
         with self.assertRaisesRegex(ValueError, "convertible to float"):
             # pyrefly: ignore [bad-argument-type]
             _realize_dicts_of_proportions({"var": {"cat": BadReal()}})
+
+
+class TestRakeFitMetadata(balance.testutil.BalanceTestCase):
+    """Coverage for rake fit-metadata persistence edge-cases."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.sample_df = pd.DataFrame(
+            {
+                "a": ["A", "A", "B", "B", "A", "B"],
+                "b": ["X", "Y", "X", "Y", "X", "Y"],
+            }
+        )
+        self.target_df = pd.DataFrame(
+            {
+                "a": ["A", "A", "A", "B", "B", "B"],
+                "b": ["X", "Y", "X", "X", "Y", "Y"],
+            }
+        )
+        self.sample_w = pd.Series(np.ones(len(self.sample_df)))
+        self.target_w = pd.Series(np.ones(len(self.target_df)))
+
+    def test_rake_does_not_store_fit_metadata_by_default(self) -> None:
+        result = rake(
+            self.sample_df,
+            self.sample_w,
+            self.target_df,
+            self.target_w,
+            transformations=None,
+        )
+        model = result["model"]
+        self.assertNotIn("m_fit", model)
+        self.assertNotIn("training_sample_weights", model)
+
+    def test_rake_store_fit_metadata_true_persists_required_artifacts(self) -> None:
+        result = rake(
+            self.sample_df,
+            self.sample_w,
+            self.target_df,
+            self.target_w,
+            transformations=None,
+            store_fit_metadata=True,
+        )
+        model = result["model"]
+        for key in (
+            "variables",
+            "variables_before_transformations",
+            "categories",
+            "m_fit",
+            "m_sample",
+            "na_action",
+            "transformations",
+            "training_sample_weights",
+            "training_target_weights",
+        ):
+            self.assertIn(key, model)
+        self.assertEqual(model["m_fit"].shape, model["m_sample"].shape)
+        self.assertIn(type(model["transformations"]), (dict, type(None)))
+
+    def test_rake_store_fit_metadata_via_kwargs_is_accepted(self) -> None:
+        result = rake(
+            self.sample_df,
+            self.sample_w,
+            self.target_df,
+            self.target_w,
+            transformations=None,
+            **{"store_fit_metadata": True},
+        )
+        self.assertTrue(bool(result["model"].get("store_fit_metadata")))
+
+    def test_rake_rejects_non_bool_store_fit_metadata(self) -> None:
+        with self.assertRaisesRegex(TypeError, "store_fit_metadata"):
+            rake(
+                self.sample_df,
+                self.sample_w,
+                self.target_df,
+                self.target_w,
+                transformations=None,
+                store_fit_metadata="False",  # type: ignore[arg-type]
+            )
+
+    def test_rake_store_fit_metadata_requires_pickleable_transformations(self) -> None:
+        with self.assertRaisesRegex(ValueError, "pickleable"):
+            rake(
+                self.sample_df,
+                self.sample_w,
+                self.target_df,
+                self.target_w,
+                transformations={"a": lambda s: s, "b": lambda s: s},  # noqa: E731
+                store_fit_metadata=True,
+            )


### PR DESCRIPTION
Summary:

Moves the bulk of `BalanceFrame._predict_weights_rake` (~210 lines) into a new `predict_weights_from_model` function in `balance/weighting_methods/rake.py`. The BalanceFrame method becomes a thin ~30-line wrapper.

Motivation: balance_frame.py was already ~2,300 lines and rake-specific predict logic was awkwardly far from rake's fit code. Co-locating the lifecycle (fit + replay + transfer) inside `weighting_methods/rake.py` makes it easier to reason about rake's contract — anything that depends on the rake-specific model dict structure (m_fit, m_sample, categories, training_*_weights, etc.) now lives next to the function that produces that structure. This also establishes a template for the same extraction on cbps, poststratify, and ipw in subsequent diffs.

What stays in `BalanceFrame._predict_weights_rake` (~30-line wrapper): resolve `self` vs `source`, validate that `data` has a target set, extract sample/target covariate DataFrames and design weights from the BalanceFrame, call into `predict_weights_from_model`, apply weight name and `_align_to_index` on the result.

What moves to `weighting_methods/rake.py::predict_weights_from_model`: all metadata validation (required keys, types, transformations_origin/data-dependent guards), covariate column existence checks, stored-transformations replay, NA handling (drop / add_indicator), category-code mapping against stored fit-time categories, per-cell ratio compute (m_fit / m_sample at the scored cells only), unconditional transfer warning, joint-support validation, target-sum determination across in-place vs transfer × na_action variants, trim_weights, and na_action="drop" full-index restoration.

Side benefit: `predict_weights_from_model` is callable directly from outside BalanceFrame — users holding a fitted rake model dict and plain DataFrames can replay/transfer weights without going through the BalanceFrame class. No public API change: `BalanceFrame.predict_weights()` behavior is unchanged.

Differential Revision: D103588867


