### PR TITLE
Relicense Docusaurus website assets GPLv2 -> MIT (#454)

### DIFF
--- a/sphinx/_static/css/custom.css
+++ b/sphinx/_static/css/custom.css
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This software may be used and distributed according to the terms of the
- * GNU General Public License version 2.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 /**/

--- a/sphinx/make.bat
+++ b/sphinx/make.bat
@@ -1,7 +1,7 @@
 @REM Copyright (c) Meta Platforms, Inc. and affiliates.
 @REM
-@REM This software may be used and distributed according to the terms of the
-@REM GNU General Public License version 2.
+@REM This source code is licensed under the MIT license found in the
+@REM LICENSE file in the root directory of this source tree.
 
 @ECHO OFF
 

--- a/website/babel.config.js
+++ b/website/babel.config.js
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This software may be used and distributed according to the terms of the
- * GNU General Public License version 2.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 module.exports = {

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This software may be used and distributed according to the terms of the
- * GNU General Public License version 2.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 /**

--- a/website/src/components/HTMLLoader.js
+++ b/website/src/components/HTMLLoader.js
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This software may be used and distributed according to the terms of the
- * GNU General Public License version 2.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import React, { useRef } from 'react';

--- a/website/src/components/HomepageFeatures.js
+++ b/website/src/components/HomepageFeatures.js
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This software may be used and distributed according to the terms of the
- * GNU General Public License version 2.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import React from 'react';

--- a/website/src/components/HomepageFeatures.module.css
+++ b/website/src/components/HomepageFeatures.module.css
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This software may be used and distributed according to the terms of the
- * GNU General Public License version 2.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 .features {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This software may be used and distributed according to the terms of the
- * GNU General Public License version 2.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 /**

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This software may be used and distributed according to the terms of the
- * GNU General Public License version 2.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import React from 'react';

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -1,8 +1,8 @@
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
- * This software may be used and distributed according to the terms of the
- * GNU General Public License version 2.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 /**


### PR DESCRIPTION
Summary:

Sweeps the Docusaurus-bootstrapped website JS/CSS files AND two parallel sphinx scaffold leftovers from their original GPLv2 header (inherited verbatim from the Docusaurus 2.x scaffold's example files and the matching sphinx scaffold) to MIT, matching the rest of the open-source `balance` repo. The repo as a whole has always been MIT (see top-level `LICENSE`), and these scaffold files were never intentionally GPLv2 — the GPLv2 header was a leftover from the scaffold templates.

The relicense aligns these files with **upstream Docusaurus**, which itself is MIT (see https://github.com/facebook/docusaurus/blob/main/LICENSE). Docusaurus shipped the GPLv2 boilerplate in some of its 1.x/early-2.x scaffolded templates by mistake; current upstream has been MIT since at least the 2.x stable line. Re-applying the upstream license here is a cleanup, not a license change in spirit. The two sphinx files are the same class of scaffold leftover.

Files relicensed (10 total):

Docusaurus website:
- \`parent_balance/website/babel.config.js\`
- \`parent_balance/website/sidebars.js\`
- \`parent_balance/website/src/components/HTMLLoader.js\` (note: contains some balance-team-authored iframe-resize logic alongside the scaffold; relicense is to a more permissive license, low legal risk)
- \`parent_balance/website/src/components/HomepageFeatures.js\`
- \`parent_balance/website/src/components/HomepageFeatures.module.css\`
- \`parent_balance/website/src/css/custom.css\`
- \`parent_balance/website/src/pages/index.js\`
- \`parent_balance/website/src/pages/index.module.css\`

Sphinx scaffold leftovers (added in revision N following review):
- \`parent_balance/sphinx/make.bat\`
- \`parent_balance/sphinx/_static/css/custom.css\`

Extracted from D103436269 (the diff-diff documentation diff) following review feedback that the license-header sweep was unrelated to documenting the diff-diff integration and bundling them obscured what was a legally-meaningful change. This standalone relicense diff lands first; the documentation diff above (D103436269) inherits a clean MIT baseline and only carries the actual new content (README's "Design-based inference" section, copilot-instructions checklist bullet, Docusaurus tip card, and HomepageFeatures.js feature card).

Differential Revision: D104026494


