### PR TITLE
ci: declare workflow-scope permissions on five workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,6 +11,9 @@ on:
   # allow this to be scheduled manually in addition to cron
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     # Default matrix: bare-import balance on every OS / python combination —

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     name: Deploy to GitHub Pages

--- a/.github/workflows/notebook-ci.yml
+++ b/.github/workflows/notebook-ci.yml
@@ -39,6 +39,9 @@ on:
       - '.github/workflows/notebook-ci.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   execute-tutorial:
     name: Execute balance_diff_diff_brfss tutorial

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Five workflows currently don't declare a `permissions:` block, so the workflow `GITHUB_TOKEN` falls back to the repository default. This patch pins each to its minimum:

- `.github/workflows/build-and-test.yml` -- `contents: read`. Matrix tests across Ubuntu/macOS/Windows and Python 3.9-3.14. No GitHub API write.
- `.github/workflows/coverage.yml` -- `contents: read`. `pytest --cov` plus `actions/upload-artifact@v4` for the coverage reports. Artifact upload in v4 doesn't require explicit permissions.
- `.github/workflows/deploy-website.yml` -- `contents: write`. The deploy step is `peaceiris/actions-gh-pages@v4` pushing the Docusaurus build to `gh-pages` via `${{ secrets.GITHUB_TOKEN }}`.
- `.github/workflows/notebook-ci.yml` -- `contents: read`. Executes `tutorials/balance_diff_diff_brfss.ipynb` via Papermill. No GitHub API write.
- `.github/workflows/release.yml` -- `contents: read`. Runs the test matrix and `pypa/gh-action-pypi-publish` against PyPI using `PYPI_API_TOKEN`. The workflow `GITHUB_TOKEN` is unused for the publish.

The pattern matches `codeql.yml` (per-job `actions: read, contents: read, security-events: write`), `diff-diff-canary.yml` (workflow-level `contents: read, issues: write` plus a per-job override), and `cleanup-copilot-artifacts.yml` (workflow-level `actions: write`).

Third-party action exposure that motivates pinning: `peaceiris/actions-gh-pages`, `pypa/gh-action-pypi-publish`, `actions/setup-python`, `actions/setup-node`. Explicit per-workflow scopes narrow the blast radius if any is compromised (cf. `tj-actions/changed-files` CVE-2025-30066).

No behavioural change to any of the five.