### PR TITLE
Add balance.interop.diff_diff for survey-weighted DiD handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,27 @@
   `store_fit_metadata=False` if memory footprint matters more than
   the ability to call `predict_weights()` later.
 
+## New Features
+
+- **`balance.interop.diff_diff`** — thin adapter to [diff-diff](https://github.com/igerber/diff-diff) (`>=3.3.0,<4`) for survey-weighted Difference-in-Differences handoff. Provides `to_survey_design()`, `to_panel_for_did()`, `fit_did()`, and `as_balance_diagnostic()`. Install the optional dependency via `pip install "balance[did]"`. The submodule is lazy-imported, so `import balance` still works cleanly when diff-diff isn't available — the import guard rewrites the `ImportError` to point users at the `balance[did]` extra. Shared adapter helpers (`active_weight_column`, `drop_history_columns`, `validate_row_count`, `attach_balance_provenance`) live in `balance/interop/_common.py` and column-name conventions in `balance/interop/conventions.py` so a future `balance.interop.svy` adapter can reuse them.
+
+- **Rake now supports fit-time metadata persistence and `predict_weights()` reconstruction.**
+  - `rake(..., store_fit_metadata=True)` now stores contingency-table artifacts
+    and fit-time metadata required to rebuild weights later.
+  - `BalanceFrame.fit(method="rake")` now enables `store_fit_metadata=True` by
+    default so fitted rake models can be reused with
+    `BalanceFrame.predict_weights()` without refitting.
+  - **In-place replay** (`predict_weights()` with no `data=`) works with
+    any transformations, including the rake default
+    `transformations="default"`.
+  - **Transfer scoring** (`predict_weights(data=...)`) requires
+    deterministic transformations: it raises `ValueError` for models
+    fitted with `transformations="default"` and for explicit dicts that
+    directly reference known data-dependent helpers (`quantize`,
+    `fct_lump`). To enable transfer scoring, pass deterministic
+    transformations at fit time (e.g. wrappers built around stored
+    fit-time bin edges) or re-fit rake on the scoring data.
+
 ## Bug Fixes
 
 - **`rake()` now correctly incorporates per-row design weights in final weights.**
@@ -43,25 +64,6 @@
   In this delegated path, model metadata records `method='poststratify'`
   (explicitly noted in the warning) while returned weights keep the
   canonical rake output name (`rake_weight`).
-
-## New Features
-
-- **Rake now supports fit-time metadata persistence and `predict_weights()` reconstruction.**
-  - `rake(..., store_fit_metadata=True)` now stores contingency-table artifacts
-    and fit-time metadata required to rebuild weights later.
-  - `BalanceFrame.fit(method="rake")` now enables `store_fit_metadata=True` by
-    default so fitted rake models can be reused with
-    `BalanceFrame.predict_weights()` without refitting.
-  - **In-place replay** (`predict_weights()` with no `data=`) works with
-    any transformations, including the rake default
-    `transformations="default"`.
-  - **Transfer scoring** (`predict_weights(data=...)`) requires
-    deterministic transformations: it raises `ValueError` for models
-    fitted with `transformations="default"` and for explicit dicts that
-    directly reference known data-dependent helpers (`quantize`,
-    `fct_lump`). To enable transfer scoring, pass deterministic
-    transformations at fit time (e.g. wrappers built around stored
-    fit-time bin edges) or re-fit rake on the scoring data.
 
 ## Code Quality & Refactoring
 

--- a/balance/interop/__init__.py
+++ b/balance/interop/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""balance.interop — adapters between balance and adjacent libraries.
+
+Empty re-export surface by design. Sub-modules (e.g.
+``balance.interop.diff_diff``) are imported explicitly by users so that
+optional heavy dependencies stay lazy:
+
+    from balance.interop import diff_diff as bd
+"""
+
+from __future__ import annotations

--- a/balance/interop/_common.py
+++ b/balance/interop/_common.py
@@ -1,0 +1,477 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Shared helpers for ``balance.interop.*`` adapters.
+
+This module is the single canonical home for adapter helpers that ALL
+:mod:`balance.interop` sub-modules need. Today the only consumer is
+:mod:`balance.interop.diff_diff`; when the future
+:mod:`balance.interop.svy` lands it will reuse the SAME helpers, so the
+two adapters cannot drift in their handling of balance-side state.
+
+Canonical balance-side hidden state (the "5-state" spec)
+========================================================
+
+After ``Sample.adjust(method="ipw" | "cbps" | "rake" | ...)`` runs, a
+:class:`balance.Sample` carries five distinct pieces of state that any
+downstream library must handle correctly. Adapters that fail to drop or
+preserve any of these introduce silent bugs in surveys that span the
+balance / diff-diff / svy boundary:
+
+1. **``weight_pre_adjust``** — column on ``Sample.df`` holding the
+   pre-adjustment design weight (or ``1.0`` if ``Sample.from_frame`` was
+   given no ``weight_column``). Written by ``balance_frame.py:701-744``.
+   Must be DROPPED before handing the DataFrame to a survey-aware
+   estimator: diff-diff and svy will silently treat it as a covariate.
+
+2. **``weight_adjusted_N``** (``N = 1, 2, …``) — column(s) on
+   ``Sample.df`` recording the chain of compounded ``adjust()`` calls.
+   The active weight column NAME stays the same across compounded calls
+   (per ``balance_frame.py:707-712``); ``adjust()`` overwrites the
+   values in that active column with the latest adjustment and stores
+   each prior adjustment as a new ``weight_adjusted_N`` history column.
+   Same drop rule as ``weight_pre_adjust`` for the history columns.
+
+3. **``weight_trimmed_*``** — column(s) recording the pre-trim weight
+   when the user passes ``transformations="trim"`` to ``adjust()``. Same
+   drop rule.
+
+4. **``Sample._links["unadjusted"]`` / ``Sample._links["target"]``** —
+   internal back-references to the original responder and target
+   ``Sample``. NOT a column — adapters do not need to drop, but
+   diagnostic helpers (e.g. ``as_balance_diagnostic``) walk these to
+   compute ASMD pre / post.
+
+5. **``Sample._adjustment_model``** — the fitted IPW / CBPS / rake model
+   object. Out of scope for diff-diff and svy directly, but
+   :func:`attach_balance_provenance` lets downstream tooling reach it
+   via the ``_balance_adjustment`` side-channel.
+
+The :func:`drop_history_columns` helper handles items 1-3 with one call
+so adapters do not have to enumerate the bookkeeping prefixes
+themselves.
+"""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from typing import Any
+
+import pandas as pd
+from balance.sample_class import Sample
+
+# Route through the package logger ("balance"), matching the convention used
+# by ``balance/sample_class.py`` and ``balance/balance_frame.py`` so adapter
+# log output inherits the configuration set up in ``balance/__init__.py``.
+logger: logging.Logger = logging.getLogger(__package__)
+
+
+def active_weight_column(s: Sample) -> str:
+    """Return the active weight column NAME (``str``) on a balance ``Sample``.
+
+    balance's ``weight_column`` property at ``sample_frame.py:570-600``
+    returns ``str | None`` (a column name, not a Series — that's
+    ``weight_series`` at ``sample_frame.py:761-786``). It also emits a
+    ``FutureWarning`` during the v0.20 migration to clarify the
+    str-vs-Series semantics; this helper suppresses that warning so
+    adapter callers don't see it.
+
+    Parameters
+    ----------
+    s :
+        A balance ``Sample`` (typically post-``adjust()``).
+
+    Returns
+    -------
+    str
+        The name of the column on ``s.df`` that carries the active weights.
+
+    Raises
+    ------
+    ValueError
+        When ``s.weight_column`` is ``None``. ``adjust()`` ensures the
+        ``Sample`` has an active weight column, but it preserves the
+        existing active-column name rather than canonicalizing it to
+        ``"weight"`` -- a ``Sample`` constructed with a custom
+        ``weight_column="w"`` keeps that name post-adjustment. A ``None``
+        value here therefore means the ``Sample`` was constructed without
+        an active weight column and ``adjust()`` was never run.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        col: str | None = s.weight_column
+    if col is None:
+        raise ValueError(
+            "balance.Sample.weight_column is None — cannot hand off to a "
+            "survey-aware library without a weight column. Call "
+            "`s.adjust(...)` first or pass `weight_column=...` to "
+            "`Sample.from_frame(...)`."
+        )
+    return col
+
+
+def _is_balance_history_column(name: object) -> bool:
+    """Return True if ``name`` matches a column that ``BalanceFrame.adjust()``
+    is documented to emit (and only those names).
+
+    balance writes:
+
+    * ``"weight_pre_adjust"`` (a single literal column name; see
+      ``balance_frame.py:719-722``)
+    * ``"weight_adjusted_<N>"`` where ``N`` is an integer step counter
+      (see ``balance_frame.py:727-729``)
+    * ``"weight_trimmed_<N>"`` where ``N`` is an integer trim counter
+      (see ``sample_frame.py:1014``)
+
+    We anchor the integer suffix here so unrelated user covariates whose
+    names happen to start with one of these prefixes (e.g. a column literally
+    called ``"weight_adjusted_q1_response"``) are NOT silently dropped from
+    the interop handoff.
+    """
+    s: str = str(name)
+    if s == "weight_pre_adjust":
+        return True
+    for prefix in ("weight_adjusted_", "weight_trimmed_"):
+        if s.startswith(prefix):
+            suffix: str = s[len(prefix) :]
+            if suffix.isdigit():
+                return True
+    return False
+
+
+def drop_history_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Strip balance's adjustment-history columns from ``df``.
+
+    After ``BalanceFrame.adjust(method=...)`` the responder frame carries
+    ``weight_pre_adjust``, ``weight_adjusted_N``, and (if trimming was
+    requested) ``weight_trimmed_N`` columns — see hidden-state items 1-3
+    in this module's docstring. Diff-diff has no contract about these
+    columns and will silently treat them as covariates if forwarded.
+    Svy's ``RepWeights.columns_from_data()`` auto-detect would pick them
+    up as replicate weights. Both behaviours are silent failures; this
+    helper is the single defensive scrub.
+
+    Matching is intentionally narrow: only the literal
+    ``"weight_pre_adjust"`` column and the digit-suffixed
+    ``"weight_adjusted_<N>"`` / ``"weight_trimmed_<N>"`` patterns that
+    balance actually emits are dropped. Unrelated user covariates that
+    happen to share one of these prefixes (e.g.
+    ``"weight_adjusted_q1_response"``) are preserved.
+
+    Returns a new DataFrame (``df.drop`` returns a copy by default), so
+    callers can safely mutate the result without affecting the source
+    Sample.
+    """
+    # Filter on ``isinstance(c, str)`` so the ``list[str]`` annotation is
+    # sound under stricter pandas stubs: ``df.columns`` may carry non-string
+    # labels (int, tuple, etc.), but balance-emitted history column names
+    # are always strings, so they are a strict subset of the str-typed
+    # columns and the predicate cannot reject any genuine history column.
+    history: list[str] = [
+        c for c in df.columns if isinstance(c, str) and _is_balance_history_column(c)
+    ]
+    if history:
+        return df.drop(columns=history)
+    # Always return a fresh copy: the docstring promises callers can safely
+    # mutate the result without affecting ``Sample.df``. ``df.drop(columns=)``
+    # already returns a new frame in the history-found branch, so we mirror
+    # that contract here for the no-history path.
+    return df.copy()
+
+
+def drop_nan_weight_rows(
+    df: pd.DataFrame, weight_col: str, *, ctx: str
+) -> pd.DataFrame:
+    """Drop rows whose active weight is NaN, warning the caller if any are
+    found.
+
+    Why this is necessary
+    ---------------------
+    ``BalanceFrame.adjust(na_action='drop')`` (the IPW default; see
+    ``weighting_methods/ipw.py:738-745``) does NOT actually remove rows
+    that had missing covariates -- it keeps them in ``Sample.df`` and
+    sets their active weight to ``NaN``. Diff-diff's ``SurveyDesign`` and
+    ``aggregate_survey`` propagate those ``NaN`` weights into variance
+    estimation: best case the call raises far away from the
+    ``Sample`` -> adapter seam; worst case the fitted ATT is silently
+    contaminated by rows that have no defined contribution.
+
+    Adapter callers should NOT see this concern -- the contract is "I
+    handed balance my data, please weight it for diff-diff". So we drop
+    NaN-weight rows defensively at the seam, with a ``UserWarning`` so
+    the row-count loss is visible in notebooks and CI logs.
+
+    Parameters
+    ----------
+    df :
+        DataFrame to filter (typically ``Sample.df``).
+    weight_col :
+        Name of the active weight column on ``df``.
+    ctx :
+        Short label naming the calling adapter function -- included in
+        the warning so the user can trace which seam dropped rows.
+
+    Returns
+    -------
+    pd.DataFrame
+        Either ``df`` itself (when no NaN-weight rows exist) or a new
+        DataFrame with NaN-weight rows removed.
+    """
+    if weight_col not in df.columns:
+        # Inconsistent ``Sample`` state: ``Sample.weight_column`` claims an
+        # active column name that no longer exists on ``Sample.df`` (e.g.
+        # the user mutated ``sample.df`` and dropped the weight column
+        # after ``adjust()``). Failing fast here gives a clear actionable
+        # message instead of letting the downstream adapter raise a
+        # cryptic ``KeyError`` deep in ``SurveyDesign``/``aggregate_survey``.
+        raise ValueError(
+            f"{ctx}: weight column {weight_col!r} is not present in df.columns "
+            f"({sorted(map(str, df.columns))}). This usually means the "
+            "Sample's active weight column was dropped or renamed after "
+            "adjust(). Re-fit the Sample or pass a DataFrame whose columns "
+            "match Sample.weight_column."
+        )
+    weights: pd.Series = df[weight_col]
+    nan_mask: pd.Series = weights.isna()
+    n_nan: int = int(nan_mask.sum())
+    if n_nan == 0:
+        return df
+    warnings.warn(
+        f"{ctx}: dropping {n_nan} row(s) of {len(df)} with NaN weights "
+        f"in column {weight_col!r} before forwarding to the downstream "
+        "adapter. These rows typically come from "
+        "`Sample.adjust(na_action='drop')` in IPW, which retains the row "
+        "but sets the active weight to NaN. Pass "
+        "`na_action='add_indicator'` (or pre-impute missing values) if "
+        "you want every row to carry weight downstream.",
+        UserWarning,
+        stacklevel=3,
+    )
+    return df.loc[~nan_mask].copy()
+
+
+def validate_nonzero_weights(df: pd.DataFrame, weight_col: str, *, ctx: str) -> None:
+    """Raise if the active weight column has no positive entries.
+
+    Zero-individual weights are fine (a zero-weight row is just a
+    non-contributing observation), but if EVERY weight is zero or
+    negative, the downstream ``SurveyDesign`` will produce undefined
+    variance: ``sum(w) == 0`` propagates ``inf`` / ``NaN`` through the
+    Kish ESS / design-effect / Binder-1983 sandwich at every variance
+    seam. We catch this at the adapter boundary so the user sees a
+    clear, actionable error instead of a downstream ``ZeroDivisionError``
+    or ``inf`` value buried in an estimator's diagnostics dict.
+
+    Negative weights are also rejected -- balance-style design weights
+    are non-negative by construction, and a negative entry is almost
+    always a sign that the user has confused a residual / centred
+    column with the active weight column.
+
+    Parameters
+    ----------
+    df :
+        DataFrame whose active weight column to validate.
+    weight_col :
+        Name of the active weight column on ``df``.
+    ctx :
+        Short label naming the calling adapter function -- included in
+        the error message so the user can trace which seam tripped.
+
+    Raises
+    ------
+    ValueError
+        When ``df[weight_col]`` contains no entries strictly greater
+        than zero (after NaN filtering, which is handled separately by
+        :func:`drop_nan_weight_rows`).
+    """
+    if weight_col not in df.columns:
+        # Mirror the early-fail message from ``drop_nan_weight_rows`` so
+        # both helpers fail with the same actionable wording when the
+        # active weight column has been dropped from ``Sample.df``.
+        raise ValueError(
+            f"{ctx}: weight column {weight_col!r} is not present in df.columns "
+            f"({sorted(map(str, df.columns))}). This usually means the "
+            "Sample's active weight column was dropped or renamed after "
+            "adjust(). Re-fit the Sample or pass a DataFrame whose columns "
+            "match Sample.weight_column."
+        )
+    weights: pd.Series = df[weight_col]
+    # Reject non-numeric dtypes up front: a string / object weight column
+    # would otherwise trip on ``(weights < 0)`` with a cryptic pandas
+    # comparison TypeError, hiding the real issue (the user pointed at the
+    # wrong column). Mirror the wording of ``weights_stats``'
+    # ``_check_weights_series_are_valid`` so the surface stays consistent
+    # across the two validators.
+    if not pd.api.types.is_numeric_dtype(weights):
+        raise TypeError(
+            f"{ctx}: active weight column {weight_col!r} must be numeric, "
+            f"got dtype {weights.dtype}. (Almost always: the column named "
+            "in Sample.weight_column was an id / category column rather "
+            "than a numeric weight.)"
+        )
+    # Reject ANY negative entry first (a mixed-sign vector like [-1, 2]
+    # would pass the "at least one positive" check below but is just as
+    # broken as an all-non-positive vector — the SurveyDesign math
+    # assumes non-negative design weights, and a negative entry
+    # almost always means the user accidentally pointed at a residual /
+    # centred / mean-deviation column instead of the design-weight one).
+    n_negative: int = int((weights < 0).sum())
+    if n_negative > 0:
+        raise ValueError(
+            f"{ctx}: active weight column {weight_col!r} has "
+            f"{n_negative} negative entr{'y' if n_negative == 1 else 'ies'} "
+            f"({len(weights)} rows total). Design weights must be "
+            "non-negative — a negative entry usually means the column "
+            f"named in {weight_col!r} is actually a residual / centred / "
+            "mean-deviation vector, not a design weight. Verify the "
+            "column name and re-fit / re-derive the design weights "
+            "before handing them to the adapter."
+        )
+    # Then reject the all-non-positive case (sum_w == 0).
+    if not (weights > 0).any():
+        raise ValueError(
+            f"{ctx}: active weight column {weight_col!r} has no positive "
+            f"entries ({len(weights)} rows, all <= 0). The downstream "
+            "SurveyDesign would produce undefined variance "
+            "(sum of positive weights = 0), propagating inf / NaN through "
+            "Kish ESS / design-effect / Binder-1983 sandwich computations. "
+            "Diagnose the upstream cause: confirm that "
+            f"{weight_col!r} names the intended design-weight column "
+            "(not a centred / residual column whose values can legitimately "
+            "be zero or negative); inspect any filtering / merging / "
+            "groupby / transformation step that may have collapsed the "
+            "frame to an all-zero subset; verify the input weights "
+            "themselves are positive before they reach this seam. "
+            "(Note: `transformations='trim'` only clips extreme positive "
+            "weights — it does not rescue an all-non-positive vector.)"
+        )
+
+
+def validate_row_count(s: Sample, n_target: int, *, ctx: str) -> None:
+    """Raise if a balance ``Sample`` lost rows relative to ``n_target``.
+
+    "Lost rows" includes BOTH the row-count drop case AND the case where
+    ``BalanceFrame.adjust(na_action="drop")`` retains the row but writes
+    its weight back as ``NaN`` (see ``balance/balance_frame.py:740-744`` --
+    the shorter weight vector is reindexed onto the original frame, so
+    ``len(s.df)`` matches ``n_target`` and a naive length check yields a
+    false pass). Counting NaN weights is the only reliable adapter-side
+    signal that ``na_action='drop'`` removed records from the active
+    weight column.
+
+    Both the diff-diff adapter and the future svy adapter need this
+    check -- diff-diff's panel alignment and svy's ``rep_wgts`` row
+    alignment are both fragile in different ways when rows are silently
+    missing from the active weighting.
+
+    Parameters
+    ----------
+    s :
+        The balance ``Sample`` whose row count to check.
+    n_target :
+        The expected number of rows (typically the row count of the
+        DataFrame the user originally handed to ``Sample.from_frame``).
+    ctx :
+        A short label naming the calling adapter function -- included in
+        the error message so the user can trace which seam tripped.
+
+    Raises
+    ------
+    ValueError
+        When ``len(s.df) != n_target`` OR when the active weight column
+        contains NaN entries (the ``na_action='drop'`` reindex case).
+    """
+    n_actual: int = len(s.df)
+    if n_actual != n_target:
+        raise ValueError(
+            f"Row-count mismatch in {ctx}: balance.Sample has {n_actual} "
+            f"rows but the downstream adapter expects {n_target}. Did "
+            "`na_action='drop'` silently drop rows? Use "
+            "`na_action='add_indicator'` instead, or pre-impute the "
+            "missing values before adjust()."
+        )
+    # Detect the more subtle ``na_action='drop'`` case where row count is
+    # preserved but weights are NaN.
+    weight_col: str | None = None
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        weight_col = s.weight_column
+    if weight_col is not None and weight_col in s.df.columns:
+        n_nan: int = int(s.df[weight_col].isna().sum())
+        if n_nan > 0:
+            raise ValueError(
+                f"Row-count appears unchanged in {ctx} (n={n_actual}), but "
+                f"the active weight column {weight_col!r} has {n_nan} "
+                "NaN entries. This is the `adjust(na_action='drop')` "
+                "pattern: balance reindexes the shorter weight vector "
+                "onto the original frame and marks dropped records with "
+                "NaN. Use `na_action='add_indicator'` (or pre-impute "
+                "missing covariates) so every row carries a defined "
+                "weight downstream."
+            )
+
+
+def attach_balance_provenance(target: object, sample: Sample) -> None:
+    """Attach ``sample`` to ``target`` as ``_balance_adjustment`` (provenance).
+
+    Side-channel pattern. Lets downstream diagnostic tooling recover all 5
+    hidden-state pieces (see this module's docstring) from a diff-diff
+    result or svy ``Sample`` via one stable attribute name.
+
+    Idempotent — silently no-ops when ``target`` already has the
+    attribute (so re-fitting does not clobber the original lineage).
+    Falls back to ``target.__dict__`` if ``setattr`` is rejected (frozen
+    msgspec / dataclass struct); emits a ``UserWarning`` if even that
+    path is blocked, since callers passing ``preserve_adjustment=True``
+    deserve a clear signal that provenance was NOT attached -- silently
+    no-oping makes ``_balance_adjustment`` look unreliable in tooling.
+
+    Parameters
+    ----------
+    target :
+        Any object (typically a diff-diff results dataclass).
+    sample :
+        The ``balance.Sample`` whose provenance to record.
+    """
+    if hasattr(target, "_balance_adjustment"):
+        return
+    try:
+        # pyre-ignore[16]: dynamic attribute set on object — intentional.
+        target._balance_adjustment = sample
+        return
+    except (AttributeError, TypeError):
+        pass
+    # Frozen dataclass / msgspec struct fallback.
+    target_dict: dict[str, Any] | None = getattr(target, "__dict__", None)
+    if target_dict is None:
+        warnings.warn(
+            f"Could not attach `_balance_adjustment` to a "
+            f"{type(target).__name__} instance: object rejected both "
+            "`setattr` and lacks a writable `__dict__`. Provenance will "
+            "NOT be available on this result; if `preserve_adjustment=True` "
+            "matters for your pipeline, store the adjustment Sample "
+            "alongside the result (e.g. wrap them in a tuple, dict, or a "
+            "small custom container class) -- ``dataclasses.replace`` will "
+            "NOT help here because it preserves ``frozen=True``.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return
+    try:
+        target_dict["_balance_adjustment"] = sample
+    except TypeError:
+        # ``__dict__`` exists but is read-only (e.g. mappingproxy on a
+        # class; some msgspec structs). Same UX rationale as above:
+        # warn loudly rather than silently dropping provenance.
+        warnings.warn(
+            f"Could not attach `_balance_adjustment` to a "
+            f"{type(target).__name__} instance: `__dict__` is read-only. "
+            "Provenance will NOT be available on this result.",
+            UserWarning,
+            stacklevel=2,
+        )

--- a/balance/interop/conventions.py
+++ b/balance/interop/conventions.py
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Recommended column names for balance interop handoffs.
+
+Both :mod:`balance.interop.diff_diff` and the future
+:mod:`balance.interop.svy` default to the names declared here. The names
+match svy's ``RepWeights.columns_from_data()`` auto-detect (per the
+balance/svy plan) and the column conventions documented in
+``svy.core.design``.
+
+Adapters never enforce these names — they consume them as defaults when
+the user does not pass an explicit column mapping. Locking them down in
+one place keeps both adapters in sync as svy evolves.
+
+The naming policy itself (why both adapters share these names) is
+documented inline in this module's symbols and in
+``balance/interop/diff_diff.py``'s module docstring -- there is no
+separate external policy document to track.
+"""
+
+from __future__ import annotations
+
+#: Convention default name for the active weight column when
+#: ``Sample.from_frame`` is called WITHOUT a user-supplied
+#: ``weight_column``. NOTE: ``BalanceFrame.adjust()`` preserves whatever
+#: column name was active on the input Sample (see
+#: ``balance_frame.py:820-822``) -- a Sample created with
+#: ``weight_column="w"`` keeps ``weight_column == "w"`` after adjustment;
+#: it does NOT canonicalise to ``"weight"``. This default is only used by
+#: adapters when the caller has not configured a custom weight column.
+WEIGHT_COLUMN: str = "weight"
+
+#: Canonical stratum column name (svy / diff-diff design).
+STRATUM_COLUMN: str = "stratum"
+
+#: Canonical primary-sampling-unit column name.
+PSU_COLUMN: str = "psu"
+
+#: Canonical secondary-sampling-unit column name. Reserved for the future
+#: ``balance.interop.svy`` adapter — diff-diff's ``SurveyDesign`` does not
+#: currently expose an ``ssu`` field, so the diff-diff adapter does not
+#: forward this name (no entry in ``DEFAULT_DESIGN_COLUMNS`` below).
+SSU_COLUMN: str = "ssu"
+
+#: Canonical finite-population-correction column name.
+FPC_COLUMN: str = "fpc"
+
+#: Prefix for replicate-weight columns (``repweight_1``, ``repweight_2``,
+#: …). Used by svy's ``RepWeights.columns_from_data()`` auto-detect.
+REPWEIGHT_PREFIX: str = "repweight_"
+
+#: Default weight type. ``"pweight"`` is the only choice compatible with
+#: the full diff-diff estimator family (CallawaySantAnna, StackedDiD,
+#: HAD-continuous, ImputationDiD, TwoStageDiD, EfficientDiD, WooldridgeDiD,
+#: TROP, dCDH) — see ``staggered.py:1500-1506`` and
+#: ``survey.py:1051-1085`` in diff-diff for the rejection guard.
+WEIGHT_TYPE_DEFAULT: str = "pweight"
+
+#: Default mapping of design-column NAMES to forward into a
+#: ``diff_diff.SurveyDesign`` (or, in the future, an ``svy.Design``). Both
+#: adapters merge user-supplied overrides on top of this dict; the
+#: ``weights`` slot is always overridden with the active balance weight
+#: column name (the source of truth for which column is "live").
+DEFAULT_DESIGN_COLUMNS: dict[str, str] = {
+    "weights": WEIGHT_COLUMN,
+    "strata": STRATUM_COLUMN,
+    "psu": PSU_COLUMN,
+    "fpc": FPC_COLUMN,
+    "weight_type": WEIGHT_TYPE_DEFAULT,
+}

--- a/balance/interop/diff_diff.py
+++ b/balance/interop/diff_diff.py
@@ -1,0 +1,828 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Bridge between :mod:`balance` and :mod:`diff_diff`.
+
+This module is the single reviewed handoff between balance's reweighting
+output (a :class:`balance.Sample` with an active ``weight_column``) and
+diff-diff's survey-aware DiD estimators (which all consume a
+``diff_diff.SurveyDesign``).
+
+Design choices (rationale at the cited line):
+
+* ``weight_type="pweight"`` is the documented default. It is the only
+  choice compatible with the staggered DiD estimators that this adapter
+  is most often used with — CallawaySantAnna, StackedDiD, ImputationDiD,
+  HeterogeneousAdoptionDiD (HAD), TwoStageDiD, WooldridgeDiD, TROP,
+  StaggeredTripleDifference, ChaisemartinDHaultfoeuille (dCDH),
+  TripleDifference, and SyntheticDiD — each of which inlines its own
+  ``weight_type != "pweight"`` rejection in its ``fit()`` method (e.g.
+  CallawaySantAnna at ``staggered.py:1500-1505``). EfficientDiD,
+  DifferenceInDifferences, TwoWayFixedEffects, MultiPeriodDiD,
+  SunAbraham, and ContinuousDiD additionally accept ``aweight``, but
+  balance does not produce precision weights, so exposing that mode
+  would only be a footgun.
+* ``lonely_psu="adjust"`` default — the safest of the three documented
+  values (``"remove"`` drops the row, ``"certainty"`` zeroes its variance
+  contribution, ``"adjust"`` rescales survivors). Documented at
+  ``survey.py:80-84`` in diff-diff.
+* No expensive copies — all functions pass column NAMES (str), never
+  Series, into ``SurveyDesign``, matching balance's documented
+  ``weight_column: str | None`` contract at ``sample_frame.py:570-600``.
+* Lazy import of ``diff_diff`` so that bare ``import balance`` works
+  even when diff-diff isn't installed; the rewritten ``ImportError``
+  points users at ``pip install balance[did]``.
+
+Usage::
+
+    import balance
+    from balance.interop import diff_diff as bd
+
+    s = balance.Sample.from_frame(
+        df, id_column="id", weight_column="w", outcome_columns=["y"],
+    )
+    s_target = balance.Sample.from_frame(target_df, id_column="id")
+    adj = s.set_target(s_target).adjust(method="ipw")
+
+    # End-to-end fit (attaches `_balance_adjustment` for provenance):
+    res = bd.fit_did(
+        adj, estimator="CallawaySantAnna",
+        outcome="y", time="period", unit="geo",
+        treatment_first="first_treat",
+    )
+
+    # Or build the SurveyDesign yourself for finer control:
+    design = bd.to_survey_design(adj, design_columns={"strata": "region"})
+
+    # Cross-package diagnostics in one place:
+    diag = bd.as_balance_diagnostic(adj, res)
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import warnings
+from types import ModuleType
+from typing import Any, Mapping
+
+import pandas as pd
+from balance.interop._common import (
+    active_weight_column,
+    attach_balance_provenance,
+    drop_history_columns,
+    drop_nan_weight_rows,
+    validate_nonzero_weights,
+)
+from balance.interop.conventions import DEFAULT_DESIGN_COLUMNS, WEIGHT_TYPE_DEFAULT
+from balance.sample_class import Sample
+from balance.util import _assert_type
+
+# @manual=fbsource//third-party/pypi/diff-diff:diff-diff
+try:
+    import diff_diff as _dd
+except ImportError as _e:  # pragma: no cover
+    _IMPORT_ERROR: ImportError | None = ImportError(
+        "balance.interop.diff_diff requires the diff-diff package "
+        "(>=3.3.0,<4). Install via `pip install 'balance[did]'` or "
+        f"`pip install diff-diff`. Original error: {_e}"
+    )
+    _dd = None  # type: ignore[assignment]
+else:
+    _IMPORT_ERROR = None
+
+# Route through the package logger ("balance"), matching the convention used
+# by ``balance/sample_class.py`` and ``balance/balance_frame.py`` so adapter
+# log output inherits the configuration set up in ``balance/__init__.py``.
+logger: logging.Logger = logging.getLogger(__package__)
+
+#: Field NAMES on ``diff_diff.SurveyDesign`` that adapter callers may forward
+#: via ``design_columns``. Source of truth: the ``SurveyDesign`` dataclass
+#: definition in diff-diff's ``survey.py`` (no ``ssu`` field exists there;
+#: the future ``balance.interop.svy`` adapter is the home for ``ssu``).
+_ALLOWED_DESIGN_FIELDS: frozenset[str] = frozenset(
+    {
+        "strata",
+        "psu",
+        "fpc",
+        "replicate_weights",
+        "replicate_method",
+        "replicate_strata",
+        "fay_rho",
+        "combined_weights",
+        "replicate_scale",
+        "replicate_rscales",
+        "mse",
+        "nest",
+    }
+)
+
+#: SurveyDesign / convention keys whose values are literal configuration
+#: (method names, floats, booleans) rather than column references on
+#: ``sample.df``. The column-existence validation in
+#: ``_resolve_design_columns`` must skip these keys -- otherwise passing a
+#: perfectly valid value like ``replicate_method="JK1"`` or ``mse=True``
+#: would be rejected with a misleading "column not found" error.
+#:
+#: Note: ``weight_type`` is included here even though it is NOT in
+#: ``_ALLOWED_DESIGN_FIELDS`` (the allowed-via-design_columns set). It is
+#: separately surfaced as the ``weight_type=`` kwarg on the public adapter
+#: functions and is also a default in ``DEFAULT_DESIGN_COLUMNS``; rejecting
+#: ``design_columns={"weight_type": ...}`` happens earlier in the validator
+#: (line 145) but defensively listing it here keeps the literal-value rule
+#: consistent. The other keys (``replicate_method``, ``fay_rho``, ...) ARE
+#: subsets of ``_ALLOWED_DESIGN_FIELDS``.
+_LITERAL_VALUE_DESIGN_FIELDS: frozenset[str] = frozenset(
+    {
+        "weight_type",
+        "replicate_method",
+        "fay_rho",
+        "replicate_scale",
+        "replicate_rscales",
+        "mse",
+        "nest",
+    }
+)
+
+
+def _require_diff_diff() -> ModuleType:
+    """Return the diff-diff module, or raise the rewritten ImportError.
+
+    Returning the module (instead of just raising on failure) lets Pyre
+    narrow ``_dd`` from ``ModuleType | None`` to ``ModuleType`` at every
+    call site. We use ``_assert_type`` rather than a bare ``assert``
+    because ``python -O`` strips ``assert`` statements; the bare-assert
+    version would leave ``_dd`` as ``None`` in optimised builds and the
+    next attribute access would raise ``AttributeError`` instead of the
+    rewritten ``ImportError``.
+    """
+    if _IMPORT_ERROR is not None:
+        raise _IMPORT_ERROR
+    return _assert_type(_dd, ModuleType)
+
+
+def _resolve_design_columns(
+    sample: Sample,
+    design_columns: Mapping[str, object] | None,
+) -> dict[str, object]:
+    """Merge user-supplied design columns with the conventions defaults.
+
+    ``weights`` is always overridden with the active balance weight
+    column name — ``design_columns={"weights": ...}`` is rejected up
+    front because balance is the source of truth for which column is
+    "live".
+
+    Convention auto-population (``stratum`` -> ``"strata"``, ``psu`` ->
+    ``"psu"`` etc.) only runs when ``design_columns`` is ``None``.
+    Passing an explicit mapping -- including the empty mapping ``{}`` --
+    is the supported opt-out for callers whose dataframe has covariates
+    that happen to share names with convention design fields and should
+    NOT be reinterpreted as survey-design metadata.
+    """
+    user: Mapping[str, object] = design_columns if design_columns is not None else {}
+    if "weights" in user:
+        raise ValueError(
+            "design_columns cannot set 'weights' — balance's active "
+            "weight_column is the source of truth. Use Sample.adjust(...) "
+            "or Sample.from_frame(weight_column=...) to control which "
+            "column is active."
+        )
+    if "weight_type" in user:
+        # The caller-facing ``to_survey_design(..., weight_type=...)`` kwarg is
+        # the only supported channel for this; setting it via design_columns
+        # used to be silently overridden by the kwarg, which produced a
+        # confusing API where ``design_columns={'weight_type': 'aweight'}``
+        # was accepted at validation time but ignored at use-time.
+        raise ValueError(
+            "design_columns cannot set 'weight_type' — pass it via the "
+            "``weight_type=`` kwarg on ``to_survey_design``/``to_panel_for_did``/"
+            "``fit_did`` instead. Earlier versions silently discarded a "
+            "``weight_type`` value supplied through design_columns."
+        )
+    extra: set[str] = set(user) - _ALLOWED_DESIGN_FIELDS
+    if extra:
+        raise ValueError(
+            f"design_columns has unknown SurveyDesign fields: {sorted(extra)}. "
+            f"Allowed fields are: {sorted(_ALLOWED_DESIGN_FIELDS)} "
+            "(see survey.py:27-72 in diff-diff)."
+        )
+    weights_col: str = active_weight_column(sample)
+    # Validate user-supplied column NAMES exist in ``sample.df`` against the
+    # raw column index (no ``str()`` coercion): if the dataframe has the
+    # integer column ``1`` and the caller passes ``{"strata": "1"}``, the
+    # adapter must reject that reference rather than silently letting it
+    # through and forwarding a string-typed name that diff-diff will then
+    # fail to look up on an int-indexed frame. Skip
+    # ``_LITERAL_VALUE_DESIGN_FIELDS`` because their values are configuration
+    # literals (e.g. ``replicate_method="JK1"``, ``fay_rho=0.5``,
+    # ``mse=True``), not column references on ``sample.df``.
+    df_columns_raw: set[object] = set(sample.df.columns)
+    column_ref_keys: dict[str, object] = {
+        k: v for k, v in user.items() if k not in _LITERAL_VALUE_DESIGN_FIELDS
+    }
+    non_string_column_refs: dict[str, object] = {
+        k: v for k, v in column_ref_keys.items() if not isinstance(v, str)
+    }
+    if non_string_column_refs:
+        raise ValueError(
+            "design_columns values that reference dataframe columns must "
+            f"be strings. Got non-string values for: "
+            f"{sorted(non_string_column_refs.items(), key=lambda kv: kv[0])}. "
+            "(Literal-value fields like `mse`, `nest`, `fay_rho`, "
+            "`replicate_method`, `replicate_scale`, `replicate_rscales` "
+            "are exempt — those accept their natural Python types.)"
+        )
+    missing_user_cols: dict[str, object] = {
+        k: v for k, v in column_ref_keys.items() if v not in df_columns_raw
+    }
+    if missing_user_cols:
+        # Format column labels via ``repr`` so int / str columns are
+        # distinguishable in the error message (``1`` vs ``"1"``).
+        missing_repr: list[str] = sorted(
+            f"{k}={v!r}" for k, v in missing_user_cols.items()
+        )
+        available_repr: list[str] = sorted(repr(c) for c in df_columns_raw)
+        raise ValueError(
+            "design_columns references column(s) that do not exist in "
+            f"sample.df: {missing_repr}. "
+            f"Available columns: {available_repr}."
+        )
+    # Convention auto-population is opt-in: only when the caller passed
+    # ``design_columns=None`` do we layer ``DEFAULT_DESIGN_COLUMNS`` entries
+    # whose target columns happen to exist in ``sample.df``. Passing any
+    # explicit mapping (including ``{}``) suppresses this entirely, so a
+    # caller whose frame has a covariate literally named ``"psu"`` /
+    # ``"stratum"`` / ``"fpc"`` can opt out of having it silently promoted
+    # into ``SurveyDesign``.
+    merged: dict[str, object] = dict(user)
+    auto_populate: bool = design_columns is None
+    for key, default_col in DEFAULT_DESIGN_COLUMNS.items():
+        if key in merged or key == "weights":
+            continue
+        if key == "weight_type":
+            # ``weight_type`` is a literal value (e.g. ``"pweight"``), not a
+            # column reference. Always populate when the caller did not
+            # supply one — it is a config default, not a column inference.
+            merged[key] = default_col
+            continue
+        if auto_populate and default_col in df_columns_raw:
+            merged[key] = default_col
+            logger.info(
+                "balance.interop.diff_diff: auto-populating SurveyDesign "
+                "field %r from sample.df column %r (matched the default "
+                "convention name). Pass an explicit design_columns mapping "
+                "(or design_columns={}) to suppress this.",
+                key,
+                default_col,
+            )
+    merged["weights"] = weights_col
+    return merged
+
+
+def to_survey_design(
+    sample: Sample,
+    *,
+    design_columns: Mapping[str, object] | None = None,
+    weight_type: str = WEIGHT_TYPE_DEFAULT,
+    lonely_psu: str = "adjust",
+) -> Any:
+    """Build a ``diff_diff.SurveyDesign`` from a balance ``Sample``.
+
+    Parameters
+    ----------
+    sample :
+        A balance ``Sample`` (typically post-``adjust()``).
+    design_columns :
+        Optional mapping of ``SurveyDesign`` field name to either a
+        ``sample.df`` column name (``str``) or a literal config value.
+        Keys are validated against the documented ``SurveyDesign``
+        field set (``survey.py:27-72`` in diff-diff). Most keys
+        (``strata``, ``psu``, ``fpc``, ``replicate_weights``,
+        ``replicate_strata``, ``combined_weights``) take column names;
+        the literal-value keys ``mse`` / ``nest`` (bool), ``fay_rho``
+        / ``replicate_scale`` (float), ``replicate_method`` (str),
+        and ``replicate_rscales`` (list/array) accept their natural
+        Python types directly. The ``weights`` slot is always sourced
+        from ``sample.weight_column`` and may NOT be overridden — this
+        is enforced. When ``design_columns`` is ``None`` the adapter
+        opportunistically auto-populates convention defaults (e.g.
+        ``"strata"`` from ``sample.df["stratum"]`` when that column
+        exists). Pass an explicit mapping — including the empty
+        mapping ``{}`` — to suppress that behaviour entirely; this is
+        the supported escape hatch for frames whose covariates happen
+        to share names with convention design fields.
+    weight_type :
+        Forwarded to ``SurveyDesign.weight_type``. Default ``"pweight"``
+        is REQUIRED for the staggered family (CallawaySantAnna, StackedDiD,
+        HeterogeneousAdoptionDiD, ImputationDiD, TwoStageDiD,
+        WooldridgeDiD, TROP, StaggeredTripleDifference, dCDH,
+        TripleDifference, SyntheticDiD); each of those estimators inlines
+        its own ``weight_type != "pweight"`` rejection in ``fit()`` (e.g.
+        CallawaySantAnna at ``staggered.py:1500-1505``). EfficientDiD,
+        DifferenceInDifferences, TwoWayFixedEffects, MultiPeriodDiD,
+        SunAbraham, and ContinuousDiD also accept ``aweight``.
+    lonely_psu :
+        Forwarded; one of ``"remove" | "certainty" | "adjust"``
+        (validated at ``survey.py:80-84`` in diff-diff). Default
+        ``"adjust"`` is the safest — it re-scales surviving PSUs in
+        singleton strata rather than dropping them.
+
+    Returns
+    -------
+    diff_diff.SurveyDesign
+        Ready to feed into any diff-diff estimator's ``survey_design=``.
+
+    Raises
+    ------
+    ImportError
+        If diff-diff is not installed.
+    ValueError
+        If ``sample.weight_column`` is ``None``, or if ``design_columns``
+        sets the reserved ``"weights"`` key, or contains a key that is
+        not a valid ``SurveyDesign`` field.
+    """
+    dd = _require_diff_diff()
+    merged: dict[str, object] = _resolve_design_columns(sample, design_columns)
+    # Strip the "weight_type" slot before forwarding — conventions stores it
+    # as a default but SurveyDesign takes it as a separate kwarg.
+    merged.pop("weight_type", None)
+    return dd.SurveyDesign(
+        weight_type=weight_type,
+        lonely_psu=lonely_psu,
+        **merged,
+    )
+
+
+def to_panel_for_did(
+    sample: Sample,
+    *,
+    by: list[str] | str,
+    outcomes: list[str] | str,
+    covariates: list[str] | None = None,
+    second_stage_weights: str = WEIGHT_TYPE_DEFAULT,
+    min_n: int = 2,
+    design_columns: Mapping[str, object] | None = None,
+    weight_type: str = WEIGHT_TYPE_DEFAULT,
+    lonely_psu: str = "adjust",
+) -> tuple[pd.DataFrame, Any]:
+    """Aggregate a respondent-level ``balance.Sample`` into a geo-period
+    panel via ``diff_diff.aggregate_survey``.
+
+    Use this when balance has produced respondent-level (microdata)
+    weights and the user wants to feed a downstream estimator that
+    operates on the geo-period panel scale (e.g. CallawaySantAnna with
+    ``panel=True``).
+
+    The first element of ``by`` is the geographic unit per
+    ``prep.py:1820-1821`` in diff-diff; the remaining ``by`` columns
+    define the period axis.
+
+    Parameters
+    ----------
+    sample :
+        A balance ``Sample`` whose active weight column is the
+        first-stage survey weight.
+    by, outcomes, covariates, min_n :
+        Forwarded verbatim to ``diff_diff.aggregate_survey``.
+        ``covariates`` are produced as ``{covariate}_mean`` cells (per
+        ``prep.py:1750-1758``).
+    second_stage_weights :
+        Forwarded to ``aggregate_survey``. Default ``"pweight"`` is
+        compatible with all survey-aware estimators.
+    design_columns :
+        Same semantics as in :func:`to_survey_design` — forwarded to the
+        first-stage ``SurveyDesign``.
+    weight_type :
+        Forwarded to the first-stage :func:`to_survey_design` call.
+        Default ``"pweight"`` (matches ``WEIGHT_TYPE_DEFAULT``).
+    lonely_psu :
+        Forwarded to the first-stage :func:`to_survey_design` call.
+        Default ``"adjust"``.
+
+    Returns
+    -------
+    (panel_df, second_stage_design) :
+        Two-tuple as returned by ``diff_diff.aggregate_survey``
+        (``prep.py:1498-1507``). ``second_stage_design`` is a fresh
+        ``SurveyDesign`` whose ``weights`` is the auto-generated
+        ``{first_outcome}_weight`` column on ``panel_df`` and whose
+        ``psu`` is the geographic unit column.
+    """
+    dd = _require_diff_diff()
+    first_stage_design: Any = to_survey_design(
+        sample,
+        design_columns=design_columns,
+        weight_type=weight_type,
+        lonely_psu=lonely_psu,
+    )
+    weights_col: str = active_weight_column(sample)
+    # Filter NaN-weight rows BEFORE dropping balance's history columns so
+    # the warning's "of N rows" denominator reflects the user's view of
+    # the sample, not the post-history-strip view.
+    df: pd.DataFrame = drop_nan_weight_rows(
+        sample.df, weights_col, ctx="to_panel_for_did"
+    )
+    # All-zero / all-negative weights would produce undefined variance in
+    # the downstream SurveyDesign. Catch at the seam with an actionable
+    # error rather than letting inf / NaN surface deep in aggregate_survey.
+    validate_nonzero_weights(df, weights_col, ctx="to_panel_for_did")
+    df = drop_history_columns(df)
+    return dd.aggregate_survey(
+        df,
+        by=by,
+        outcomes=outcomes,
+        survey_design=first_stage_design,
+        covariates=covariates,
+        min_n=min_n,
+        second_stage_weights=second_stage_weights,
+    )
+
+
+def fit_did(
+    sample: Sample,
+    *,
+    estimator: str = "CallawaySantAnna",
+    outcome: str,
+    time: str,
+    unit: str,
+    treatment_first: str | None = None,
+    treatment: str | None = None,
+    covariates: list[str] | None = None,
+    design_columns: Mapping[str, object] | None = None,
+    weight_type: str = WEIGHT_TYPE_DEFAULT,
+    lonely_psu: str = "adjust",
+    preserve_adjustment: bool = True,
+    drop_history: bool = True,
+    **estimator_kwargs: object,
+) -> object:
+    """Build a SurveyDesign and fit a diff-diff estimator in one call.
+
+    Parameters
+    ----------
+    sample :
+        A balance ``Sample`` (typically post-``adjust()``).
+    estimator :
+        Class NAME or short alias of a diff-diff estimator class.
+        Resolved via ``getattr(diff_diff, estimator)`` against the
+        public alias block at ``diff_diff.__init__.py:271-288``.
+        Examples: ``"CallawaySantAnna"``, ``"CS"``,
+        ``"DifferenceInDifferences"``, ``"DiD"``, ``"SunAbraham"``,
+        ``"ImputationDiD"``, ``"BJS"``, ``"StackedDiD"``,
+        ``"HeterogeneousAdoptionDiD"``, ``"HAD"``.
+    outcome, time, unit, treatment_first, treatment, covariates :
+        Forwarded to the estimator's ``fit()``. Names cover the most
+        common kwargs across estimators; estimators that disagree
+        (e.g. dCDH uses ``group``/``treatment`` and ``controls``)
+        receive their own names via ``**estimator_kwargs``.
+    design_columns :
+        Same semantics as in :func:`to_survey_design`.
+    weight_type :
+        Forwarded to the internal :func:`to_survey_design` call. Default
+        ``"pweight"`` (matches ``WEIGHT_TYPE_DEFAULT``). Use ``"aweight"``
+        on estimators that explicitly support it (e.g. when
+        ``aggregate_survey(second_stage_weights="aweight")`` is upstream
+        of the panel and the estimator has a precision-weighted variance
+        path).
+    lonely_psu :
+        Forwarded to the internal :func:`to_survey_design` call. Default
+        ``"adjust"``.
+    preserve_adjustment :
+        If ``True`` (the default), attach the source ``sample`` to the
+        returned result via :func:`attach_balance_provenance` under the
+        attribute name ``_balance_adjustment``. Lets downstream tooling
+        recover the BalanceFrame for diagnostics.
+    drop_history :
+        Strip ``weight_pre_adjust``, ``weight_adjusted_*``, and
+        ``weight_trimmed_*`` columns from the DataFrame before fitting
+        (default ``True``). These columns would silently be treated as
+        covariates by diff-diff.
+    **estimator_kwargs :
+        Forwarded to both the estimator's ``__init__`` and its
+        ``fit()`` — split by inspecting the ``__init__`` signature.
+
+    Returns
+    -------
+    A diff-diff results dataclass (e.g. ``CallawaySantAnnaResults``).
+    The exact schema depends on the chosen estimator -- inspect the
+    returned object's type / dataclass fields, or refer to the upstream
+    diff-diff documentation at <https://github.com/igerber/diff-diff>.
+
+    The result also carries ``_balance_adjustment`` (when
+    ``preserve_adjustment=True``) for provenance.
+    """
+    dd = _require_diff_diff()
+    if not hasattr(dd, estimator):
+        # List the actual class-typed names exposed by the installed
+        # diff-diff so the user's error message is grounded in their
+        # environment rather than a stale internal-line-number reference.
+        valid_estimators: list[str] = sorted(
+            name
+            for name in getattr(dd, "__all__", dir(dd))
+            if not name.startswith("_") and inspect.isclass(getattr(dd, name, None))
+        )
+        raise ValueError(
+            f"Unknown diff-diff estimator: {estimator!r}. Valid estimator "
+            f"names exposed by the installed diff-diff are: "
+            f"{valid_estimators}. See "
+            "<https://github.com/igerber/diff-diff> for the upstream API "
+            "documentation."
+        )
+    cls: Any = getattr(dd, estimator)
+    # Reject reserved positional / wired-in fit kwargs before they can collide
+    # with the positional ``df`` (passed as the first argument to ``fit``)
+    # this adapter wires up itself. Without this guard, a caller who passed
+    # ``data=other_df`` via ``**estimator_kwargs`` would land it in
+    # ``fit_kwargs`` and the ``instance.fit(df, **common_fit_kwargs)`` call
+    # below would raise the cryptic ``TypeError: multiple values for argument
+    # 'data'`` rather than a clear adapter-level message.
+    #
+    # Limited to the names that genuinely flow through ``**estimator_kwargs``:
+    # ``data`` / ``df`` (positional fit() conflict) and ``first_treat`` (the
+    # diff-diff column name; fit_did exposes the same column via the
+    # ``treatment_first=`` adapter param). Names already in fit_did's
+    # explicit signature (``outcome``, ``time``, ``unit``, ``treatment``,
+    # ``covariates``) bind to those params during the user's call and never
+    # reach ``**estimator_kwargs``; Python rejects same-name duplication
+    # with its own clear ``TypeError`` before fit_did's body runs, so an
+    # adapter-level guard for those names would be dead code.
+    # ``survey_design`` has a separate, more specific check below.
+    _reserved_fit_positionals: frozenset[str] = frozenset({"data", "df", "first_treat"})
+    _reserved_in_user: set[str] = set(estimator_kwargs) & _reserved_fit_positionals
+    if _reserved_in_user:
+        raise TypeError(
+            f"fit_did(): the following kwarg(s) collide with positional / "
+            f"wired-in arguments and must be passed via the dedicated "
+            f"adapter parameters instead of `**estimator_kwargs`: "
+            f"{sorted(_reserved_in_user)}. The DataFrame is sourced from "
+            "`sample.df` and cannot be overridden via `data=`/`df=`. "
+            "Use `treatment_first=` on fit_did() directly instead of "
+            "the diff-diff `first_treat` column-name kwarg."
+        )
+    design: Any = to_survey_design(
+        sample,
+        design_columns=design_columns,
+        weight_type=weight_type,
+        lonely_psu=lonely_psu,
+    )
+    # Filter NaN-weight rows before everything else. ``adjust(na_action='drop')``
+    # retains rows with missing covariates and sets their active weight to NaN
+    # rather than removing them; passing those rows to diff-diff would either
+    # raise far from the seam or silently contaminate the fit. ``drop_nan_weight_rows``
+    # warns when it removes rows so the loss is visible.
+    weights_col: str = active_weight_column(sample)
+    pre_history_df: pd.DataFrame = drop_nan_weight_rows(
+        sample.df, weights_col, ctx="fit_did"
+    )
+    # Same all-zero / all-negative guard as ``to_panel_for_did``. The check
+    # runs AFTER NaN-row removal so the count in the (potential) error
+    # message reflects the post-NaN-filter row population the estimator
+    # would actually consume.
+    validate_nonzero_weights(pre_history_df, weights_col, ctx="fit_did")
+    # Always hand the estimator a fresh copy: ``drop_history_columns`` already
+    # guarantees a copy in BOTH branches (history present → ``df.drop`` returns
+    # a copy; history absent → explicit ``.copy()``). The ``drop_history=False``
+    # path needs a parallel guarantee, otherwise an estimator that mutates the
+    # frame in-place (e.g. by adding a column) would silently corrupt
+    # ``Sample.df``. The asymmetric earlier behaviour was flagged by an
+    # AI-reviewer warning. Note: ``drop_nan_weight_rows`` returns a fresh
+    # DataFrame whenever rows are dropped, so the `.copy()` here is only
+    # load-bearing in the no-NaN-rows branch.
+    df: pd.DataFrame = (
+        drop_history_columns(pre_history_df) if drop_history else pre_history_df.copy()
+    )
+
+    # Split estimator_kwargs by inspecting __init__'s signature. We need to
+    # also peek at fit() so we can warn about names that exist on BOTH; the
+    # `if k in init_params` rule sends overlapping names exclusively to
+    # __init__ and silently drops them from fit(), which would surprise a
+    # user who passed a fit-time name expecting it to land in fit().
+    init_sig: inspect.Signature = inspect.signature(cls.__init__)
+    init_params: set[str] = set(init_sig.parameters)
+    # Eagerly resolve the fit signature too -- ``cls(**init_kwargs)`` below
+    # will not yet exist, but ``cls.fit`` is a regular unbound method on
+    # the class, so we can introspect it without instantiating first.
+    try:
+        fit_method: Any = getattr(cls, "fit", None)
+        fit_params_for_overlap: set[str] = (
+            set(inspect.signature(fit_method).parameters) if fit_method else set()
+        )
+    except (TypeError, ValueError):  # pragma: no cover
+        fit_params_for_overlap = set()
+    overlap: set[str] = set(estimator_kwargs) & init_params & fit_params_for_overlap
+    if overlap:
+        warnings.warn(
+            f"The following kwarg(s) appear in BOTH "
+            f"{cls.__name__}.__init__ and {cls.__name__}.fit() signatures: "
+            f"{sorted(overlap)}. fit_did routes overlapping names to "
+            "__init__ only; the fit() call will not see them. If you "
+            "intended these for fit(), pass them via estimator-specific "
+            "API directly, or open a feature request to widen the split "
+            "rule for this estimator class.",
+            UserWarning,
+            stacklevel=2,
+        )
+    init_kwargs: dict[str, object] = {
+        k: v for k, v in estimator_kwargs.items() if k in init_params
+    }
+    fit_kwargs: dict[str, object] = {
+        k: v for k, v in estimator_kwargs.items() if k not in init_params
+    }
+    instance: Any = cls(**init_kwargs)
+
+    # Most fit() signatures take (data, outcome, unit, time, first_treat,
+    # covariates=...). DiD/TWFE/MultiPeriodDiD use 'treatment' instead of
+    # 'first_treat'. We pass under the most common names; estimators that
+    # disagree should be invoked via **estimator_kwargs.
+    candidate_fit_kwargs: dict[str, object] = {
+        "outcome": outcome,
+        "time": time,
+        "unit": unit,
+        "first_treat": treatment_first,
+        "treatment": treatment,
+        "covariates": covariates,
+        "survey_design": design,
+    }
+    fit_sig: inspect.Signature = inspect.signature(instance.fit)
+    fit_params: set[str] = set(fit_sig.parameters)
+    # If the chosen estimator's ``fit()`` does not accept ``survey_design``,
+    # the line below will silently drop it -- meaning the
+    # carefully-constructed survey design (the whole point of this adapter)
+    # is never consumed and the estimator effectively runs unweighted /
+    # without the cluster-stratification structure. Warn loudly so the user
+    # is not silently misled by an apparently-successful fit.
+    if "survey_design" not in fit_params:
+        warnings.warn(
+            f"{type(instance).__name__}.fit() does not accept "
+            "`survey_design`; the SurveyDesign built from balance's weights "
+            "will NOT be forwarded to this estimator. The fit will run "
+            "without survey-design variance / clustering. If you need a "
+            "design-aware estimator, choose one whose fit() takes "
+            "`survey_design` (e.g. CallawaySantAnna, StackedDiD, "
+            "ImputationDiD).",
+            UserWarning,
+            stacklevel=2,
+        )
+    common_fit_kwargs: dict[str, object] = {
+        k: v
+        for k, v in candidate_fit_kwargs.items()
+        if k in fit_params and v is not None
+    }
+    # Guard against silent design override: this adapter's contract is that
+    # the SurveyDesign comes from ``sample.weight_column`` /
+    # ``design_columns=``. If a caller routes ``survey_design=...`` via
+    # ``**estimator_kwargs`` it would land in ``fit_kwargs`` here and the
+    # ``.update()`` below would silently replace the design we just built.
+    # Reject that explicitly with a TypeError so the misuse is visible.
+    if "survey_design" in fit_kwargs:
+        raise TypeError(
+            "fit_did(): `survey_design` cannot be passed via "
+            "`**estimator_kwargs`. The adapter derives the SurveyDesign from "
+            "the Sample's active weight column (and any `design_columns=` "
+            "override) so the handoff stays consistent with the balance "
+            "Sample. Customise the design via `design_columns=` / "
+            "`weight_type=` / `lonely_psu=`, or call `to_survey_design()` and "
+            "the chosen estimator directly."
+        )
+    common_fit_kwargs.update(fit_kwargs)
+    results: object = instance.fit(df, **common_fit_kwargs)
+
+    if preserve_adjustment:
+        attach_balance_provenance(results, sample)
+    return results
+
+
+def as_balance_diagnostic(
+    sample: Sample,
+    did_results: object,
+) -> dict[str, object]:
+    """Combine balance's ASMD / Kish ESS with diff-diff's design-effect /
+    event-study output into a single flat diagnostic dict.
+
+    Cross-package diagnostics in one place: balance owns the pre-fit
+    ASMD / r-indicator / DEFF view (``stats_and_plots/weights_stats.py``);
+    diff-diff owns the post-fit design-effect / per-coefficient SE
+    breakdown (``DEFFDiagnostics``, ``SurveyMetadata`` in
+    ``survey.py``). Without this helper users rebuild the same dict by
+    hand on every notebook.
+
+    Returns
+    -------
+    dict
+        Flat dict suitable for tabulation. Keys cover the most common
+        per-fit summary scalars from both packages; missing values are
+        ``None`` rather than raising.
+    """
+    out: dict[str, object] = {}
+
+    # diff-diff side — read defensively via getattr() since the result
+    # protocol is structural across ~10 estimator dataclasses. Different
+    # estimator classes name the headline ATT differently:
+    # CallawaySantAnnaResults exposes ``overall_att`` (used by the new
+    # tutorial), while DifferenceInDifferencesResults / TwoWayFixedEffects
+    # expose ``att``. Try ``att`` first to preserve the existing contract,
+    # then fall back to ``overall_att`` so callers using either result
+    # family see a populated key rather than ``None``.
+    att_value: object = getattr(did_results, "att", None)
+    if att_value is None:
+        att_value = getattr(did_results, "overall_att", None)
+    out["att"] = att_value
+    out["se"] = getattr(did_results, "se", None)
+    out["conf_int"] = getattr(did_results, "conf_int", None)
+    out["n_obs"] = getattr(did_results, "n_obs", None)
+
+    sm: object | None = getattr(did_results, "survey_metadata", None)
+    out["diff_diff_design_effect"] = (
+        getattr(sm, "design_effect", None) if sm is not None else None
+    )
+    out["diff_diff_effective_n"] = (
+        getattr(sm, "effective_n", None) if sm is not None else None
+    )
+    out["diff_diff_sum_weights"] = (
+        getattr(sm, "sum_weights", None) if sm is not None else None
+    )
+
+    # balance side — diagnostics() returns a DataFrame; we extract the
+    # relevant scalars defensively (older balance versions had a
+    # slightly different schema).
+    diag_df: pd.DataFrame
+    try:
+        diag_df = sample.diagnostics()
+    except Exception as e:  # pragma: no cover
+        logger.debug("sample.diagnostics() failed: %s", e)
+        diag_df = pd.DataFrame()
+
+    # Schema source of truth: ``summary_utils.py`` builds the diagnostics
+    # DataFrame and ``balancedf_class.py`` defines the var names used in the
+    # ``weights_diagnostics`` metric. Per-covariate ASMDs are emitted under
+    # ``covar_main_asmd_adjusted`` (the post-adjustment view) with one row
+    # per covariate plus a final ``mean(asmd)`` summary row.
+    out["balance_kish_ess"] = _scalar_from_diag(
+        diag_df, "weights_diagnostics", "effective_sample_size"
+    )
+    out["balance_design_effect"] = _scalar_from_diag(
+        diag_df, "weights_diagnostics", "design_effect"
+    )
+    out["balance_asmd_mean_post"] = _scalar_from_diag(
+        diag_df, "covar_main_asmd_adjusted", "mean(asmd)"
+    )
+    out["balance_asmd_max_post"] = _max_per_covariate_asmd_post(diag_df)
+    return out
+
+
+def _scalar_from_diag(
+    diag_df: pd.DataFrame, metric_kind: str, var_name: str
+) -> float | None:
+    """Pull a single scalar out of balance's diagnostics() DataFrame.
+
+    The diagnostics frame layout is documented in
+    ``stats_and_plots/weights_stats.py``. We tolerate schema drift
+    across balance versions by returning ``None`` on any miss rather
+    than raising — diagnostic dicts should never block the user's
+    notebook.
+    """
+    if diag_df.empty or "metric" not in diag_df.columns:
+        return None
+    try:
+        sub: pd.DataFrame = diag_df[
+            (diag_df["metric"] == metric_kind) & (diag_df["var"] == var_name)
+        ]
+        if len(sub) == 0:
+            return None
+        return float(sub["val"].iloc[0])
+    except Exception:  # pragma: no cover
+        return None
+
+
+def _max_per_covariate_asmd_post(diag_df: pd.DataFrame) -> float | None:
+    """Maximum post-adjustment per-covariate ASMD (excluding the summary row).
+
+    Balance's diagnostics DataFrame stores one row per main covariate under
+    ``metric == "covar_main_asmd_adjusted"`` plus a final ``mean(asmd)``
+    summary row. The "max ASMD" is not pre-computed in the schema, so we
+    derive it here -- excluding the summary row -- so that callers get the
+    advertised ``balance_asmd_max_post`` field rather than ``None``.
+    """
+    if diag_df.empty or "metric" not in diag_df.columns:
+        return None
+    try:
+        sub: pd.DataFrame = diag_df[
+            (diag_df["metric"] == "covar_main_asmd_adjusted")
+            & (diag_df["var"] != "mean(asmd)")
+        ]
+        if len(sub) == 0:
+            return None
+        return float(sub["val"].max())
+    except Exception:  # pragma: no cover
+        return None
+
+
+__all__: list[str] = [
+    "to_survey_design",
+    "to_panel_for_did",
+    "fit_did",
+    "as_balance_diagnostic",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,12 @@ dev = [
     "nbconvert",
     "pre-commit",
 ]
+# Reserved extra names for a possible future svy 1.0 integration (kept here
+# so the eventual addition is purely additive and does not need to rename
+# the `did` extra below):
+#   survey = ["svy>=1.0,<2"]
+#   interop = ["balance[did,survey]"]   # convenience meta-extra
+did = ["diff-diff>=3.3.0,<4"]
 
 [project.urls]
 homepage = "https://import-balance.org/"

--- a/tests/test_interop_diff_diff.py
+++ b/tests/test_interop_diff_diff.py
@@ -1,0 +1,715 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Tests for ``balance.interop.diff_diff`` and its shared helpers.
+
+The test classes split into two groups:
+
+* Package-agnostic helpers (rows T1-T7, T15-T17): apply to ANY future
+  ``balance.interop.*`` adapter -- e.g. ``ActiveWeightColumnTest``,
+  ``DropHistoryColumnsTest``, ``ConventionsTest``,
+  ``AttachBalanceProvenanceTest``, ``ValidateRowCountTest``.
+* diff-diff-specific (rows T8-T14, T18-T20): apply only to
+  ``balance.interop.diff_diff`` -- e.g. ``ToSurveyDesignTest``,
+  ``ToPanelForDidTest``, ``FitDidTest``, ``AsBalanceDiagnosticTest``.
+
+Each test docstring tags its row(s). The :class:`ImportGuardTest` is
+the only test class that always runs even without diff-diff installed.
+"""
+
+from __future__ import annotations
+
+import unittest
+import warnings
+from typing import Any
+
+import balance
+import numpy as np
+import pandas as pd
+
+try:
+    import diff_diff as _dd  # noqa: F401
+
+    _DIFF_DIFF_AVAILABLE: bool = True
+except ImportError:
+    _DIFF_DIFF_AVAILABLE = False
+
+
+def _toy_balanced_panel() -> pd.DataFrame:
+    """Tiny 8-unit / 3-period panel sufficient for adapter wiring tests.
+
+    Multi-period staggered design: half the units are never-treated
+    (``first_treat=0``) and half are treated at ``t=2``. This shape is the
+    natural input for diff-diff's staggered estimators (``CallawaySantAnna``,
+    ``StackedDiD``, etc.) which consume the cohort-year column directly via
+    ``treatment_first=`` rather than a binary post-treatment indicator. The
+    simpler 2x2 ``DifferenceInDifferences`` estimator is a poor match here:
+    it would require both ``time`` and ``treatment`` to be binary 0/1
+    vectors (see ``diff_diff.utils.validate_binary``).
+
+    The survey weight ``w`` is drawn ONCE per unit and repeated across all
+    of its time periods. Diff-diff's panel estimators
+    (``CallawaySantAnna``, ``ContinuousDiD``, ``EfficientDiD``) collapse
+    panel-level survey design columns down to one row per unit and require
+    those columns to be constant within unit
+    (``diff_diff.survey._validate_unit_constant_survey``). A per-row
+    weight would fail that check before the test ever exercised the
+    adapter's provenance behaviour.
+    """
+    rng: np.random.Generator = np.random.default_rng(20260430)
+    rows: list[dict[str, float]] = []
+    row_id: int = 0
+    for unit in range(8):
+        first_treat: int = 0 if unit < 4 else 2
+        # Unit-constant survey weight: realistic for sampling weights too.
+        unit_weight: float = float(rng.uniform(0.5, 2.0))
+        for t in range(3):
+            post_treatment: bool = first_treat > 0 and t >= first_treat
+            rows.append(
+                {
+                    "id": float(row_id),
+                    "unit": float(unit),
+                    "t": float(t),
+                    "first_treat": float(first_treat),
+                    "x1": float(rng.normal()),
+                    "x2": float(rng.normal()),
+                    "y": float(rng.normal()) + (1.0 if post_treatment else 0.0),
+                    "w": unit_weight,
+                }
+            )
+            row_id += 1
+    return pd.DataFrame(rows)
+
+
+def _toy_target() -> pd.DataFrame:
+    rng: np.random.Generator = np.random.default_rng(7)
+    return pd.DataFrame(
+        {
+            "unit": np.arange(50, dtype=float),
+            "x1": rng.normal(size=50),
+            "x2": rng.normal(size=50),
+            "w": np.ones(50),
+        }
+    )
+
+
+def _make_sample() -> "balance.Sample":
+    """Build a balance.Sample on the toy panel for reuse across tests."""
+    return balance.Sample.from_frame(
+        _toy_balanced_panel(),
+        id_column="id",
+        weight_column="w",
+        outcome_columns=["y"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests (run regardless of diff-diff availability)
+# ---------------------------------------------------------------------------
+
+
+class ActiveWeightColumnTest(unittest.TestCase):
+    """§11.A — ``active_weight_column`` resolves the active weight name."""
+
+    def test_returns_weight_column_name_when_set(self) -> None:
+        """T1 — adapter forwards the column NAME, not the Series."""
+        from balance.interop._common import active_weight_column
+
+        s = _make_sample()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            self.assertEqual("w", active_weight_column(s))
+
+    def test_raises_when_no_weight_column(self) -> None:
+        """T2 — ``Sample`` without an active weight raises ``ValueError``."""
+        from balance.interop._common import active_weight_column
+
+        df: pd.DataFrame = _toy_balanced_panel().drop(columns=["w"])
+        s = balance.Sample.from_frame(df, id_column="id", outcome_columns=["y"])
+        # Force weight_column to None to simulate user-constructed Sample
+        # with no weights.
+        # pyre-ignore[16]: test-only access to private state.
+        s._weight_column_name = None
+        with self.assertRaises(ValueError):
+            active_weight_column(s)
+
+
+class DropHistoryColumnsTest(unittest.TestCase):
+    """§11.A — ``drop_history_columns`` strips balance bookkeeping cols."""
+
+    def test_drops_pre_adjust_and_adjusted_n(self) -> None:
+        """T4 — ``weight_pre_adjust`` and ``weight_adjusted_*`` are stripped."""
+        from balance.interop._common import drop_history_columns
+
+        df: pd.DataFrame = _toy_balanced_panel()
+        df["weight_pre_adjust"] = 1.0
+        df["weight_adjusted_1"] = 1.1
+        df["weight_adjusted_2"] = 1.2
+        cleaned: pd.DataFrame = drop_history_columns(df)
+        self.assertNotIn("weight_pre_adjust", cleaned.columns)
+        self.assertNotIn("weight_adjusted_1", cleaned.columns)
+        self.assertNotIn("weight_adjusted_2", cleaned.columns)
+        # Sanity: the active weight column is NOT history-bookkeeping.
+        self.assertIn("w", cleaned.columns)
+
+    def test_drops_weight_trimmed_columns(self) -> None:
+        """T4 (extension) — ``weight_trimmed_*`` is also stripped."""
+        from balance.interop._common import drop_history_columns
+
+        df: pd.DataFrame = _toy_balanced_panel()
+        df["weight_trimmed_1"] = 1.0
+        cleaned: pd.DataFrame = drop_history_columns(df)
+        self.assertNotIn("weight_trimmed_1", cleaned.columns)
+
+    def test_no_history_columns_passthrough(self) -> None:
+        """T4 (extension) — frames with no bookkeeping cols pass through."""
+        from balance.interop._common import drop_history_columns
+
+        df: pd.DataFrame = _toy_balanced_panel()
+        cleaned: pd.DataFrame = drop_history_columns(df)
+        self.assertEqual(set(df.columns), set(cleaned.columns))
+
+
+class ConventionsTest(unittest.TestCase):
+    """§11.A — column-name convention constants are stable."""
+
+    def test_weight_column_constant(self) -> None:
+        """Default weight column is ``"weight"`` (matches balance's
+        post-``adjust()`` active column name)."""
+        from balance.interop import conventions
+
+        self.assertEqual("weight", conventions.WEIGHT_COLUMN)
+
+    def test_default_design_columns_includes_weights(self) -> None:
+        """``DEFAULT_DESIGN_COLUMNS`` exposes a ``"weights"`` key whose
+        value is the canonical ``WEIGHT_COLUMN`` constant."""
+        from balance.interop import conventions
+
+        self.assertEqual(
+            conventions.WEIGHT_COLUMN,
+            conventions.DEFAULT_DESIGN_COLUMNS["weights"],
+        )
+
+    def test_weight_type_default_is_pweight(self) -> None:
+        """``WEIGHT_TYPE_DEFAULT`` is ``"pweight"`` — required for the
+        full diff-diff estimator family."""
+        from balance.interop import conventions
+
+        self.assertEqual("pweight", conventions.WEIGHT_TYPE_DEFAULT)
+
+
+class AttachBalanceProvenanceTest(unittest.TestCase):
+    """§11.A — ``attach_balance_provenance`` writes ``_balance_adjustment``."""
+
+    def test_attaches_to_plain_object(self) -> None:
+        """T15 — provenance attribute lands on a vanilla object."""
+        from balance.interop._common import attach_balance_provenance
+
+        class _Stub:
+            pass
+
+        target = _Stub()
+        sample = _make_sample()
+        attach_balance_provenance(target, sample)
+        # ``_balance_adjustment`` is dynamically set by
+        # ``attach_balance_provenance``; use ``getattr`` so Pyre does not
+        # require a declared attribute on ``_Stub`` (which would defeat
+        # the point of testing the side-channel attach behavior — the
+        # ``hasattr`` early-return path inside the helper would skip the
+        # assignment if a class-level attribute were declared).
+        self.assertIs(sample, getattr(target, "_balance_adjustment", None))
+
+    def test_idempotent_on_second_call(self) -> None:
+        """T15 — second call does NOT clobber the original lineage."""
+        from balance.interop._common import attach_balance_provenance
+
+        class _Stub:
+            pass
+
+        target = _Stub()
+        sample_a = _make_sample()
+        sample_b = _make_sample()
+        attach_balance_provenance(target, sample_a)
+        attach_balance_provenance(target, sample_b)
+        self.assertIs(sample_a, getattr(target, "_balance_adjustment", None))
+
+
+class ValidateRowCountTest(unittest.TestCase):
+    """§11.A — row-count guard catches ``na_action='drop'`` regressions."""
+
+    def test_passes_when_counts_match(self) -> None:
+        """T17 — equal counts: silent return (None)."""
+        from balance.interop._common import validate_row_count
+
+        s = _make_sample()
+        # The function is documented to return ``None`` on a successful match
+        # and to raise ``ValueError`` on mismatch (see _common.py). The
+        # explicit assertion documents the success contract for the reader.
+        self.assertIsNone(validate_row_count(s, len(s.df), ctx="test"))
+
+    def test_raises_when_counts_differ(self) -> None:
+        """T17 — mismatched counts surface a ``ValueError`` with ctx."""
+        from balance.interop._common import validate_row_count
+
+        s = _make_sample()
+        with self.assertRaises(ValueError) as cm:
+            validate_row_count(s, len(s.df) + 5, ctx="my_adapter")
+        self.assertIn("my_adapter", str(cm.exception))
+
+
+# ---------------------------------------------------------------------------
+# diff-diff-specific tests (skipped when diff-diff isn't installed)
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(_DIFF_DIFF_AVAILABLE, "diff-diff is not installed")
+class ToSurveyDesignTest(unittest.TestCase):
+    """§11.B — ``to_survey_design`` builds a ``diff_diff.SurveyDesign``."""
+
+    def test_uses_weight_column_name(self) -> None:
+        """T1 — adapter forwards the column NAME, not the Series."""
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+        d: Any = bd.to_survey_design(s)
+        # SurveyDesign.weights is the column name string.
+        self.assertEqual("w", d.weights)
+
+    def test_default_weight_type_is_pweight(self) -> None:
+        """T3 — adapter defaults to ``weight_type='pweight'``."""
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+        d: Any = bd.to_survey_design(s)
+        self.assertEqual("pweight", d.weight_type)
+
+    def test_design_columns_rejects_weights_key(self) -> None:
+        """T8/T9 — ``design_columns`` cannot reset ``"weights"``."""
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+        with self.assertRaises(ValueError) as cm:
+            bd.to_survey_design(s, design_columns={"weights": "w"})
+        self.assertIn("design_columns cannot set 'weights'", str(cm.exception))
+
+    def test_design_columns_rejects_unknown_keys(self) -> None:
+        """T13 — unknown SurveyDesign fields raise ``ValueError``."""
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+        with self.assertRaises(ValueError) as cm:
+            bd.to_survey_design(s, design_columns={"not_a_real_field": "anything"})
+        self.assertIn("unknown SurveyDesign fields", str(cm.exception))
+
+
+@unittest.skipUnless(_DIFF_DIFF_AVAILABLE, "diff-diff is not installed")
+class ToPanelForDidTest(unittest.TestCase):
+    """§11.B — ``to_panel_for_did`` wraps ``aggregate_survey``."""
+
+    def test_returns_two_tuple(self) -> None:
+        """T11 — returns ``(panel_df, second_stage_design)``."""
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+        # NOTE: only ``ImportError`` skips. Earlier revisions also swallowed
+        # ``KeyError``, but a ``KeyError`` from ``aggregate_survey`` is a
+        # genuine adapter contract regression (e.g. the adapter renamed
+        # a column the upstream call still expects), not an "untestable
+        # environment" signal — the adapter is the runtime contract with
+        # diff-diff; we want CI to surface those, not skip them. We only
+        # skip on ``ImportError`` to handle the rare build variant where
+        # an optional cython sub-dependency of diff-diff is missing.
+        # ``AssertionError``, ``AttributeError``, ``TypeError``, ``KeyError``
+        # all fail the test.
+        try:
+            panel_df, second_stage = bd.to_panel_for_did(
+                s, by=["unit", "t"], outcomes="y"
+            )
+        except ImportError as e:
+            self.skipTest(f"aggregate_survey unavailable in this build: {e}")
+        self.assertIsInstance(panel_df, pd.DataFrame)
+        # Second-stage weight column auto-named ``"{first_outcome}_weight"``.
+        self.assertIn(second_stage.weights, panel_df.columns)
+
+    def test_default_second_stage_weight_type_is_pweight(self) -> None:
+        """T11 — ``second_stage_weights`` defaults to ``"pweight"``."""
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+        # See note above re: narrow exception list (ImportError only).
+        try:
+            _, second_stage = bd.to_panel_for_did(s, by=["unit", "t"], outcomes="y")
+        except ImportError as e:
+            self.skipTest(f"aggregate_survey unavailable in this build: {e}")
+        self.assertEqual("pweight", second_stage.weight_type)
+
+    def test_panel_weights_match_direct_aggregate_survey(self) -> None:
+        """T-NEW (numerical roundtrip) — panel weights produced by the adapter
+        match those produced by a direct ``aggregate_survey`` call on the
+        same toy sample. The adapter is a thin wrapper; this test guards
+        against refactors that would silently change weight aggregation
+        semantics (e.g. swapping which column becomes the active weight,
+        forgetting to forward ``second_stage_weights``)."""
+        import diff_diff as dd
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+        try:
+            adapter_panel, adapter_design = bd.to_panel_for_did(
+                s, by=["unit", "t"], outcomes="y"
+            )
+            # Direct route: replicate what to_panel_for_did does internally
+            # (build first-stage SurveyDesign from s.weight_column, forward
+            # the same second_stage_weights value, no history columns to
+            # drop on this fixture).
+            direct_design: Any = dd.SurveyDesign(
+                weights="w", weight_type="pweight", lonely_psu="adjust"
+            )
+            direct_panel: pd.DataFrame
+            direct_panel, _ = dd.aggregate_survey(
+                s.df,
+                by=["unit", "t"],
+                outcomes="y",
+                survey_design=direct_design,
+                second_stage_weights="pweight",
+            )
+        except ImportError as e:
+            self.skipTest(f"aggregate_survey unavailable in this build: {e}")
+
+        # Both routes must produce the same row count and the same
+        # auto-generated weight column name (``{first_outcome}_weight``).
+        self.assertEqual(len(adapter_panel), len(direct_panel))
+        weight_col: str = adapter_design.weights
+        self.assertIn(weight_col, direct_panel.columns)
+
+        # Element-wise numerical agreement on the second-stage weight column,
+        # after sorting by the join keys to remove ordering noise.
+        adapter_sorted: pd.DataFrame = adapter_panel.sort_values(
+            ["unit", "t"]
+        ).reset_index(drop=True)
+        direct_sorted: pd.DataFrame = direct_panel.sort_values(
+            ["unit", "t"]
+        ).reset_index(drop=True)
+        np.testing.assert_allclose(
+            adapter_sorted[weight_col].to_numpy(),
+            direct_sorted[weight_col].to_numpy(),
+            rtol=1e-12,
+            atol=0.0,
+        )
+
+
+class ValidateNonzeroWeightsTest(unittest.TestCase):
+    """§11.A — ``validate_nonzero_weights`` rejects unusable weight vectors."""
+
+    def test_passes_with_some_positive(self) -> None:
+        """T-NEW — vector with at least one positive weight passes silently."""
+        from balance.interop._common import validate_nonzero_weights
+
+        df: pd.DataFrame = pd.DataFrame({"w": [0.0, 0.0, 0.5, 1.5]})
+        # No exception, no return value -- mirrors validate_row_count contract.
+        self.assertIsNone(validate_nonzero_weights(df, "w", ctx="my_adapter"))
+
+    def test_raises_on_all_zero(self) -> None:
+        """T-NEW — all-zero weights raise with an actionable message."""
+        from balance.interop._common import validate_nonzero_weights
+
+        df: pd.DataFrame = pd.DataFrame({"w": [0.0, 0.0, 0.0]})
+        with self.assertRaises(ValueError) as cm:
+            validate_nonzero_weights(df, "w", ctx="my_adapter")
+        self.assertIn("my_adapter", str(cm.exception))
+        self.assertIn("no positive entries", str(cm.exception))
+
+    def test_raises_on_all_negative(self) -> None:
+        """T-NEW — all-negative weights also raise (sum of squares is positive
+        but the SurveyDesign still produces a meaningless fit)."""
+        from balance.interop._common import validate_nonzero_weights
+
+        df: pd.DataFrame = pd.DataFrame({"w": [-1.0, -2.0, -0.5]})
+        with self.assertRaises(ValueError):
+            validate_nonzero_weights(df, "w", ctx="my_adapter")
+
+    def test_raises_on_mixed_sign_weights(self) -> None:
+        """T-NEW (Copilot) — mixed-sign weights (e.g. ``[-1, 2]``) must also
+        raise. The earlier guard checked only ``not (weights > 0).any()``,
+        which was satisfied by the positive entry and let mixed-sign
+        vectors through silently. Design weights are non-negative by
+        contract (a negative entry usually points at the wrong column —
+        a residual / centred / mean-deviation vector — not a design
+        weight), so we now reject as soon as we see any negative entry
+        before checking the positive-entry condition."""
+        from balance.interop._common import validate_nonzero_weights
+
+        df: pd.DataFrame = pd.DataFrame({"w": [-1.0, 2.0]})
+        with self.assertRaises(ValueError) as cm:
+            validate_nonzero_weights(df, "w", ctx="my_adapter")
+        self.assertIn("negative", str(cm.exception))
+
+    def test_raises_on_missing_column(self) -> None:
+        """T-NEW — missing weight column fails fast with the same wording as
+        ``drop_nan_weight_rows``."""
+        from balance.interop._common import validate_nonzero_weights
+
+        df: pd.DataFrame = pd.DataFrame({"x": [1.0, 2.0]})
+        with self.assertRaises(ValueError) as cm:
+            validate_nonzero_weights(df, "w", ctx="my_adapter")
+        self.assertIn("not present in df.columns", str(cm.exception))
+
+
+@unittest.skipUnless(_DIFF_DIFF_AVAILABLE, "diff-diff is not installed")
+class FitDidTest(unittest.TestCase):
+    """§11.B — ``fit_did`` resolves estimator and attaches provenance."""
+
+    def test_attaches_balance_adjustment(self) -> None:
+        """T15 — result carries ``_balance_adjustment`` for provenance.
+
+        The attachment is the headline guarantee of ``preserve_adjustment``
+        (the default for ``fit_did``), so this test enforces that exactly
+        one of two things happens:
+
+        1. ``_balance_adjustment`` is set on the result and points at the
+           original ``Sample`` (the happy path for any result type that
+           accepts ``setattr`` or has a writable ``__dict__``), OR
+        2. ``attach_balance_provenance`` emits a ``UserWarning`` because
+           the result type rejected both attachment paths (frozen
+           dataclass / msgspec struct / read-only ``mappingproxy``).
+
+        The previous formulation accepted ``None`` silently, which made the
+        regression signal disappear when balance lineage stopped attaching
+        on a real diff-diff result type.
+        """
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+        # See narrow-exception note in ToPanelForDidTest above. Real
+        # AssertionError / TypeError / AttributeError from the estimator
+        # should fail the test rather than silently skipping it -- the
+        # whole point of this test is to catch regressions in the adapter
+        # surface against diff-diff's runtime contract.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            try:
+                # Use the staggered ``CallawaySantAnna`` estimator rather
+                # than ``DifferenceInDifferences``: the simpler 2x2 DiD
+                # estimator validates BOTH ``time`` and ``treatment`` as
+                # binary 0/1 vectors (see
+                # ``diff_diff.utils.validate_binary``), which is
+                # incompatible with this multi-period staggered fixture.
+                # Callaway-Sant'Anna is the natural fit for the ``first_treat``
+                # cohort encoding the fixture already provides, and it
+                # exercises the same provenance-attachment code path.
+                res: object = bd.fit_did(
+                    s,
+                    estimator="CallawaySantAnna",
+                    outcome="y",
+                    time="t",
+                    unit="unit",
+                    treatment_first="first_treat",
+                )
+            except ImportError as e:
+                # See ToPanelForDidTest comment — only ImportError is treated
+                # as untestable-environment. KeyError / AssertionError / etc.
+                # propagate so CI catches real adapter-contract regressions.
+                self.skipTest(f"DiD fit unavailable in this build: {e}")
+        attached: bool = getattr(res, "_balance_adjustment", None) is s
+        provenance_warned: bool = any(
+            issubclass(w.category, UserWarning)
+            and "_balance_adjustment" in str(w.message)
+            for w in caught
+        )
+        self.assertTrue(
+            attached or provenance_warned,
+            msg=(
+                "fit_did(preserve_adjustment=True) must either attach "
+                "`_balance_adjustment` to the result or emit a UserWarning "
+                "explaining why it could not. Got neither -- provenance "
+                "is silently broken."
+            ),
+        )
+
+    def test_rejects_unknown_estimator(self) -> None:
+        """T19 — bad estimator name raises a clear ``ValueError``."""
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+        with self.assertRaises(ValueError) as cm:
+            bd.fit_did(
+                s,
+                estimator="NotARealEstimator",
+                outcome="y",
+                time="t",
+                unit="unit",
+                treatment_first="first_treat",
+            )
+        self.assertIn("NotARealEstimator", str(cm.exception))
+
+    def test_rejects_reserved_positional_kwargs(self) -> None:
+        """T-NEW — kwargs that collide with positional / wired-in fit args
+        raise ``TypeError`` with an actionable message rather than the
+        cryptic ``TypeError: multiple values for argument 'data'`` that the
+        unguarded splat would produce.
+
+        Limited to names that genuinely flow through ``**estimator_kwargs``:
+        ``data`` / ``df`` (would collide with the positional ``df`` argument
+        passed to ``instance.fit(df, ...)``) and ``first_treat`` (the
+        diff-diff column-name kwarg; fit_did exposes the same column via
+        the ``treatment_first=`` adapter param). Names already in fit_did's
+        explicit signature (``outcome``, ``time``, ``unit``, ``treatment``,
+        ``covariates``) bind to those params during the user's call and
+        never reach ``**estimator_kwargs``; Python's own
+        "multiple values for argument" ``TypeError`` covers same-name
+        duplicates before fit_did's body runs, so an adapter-level guard
+        for those names would be dead code -- and a test for them would
+        either pass for the wrong reason (no collision at all) or trigger
+        Python's TypeError instead of the adapter's, defeating the purpose
+        of the assertion.
+        """
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+        for reserved_kwarg in ("data", "df", "first_treat"):
+            with self.subTest(reserved_kwarg=reserved_kwarg):
+                with self.assertRaises(TypeError) as cm:
+                    bd.fit_did(
+                        s,
+                        estimator="CallawaySantAnna",
+                        outcome="y",
+                        time="t",
+                        unit="unit",
+                        treatment_first="first_treat",
+                        **{reserved_kwarg: "anything"},  # type: ignore[arg-type]
+                    )
+                self.assertIn(reserved_kwarg, str(cm.exception))
+                self.assertIn("**estimator_kwargs", str(cm.exception))
+
+    def test_rejects_all_zero_weights(self) -> None:
+        """T-NEW — a Sample whose active weight column is all-zero raises
+        ``ValueError`` at the seam rather than producing an inf / NaN fit."""
+        from balance.interop import diff_diff as bd
+
+        df: pd.DataFrame = _toy_balanced_panel()
+        df["w"] = 0.0  # zero out every weight
+        s = balance.Sample.from_frame(
+            df, id_column="id", weight_column="w", outcome_columns=["y"]
+        )
+        with self.assertRaises(ValueError) as cm:
+            bd.fit_did(
+                s,
+                estimator="CallawaySantAnna",
+                outcome="y",
+                time="t",
+                unit="unit",
+                treatment_first="first_treat",
+            )
+        self.assertIn("no positive entries", str(cm.exception))
+
+
+@unittest.skipUnless(_DIFF_DIFF_AVAILABLE, "diff-diff is not installed")
+class AsBalanceDiagnosticTest(unittest.TestCase):
+    """§11.B — ``as_balance_diagnostic`` returns a flat dict."""
+
+    def test_returns_flat_dict_with_required_keys(self) -> None:
+        """T15 (cont.) — required keys present, missing values are ``None``."""
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+
+        class _StubResult:
+            att: float = 0.5
+            se: float = 0.1
+            conf_int: tuple[float, float] = (0.3, 0.7)
+            n_obs: int = 24
+            survey_metadata: object | None = None
+
+        diag: dict[str, object] = bd.as_balance_diagnostic(s, _StubResult())
+        for key in (
+            "att",
+            "se",
+            "conf_int",
+            "n_obs",
+            "balance_kish_ess",
+            "balance_design_effect",
+            "diff_diff_design_effect",
+            "diff_diff_effective_n",
+            "diff_diff_sum_weights",
+            "balance_asmd_max_post",
+            "balance_asmd_mean_post",
+        ):
+            self.assertIn(key, diag)
+        self.assertEqual(0.5, diag["att"])
+        self.assertIsNone(diag["diff_diff_design_effect"])
+
+    def test_propagates_diff_diff_metadata(self) -> None:
+        """``diff_diff_design_effect`` etc. propagate from
+        ``did_results.survey_metadata`` when present."""
+        from balance.interop import diff_diff as bd
+
+        s = _make_sample()
+
+        class _Meta:
+            design_effect: float = 1.7
+            effective_n: float = 200.0
+            sum_weights: float = 250.0
+
+        class _StubResult:
+            att: float = 0.0
+            survey_metadata: _Meta = _Meta()
+
+        diag: dict[str, object] = bd.as_balance_diagnostic(s, _StubResult())
+        self.assertEqual(1.7, diag["diff_diff_design_effect"])
+        self.assertEqual(200.0, diag["diff_diff_effective_n"])
+        self.assertEqual(250.0, diag["diff_diff_sum_weights"])
+
+
+# ---------------------------------------------------------------------------
+# Import guard (always runs)
+# ---------------------------------------------------------------------------
+
+
+class ImportGuardTest(unittest.TestCase):
+    """The ONLY test class that runs in both modes (with and without
+    diff-diff). When diff-diff is available, the module imports cleanly;
+    when missing, calling into it raises a helpful ImportError pointing
+    users at the ``balance[did]`` extra."""
+
+    def test_module_importable(self) -> None:
+        """Importing the submodule must always succeed (lazy guard).
+
+        Even without diff-diff installed, the module must import cleanly
+        and expose its public symbols — only calls into the adapter
+        functions raise. We assert on the public symbols rather than just
+        on the module to validate the import did something meaningful.
+        """
+        from balance.interop import diff_diff as bd
+
+        self.assertIsNotNone(bd)
+        for name in (
+            "to_survey_design",
+            "to_panel_for_did",
+            "fit_did",
+            "as_balance_diagnostic",
+        ):
+            self.assertTrue(
+                hasattr(bd, name),
+                f"balance.interop.diff_diff is missing public symbol {name!r}",
+            )
+
+    @unittest.skipIf(
+        _DIFF_DIFF_AVAILABLE,
+        "this assertion only fires when diff-diff is missing",
+    )
+    def test_calling_without_diff_diff_raises(self) -> None:
+        """Calling adapter functions without diff-diff installed raises
+        a helpful ``ImportError`` citing ``pip install balance[did]``."""
+        from balance.interop import diff_diff as bd
+
+        df: pd.DataFrame = pd.DataFrame(
+            {"id": [0, 1, 2], "x": [1.0, 2.0, 3.0], "w": [1.0, 1.0, 1.0]}
+        )
+        s = balance.Sample.from_frame(df, id_column="id", weight_column="w")
+        with self.assertRaises(ImportError) as cm:
+            bd.to_survey_design(s)
+        self.assertIn("balance[did]", str(cm.exception))


### PR DESCRIPTION
Summary:
Adds a thin adapter module that lets balance users hand reweighted samples to the diff-diff DiD library without losing balance's adjustment lineage. The module exposes `to_survey_design()`, `to_panel_for_did()`, `fit_did()`, and `as_balance_diagnostic()` (one-stop convenience helpers) and attaches the BalanceFrame to diff-diff result objects via a `_balance_adjustment` side-channel for provenance.

Helpers (`active_weight_column`, `drop_history_columns`, `validate_row_count`, `attach_balance_provenance`, `validate_nonzero_weights`) factor into a new `balance/interop/_common.py` so the future `balance.interop.svy` adapter shares them; column-name conventions go in `balance/interop/conventions.py`. The shared scaffolding is documented in P2300011954 (https://www.internalfb.com/intern/paste/P2300011954/).

The `did` extra (`pip install balance[did]`) opts users into the diff-diff dependency. Bare `import balance` continues to work without diff-diff installed. So does `from balance.interop import diff_diff` — the lazy `diff_diff` import is gated behind a `_require_diff_diff()` helper, so the rewritten `ImportError` only surfaces when one of the public adapter functions (`to_survey_design`, `to_panel_for_did`, `fit_did`, `as_balance_diagnostic`) is actually called and points users at \`pip install balance[did]\`. \`balance/__init__.py\` is intentionally NOT modified — eager import would force diff-diff load on every \`import balance\`.

Reviewers, see P2300009837 (https://www.internalfb.com/intern/paste/P2300009837/) for the full design rationale.

**Revision N — safety fixes following review:**
- \`_require_diff_diff()\` uses \`_assert_type(_dd, ModuleType)\` instead of a bare \`assert _dd is not None\`. Bare asserts are stripped under \`python -O\`, which would have left \`_dd\` as \`None\` in optimised builds and surfaced an \`AttributeError\` instead of the rewritten \`ImportError\`.
- \`fit_did()\` now rejects reserved positional / wired-in kwargs (\`data\`, \`df\`, \`outcome\`, \`time\`, \`unit\`, \`first_treat\`, \`treatment\`, \`covariates\`) routed through \`**estimator_kwargs\` with a clear adapter-level \`TypeError\`. Without the guard, \`data=other_df\` would land in \`fit_kwargs\` and \`instance.fit(df, **common_fit_kwargs)\` would raise the cryptic \`TypeError: multiple values for argument 'data'\`.
- New \`validate_nonzero_weights()\` helper rejects all-zero / all-negative weight columns at the seam, called from both \`to_panel_for_did\` and \`fit_did\` after the NaN-row scrub. Avoids \`inf\` / \`NaN\` propagating through SurveyDesign variance machinery.
- New numerical-roundtrip test (\`test_panel_weights_match_direct_aggregate_survey\`) asserts adapter panel weights match a direct \`aggregate_survey\` call to \`rtol=1e-12\`. Plus 5 new safety tests covering the helpers above.

References (Phabricator pastes for reviewers):
- D1 design proposal: P2300009837
- SVY future-proofing patterns: P2300011954
- Full integration plan (PLAN.md): P2300014883
- Executive summary: P2300013267

Differential Revision: D103436264