### PR TITLE
Add poststratify transfer scoring (#479)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,19 @@
     transformations at fit time (e.g. wrappers built around stored
     fit-time bin edges) or re-fit rake on the scoring data.
 
+- **Poststratify now supports transfer scoring with `predict_weights(data=...)`.**
+  `BalanceFrame.fit(method="poststratify", store_fit_metadata=True)` stores the
+  transformation origin needed to safely replay fitted cell ratios on a new
+  sample/target pair. `predict_weights(data=holdout_bf)` now applies those
+  stored ratios to the holdout sample's design weights and rescales to the
+  holdout target's total weight. As with rake transfer scoring, models fitted
+  with `transformations="default"` or direct data-dependent helpers such as
+  `quantize` / `fct_lump` are rejected for transfer; pass deterministic
+  transformations explicitly or re-fit poststratify on the scoring data.
+  Models pickled before this release lack the new `transformations_origin`
+  metadata and must be re-fit to use transfer scoring; in-place
+  `predict_weights()` continues to work on older pickles.
+
 ## Documentation
 
 - **README cross-link to diff-diff.** New "Design-based inference" parent section in [README.md](https://github.com/facebookresearch/balance/blob/main/README.md) introduces the diff-diff integration above the API tour, with a fenced code snippet (canonical `Sample.from_frame` → `set_target` → `adjust` → `fit_did` workflow) and links to the upstream project. The Docusaurus tutorials index and the website landing page (`HomepageFeatures.js`) gain matching cross-references; `.github/copilot-instructions.md` gets a new review-checklist bullet for changes that touch `balance/interop/diff_diff.py`.

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -32,7 +32,6 @@ from balance.typing import FilePathOrBuffer
 from balance.util import (
     _assert_type,
     _detect_high_cardinality_features,
-    _safe_fillna_and_infer,
     HighCardinalityFeature,
 )
 from balance.utils.file_utils import _to_download
@@ -1956,9 +1955,13 @@ class BalanceFrame:
           trimming, and design weights) to reproduce fitted responder weights.
         - **CBPS**: rebuilds the CBPS scoring artifacts from stored metadata
           and supports both in-place and ``data=...`` holdout scoring.
-        - **Poststratify**: reconstructs in-place responder weights from
-          stored cell-ratio metadata; ``data=...`` holdout scoring is not yet
-          supported for poststratify.
+        - **Poststratify**: replays fitted cell-ratio metadata in-place and
+          supports ``data=...`` transfer scoring. Models fitted with
+          ``transformations='default'`` or direct data-dependent helpers
+          such as :func:`balance.utils.data_transformation.quantize` /
+          :func:`balance.utils.data_transformation.fct_lump` are rejected
+          for transfer; pass deterministic transformations explicitly or
+          re-fit poststratify on the scoring data.
         - **Rake**: replays fitted cell-ratio artifacts in-place and supports
           ``data=...`` transfer scoring. See :func:`balance.weighting_methods.rake.rake`
           Notes for validity constraints and interpretation.
@@ -1967,9 +1970,8 @@ class BalanceFrame:
         Args:
             data: An optional BalanceFrame whose sample covariates are scored
                 using this object's stored model.  Must have matching covariate
-                column names and a target set. Supported for IPW, CBPS, and
-                rake. Poststratify is supported only for in-place scoring
-                (``data=None``).
+                column names and a target set. Supported for IPW, CBPS, rake,
+                and poststratify.
 
         Returns:
             A Series of predicted responder weights.
@@ -2010,31 +2012,13 @@ class BalanceFrame:
                 return self._predict_weights_cbps(model, source=data)
             if method == "rake":
                 return self._predict_weights_rake(model, source=data)
-            # TODO: add predict_weights(data=...) support for 'poststratify'.
-            # Sketch of approach (mirrors the rake transfer path):
-            #   1. In poststratify(), when store_fit_metadata=True, persist the
-            #      same artifacts already stored for in-place replay
-            #      (variables, variables_before_transformations, categories,
-            #      m_fit, m_sample, na_action, transformations, transformations_origin,
-            #      training_target_weights, weight_trimming_*).
-            #   2. Add a `_predict_weights_poststratify(model, source=data)`
-            #      branch that, like _predict_weights_rake, applies the stored
-            #      transformations to data._sf_sample, maps each row to its
-            #      stored joint cell index, multiplies the row's design weight
-            #      by the cell ratio (m_fit / m_sample), validates joint
-            #      support, then renormalizes to data target weight sum.
-            #   3. Reject `transformations_origin == "default"` for transfer
-            #      scoring (data-dependent transforms aren't replayable),
-            #      mirroring the rake guard.
-            #   4. Unlike rake, poststratify cell ratios are exact responder
-            #      weights (no IPF), so transfer is a single multiply — no
-            #      iteration. The transfer-validity caveat still applies; see
-            #      the rake path's unconditional transfer warning for the
-            #      pattern to follow.
+            if method == "poststratify":
+                return self._predict_weights_poststratify(model, source=data)
             if method != "ipw":
                 raise ValueError(
                     f"predict_weights(data=...) is not yet supported for method '{method}'. "
-                    "Currently only 'ipw', 'cbps', and 'rake' are supported."
+                    "Currently only 'ipw', 'cbps', 'poststratify', and 'rake' are supported. "
+                    "Use adjust() to obtain weights directly for other methods."
                 )
             from balance.weighting_methods.ipw import link_transform, weights_from_link
 
@@ -2539,175 +2523,55 @@ class BalanceFrame:
             getattr(bf._sf_sample.weight_series, "name", None)
         )
 
-    def _predict_weights_poststratify(self, model: dict[str, Any]) -> pd.Series:
-        """Poststratify-specific weight reconstruction from stored fit artifacts."""
-        required = (
-            "variables",
-            "variables_before_transformations",
-            "na_action",
-            "strict_matching",
-            "transformations",
-            "transformations_drop",
-            "weight_trimming_mean_ratio",
-            "weight_trimming_percentile",
-            "keep_sum_of_weights",
-            "cell_weight_ratio",
+    def _predict_weights_poststratify(
+        self,
+        model: dict[str, Any],
+        source: BalanceFrame | None = None,
+    ) -> pd.Series:
+        """Thin wrapper around :func:`weighting_methods.poststratify._predict_weights_from_model`.
+
+        Resolves ``self`` vs ``source`` (the BalanceFrame whose covariates
+        are scored), validates that the resolved frame has a target set,
+        extracts plain DataFrames/Series from it, delegates the actual
+        cell-ratio replay to ``_predict_weights_from_model``, then renames
+        the result to the active weight column and aligns it to the
+        scoring sample's full index.
+
+        Validation order: the target-not-set check runs *before*
+        ``_predict_weights_from_model`` checks for missing model metadata.
+        Both errors are caller-fixable; we raise the target one first
+        because a missing target is more typical when callers compose
+        ``predict_weights(data=new_bf)`` against a freshly built
+        ``new_bf`` and forget to ``set_target``.
+        """
+        from balance.weighting_methods.poststratify import _predict_weights_from_model
+
+        bf = source if source is not None else self
+        if source is not None and bf._sf_target is None:
+            raise ValueError(
+                "data must have a target set for poststratify "
+                "predict_weights(data=...)."
+            )
+
+        target_frame = _assert_type(bf._sf_target)
+        predicted = _predict_weights_from_model(
+            model=model,
+            sample_df=bf._sf_sample.df_covars,
+            sample_weights_full=bf._sf_sample.df_weights.iloc[:, 0],
+            target_df=target_frame.df_covars,
+            target_weights=target_frame.df_weights.iloc[:, 0],
+            is_transfer=source is not None,
         )
-        missing = [key for key in required if key not in model]
-        if missing:
-            raise ValueError(
-                "Poststratify model is missing fit-time metadata "
-                f"({missing}) for predict_weights(). "
-                "Call BalanceFrame.fit(method='poststratify') or run "
-                "poststratify(..., store_fit_metadata=True)."
-            )
 
-        variables = model.get("variables")
-        input_variables = model.get("variables_before_transformations")
-        if not isinstance(variables, list) or not all(
-            isinstance(v, str) for v in variables
-        ):
-            raise ValueError(
-                "Poststratify model has invalid 'variables' metadata for "
-                "predict_weights()."
-            )
-        if not isinstance(input_variables, list) or not all(
-            isinstance(v, str) for v in input_variables
-        ):
-            raise ValueError(
-                "Poststratify model has invalid "
-                "'variables_before_transformations' metadata for predict_weights()."
-            )
-
-        ratio_series = model.get("cell_weight_ratio")
-        if not isinstance(ratio_series, pd.Series):
-            raise ValueError(
-                "Poststratify model is missing cell-weight ratio metadata for "
-                "predict_weights()."
-            )
-
-        current_sample_weights = self._sf_sample.df_weights.iloc[:, 0]
-        current_target_weights = _assert_type(self._sf_target).df_weights.iloc[:, 0]
-
-        sample_weights = model.get("training_sample_weights")
-        if (
-            not isinstance(sample_weights, pd.Series)
-            or len(sample_weights) != len(current_sample_weights)
-            or not sample_weights.index.equals(current_sample_weights.index)
-        ):
-            raise ValueError(
-                "Poststratify predict_weights() requires compatible "
-                "fit-time sample design weights in model['training_sample_weights']. "
-                "Re-fit with BalanceFrame.fit(method='poststratify') and "
-                "store_fit_metadata=True."
-            )
-
-        target_weights = model.get("training_target_weights")
-        if (
-            not isinstance(target_weights, pd.Series)
-            or len(target_weights) != len(current_target_weights)
-            or not target_weights.index.equals(current_target_weights.index)
-        ):
-            raise ValueError(
-                "Poststratify predict_weights() requires compatible "
-                "fit-time target design weights in model['training_target_weights']. "
-                "Re-fit with BalanceFrame.fit(method='poststratify') and "
-                "store_fit_metadata=True."
-            )
-
-        sample_covars = self._sf_sample.df_covars
-        target_covars = _assert_type(self._sf_target).df_covars
-        for column in input_variables:
-            if (
-                column not in sample_covars.columns
-                or column not in target_covars.columns
-            ):
-                raise ValueError(
-                    "Poststratify predict_weights() cannot find required covariate "
-                    f"'{column}' in both sample and target."
-                )
-        sample_df = sample_covars.loc[:, input_variables]
-        target_df = target_covars.loc[:, input_variables]
-
-        na_action = cast(str, model.get("na_action", "add_indicator"))
-        if na_action == "drop":
-            sample_df, sample_weights = balance_util.drop_na_rows(
-                sample_df, sample_weights, "sample"
-            )
-            target_df, target_weights = balance_util.drop_na_rows(
-                target_df, target_weights, "target"
-            )
-        elif na_action == "add_indicator":
-            sample_df = pd.DataFrame(_safe_fillna_and_infer(sample_df, "__NaN__"))
-            target_df = pd.DataFrame(_safe_fillna_and_infer(target_df, "__NaN__"))
-        else:
-            raise ValueError(
-                "Poststratify model has invalid na_action metadata "
-                f"'{na_action}' for predict_weights()."
-            )
-
-        sample_df, _target_df = balance_adjustment.apply_transformations(
-            (sample_df, target_df),
-            transformations=model["transformations"],
-            drop=bool(model["transformations_drop"]),
-        )
-        for column in variables:
-            if column not in sample_df.columns:
-                raise ValueError(
-                    "Poststratify transform output is missing stored variable "
-                    f"'{column}' required for predict_weights()."
-                )
-        sample_df = sample_df.loc[:, variables]
-
-        ratio_name = "_cell_ratio"
-        while ratio_name in sample_df.columns:
-            ratio_name = f"{ratio_name}_tmp"
-        sample_with_ratio = sample_df.join(
-            ratio_series.rename(ratio_name), on=variables
-        )
-        missing_ratio = sample_with_ratio[ratio_name].isna()
-        if bool(missing_ratio.any()):
-            if bool(model.get("strict_matching", True)):
-                raise ValueError(
-                    "Poststratify predict_weights() found sample cells missing from "
-                    "stored fit-time cell ratios. Re-fit with compatible cells or "
-                    "fit with strict_matching=False."
-                )
-            logger.warning(
-                "Poststratify predict_weights() encountered sample cells missing from "
-                "stored fit-time cell ratios; assigning zero weights to those rows."
-            )
-            sample_with_ratio[ratio_name] = _safe_fillna_and_infer(
-                sample_with_ratio[ratio_name], 0
-            )
-
-        raw_weights = sample_with_ratio[ratio_name] * sample_weights
-        target_total = raw_weights.sum()
-        trimmed = balance_adjustment.trim_weights(
-            raw_weights,
-            target_sum_weights=target_total,
-            weight_trimming_mean_ratio=model["weight_trimming_mean_ratio"],
-            weight_trimming_percentile=model["weight_trimming_percentile"],
-            keep_sum_of_weights=bool(model["keep_sum_of_weights"]),
-        )
-        if na_action == "drop":
-            # Align back to the full fit-time sample index so rows dropped for
-            # missing covariates retain NaN weights, matching adjust() behavior.
-            full_index = current_sample_weights.index
-            trimmed_full = pd.Series(np.nan, index=full_index, dtype=float).rename(
-                trimmed.name
-            )
-            trimmed_full.loc[trimmed.index] = trimmed.to_numpy()
-            trimmed = trimmed_full
-        weight_name = getattr(_assert_type(self.weight_series), "name", None)
+        weight_name = getattr(_assert_type(bf.weight_series), "name", None)
         return cast(
             pd.Series,
             self._align_to_index(
-                trimmed,
-                self._sf_sample.df.index,
+                predicted.rename(weight_name),
+                bf._sf_sample.df.index,
                 caller="predict_weights()",
                 method_name="poststratify",
-            ).rename(weight_name),
+            ),
         )
 
     @property

--- a/balance/weighting_methods/poststratify.py
+++ b/balance/weighting_methods/poststratify.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import logging
 import pickle
 import re
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, cast, Dict, List, Optional, Union
 
+import numpy as np
 import pandas as pd
 from balance import adjustment as balance_adjustment, util as balance_util
 from balance.util import _safe_fillna_and_infer
@@ -309,6 +310,7 @@ def poststratify(
                 "na_action": na_action,
                 "strict_matching": strict_matching,
                 "transformations": transformations_to_apply,
+                "transformations_origin": transformations,
                 "transformations_drop": transformations_drop,
                 "weight_trimming_mean_ratio": weight_trimming_mean_ratio,
                 "weight_trimming_percentile": weight_trimming_percentile,
@@ -326,6 +328,316 @@ def poststratify(
         "weight": w,
         "model": model,
     }
+
+
+# Private to ``balance``: callers should reach this through
+# ``BalanceFrame.predict_weights()`` rather than importing it directly.
+def _predict_weights_from_model(
+    model: Dict[str, Any],
+    sample_df: pd.DataFrame,
+    sample_weights_full: pd.Series,
+    target_df: pd.DataFrame,
+    target_weights: pd.Series,
+    is_transfer: bool,
+) -> pd.Series:
+    """Reconstruct poststratification weights from a stored fit-time model dict.
+
+    Internal helper. The pure-math/model-driven core of
+    ``BalanceFrame.predict_weights()`` for poststratify — callers should
+    reach this through that public API rather than importing the helper
+    directly. It takes plain DataFrames and Series for the scoring sample
+    and target, plus the ``model`` dict persisted by :func:`poststratify`
+    when ``store_fit_metadata=True``, and replays the stored cell-weight
+    ratio surface on the scoring sample.
+
+    Two modes:
+    - ``is_transfer=False`` (in-place replay): the scoring frames must be
+      the same rows that were fit; ``training_sample_weights`` and
+      ``training_target_weights`` from ``model`` are used as the canonical
+      fit-time weights, and the normalization target is the raw weight
+      sum (replay is exact, no rescaling).
+    - ``is_transfer=True`` (``data=...`` transfer): the scoring frames are
+      a different sample/target. The stored cell ratios are applied to
+      the scoring sample's design weights, then rescaled to the scoring
+      target's total weight. A warning is emitted unconditionally
+      because the stored cell ratios encode the *training* target's
+      joint cell distribution; the scoring target's cell distribution
+      is NOT re-fit.
+
+    Args:
+        model: Fitted poststratify model dict produced with
+            ``store_fit_metadata=True``.
+        sample_df: Scoring sample's covariate frame (full index,
+            pre-transform). Must contain every column listed in
+            ``model['variables_before_transformations']``.
+        sample_weights_full: Scoring sample's design weights aligned to
+            ``sample_df``'s full index.
+        target_df: Scoring target's covariate frame (pre-transform).
+            Must contain every column listed in
+            ``model['variables_before_transformations']``.
+        target_weights: Scoring target's design weights aligned to
+            ``target_df``'s full index.
+        is_transfer: ``True`` when called from
+            ``BalanceFrame.predict_weights(data=...)``; ``False`` for
+            in-place replay (``data=None``).
+
+    Returns:
+        Predicted weights as a ``pd.Series`` with
+        ``sample_weights_full``'s index. For ``na_action='drop'``
+        poststratify models, rows dropped during scoring are returned as
+        ``NaN``.
+
+    Raises:
+        ValueError: If model metadata is missing/malformed, if the
+            scoring frames are missing required covariates, if scoring
+            rows fall in fit-time cells with zero mass (depending on
+            ``strict_matching``), if in-place replay is requested
+            without compatible fit-time design weights, or if transfer
+            is requested with data-dependent fitted transformations.
+    """
+    required = (
+        "variables",
+        "variables_before_transformations",
+        "na_action",
+        "strict_matching",
+        "transformations",
+        "transformations_drop",
+        "weight_trimming_mean_ratio",
+        "weight_trimming_percentile",
+        "keep_sum_of_weights",
+        "cell_weight_ratio",
+    )
+    missing = [key for key in required if key not in model]
+    if missing:
+        raise ValueError(
+            "Poststratify model is missing fit-time metadata "
+            f"({missing}) for predict_weights(). "
+            "Call BalanceFrame.fit(method='poststratify') or run "
+            "poststratify(..., store_fit_metadata=True)."
+        )
+
+    variables = model.get("variables")
+    input_variables = model.get("variables_before_transformations")
+    if not isinstance(variables, list) or not all(
+        isinstance(v, str) for v in variables
+    ):
+        raise ValueError(
+            "Poststratify model has invalid 'variables' metadata for "
+            "predict_weights()."
+        )
+    if not isinstance(input_variables, list) or not all(
+        isinstance(v, str) for v in input_variables
+    ):
+        raise ValueError(
+            "Poststratify model has invalid "
+            "'variables_before_transformations' metadata for predict_weights()."
+        )
+
+    ratio_series = model.get("cell_weight_ratio")
+    if not isinstance(ratio_series, pd.Series):
+        raise ValueError(
+            "Poststratify model is missing cell-weight ratio metadata for "
+            "predict_weights()."
+        )
+
+    sample_weights = sample_weights_full
+    if not is_transfer:
+        training_sample_weights = model.get("training_sample_weights")
+        if (
+            not isinstance(training_sample_weights, pd.Series)
+            or len(training_sample_weights) != len(sample_weights_full)
+            or not training_sample_weights.index.equals(sample_weights_full.index)
+        ):
+            raise ValueError(
+                "Poststratify predict_weights() requires compatible "
+                "fit-time sample design weights in model['training_sample_weights']. "
+                "Re-fit with BalanceFrame.fit(method='poststratify') and "
+                "store_fit_metadata=True."
+            )
+        sample_weights = training_sample_weights
+
+        training_target_weights = model.get("training_target_weights")
+        if (
+            not isinstance(training_target_weights, pd.Series)
+            or len(training_target_weights) != len(target_weights)
+            or not training_target_weights.index.equals(target_weights.index)
+        ):
+            raise ValueError(
+                "Poststratify predict_weights() requires compatible "
+                "fit-time target design weights in model['training_target_weights']. "
+                "Re-fit with BalanceFrame.fit(method='poststratify') and "
+                "store_fit_metadata=True."
+            )
+        target_weights = training_target_weights
+    else:
+        if "transformations_origin" not in model:
+            raise ValueError(
+                "Poststratify predict_weights(data=...) requires "
+                "transformations_origin metadata to determine whether fitted "
+                "transformations are safe to replay. Re-fit with "
+                "BalanceFrame.fit(method='poststratify')."
+            )
+        transformations_origin = model.get("transformations_origin")
+        if transformations_origin == "default":
+            raise ValueError(
+                "Poststratify predict_weights(data=...) is unsupported for "
+                "models fitted with transformations='default' because those "
+                "transformations are data-dependent and not replayable across "
+                "new samples. BalanceFrame.fit(method='poststratify') uses "
+                "transformations='default' out of the box; to enable transfer "
+                "scoring, pass deterministic transformations explicitly at fit "
+                "time (for example transformations={'age': partial("
+                "quantize_with_edges, edges=...)} where the wrapper closes "
+                "over fit-time bin edges) or re-fit poststratify on the "
+                "scoring data."
+            )
+        if isinstance(transformations_origin, dict):
+            # Best-effort guard: reject explicit dicts that directly
+            # reference balance's known data-dependent helpers
+            # (quantize, fct_lump). These recompute bins/levels from the
+            # scoring data, so stored cell ratios no longer line up with
+            # the transformed scoring cells and transfer would silently
+            # return incorrect weights.
+            #
+            # This guard does NOT catch indirect uses such as
+            # ``functools.partial(fct_lump, prop=0.1)``, top-level wrapper
+            # functions, or user-defined data-dependent transformations.
+            # The general invariant is: any callable whose output for a
+            # row depends on other rows in the input is unsafe to replay
+            # on a different sample. Users supplying such transformations
+            # are responsible for either (a) wrapping them as
+            # deterministic functions of stored fit-time parameters or
+            # (b) re-fitting poststratify on the scoring data.
+            from balance.utils.data_transformation import fct_lump, quantize
+
+            data_dependent_helpers = {quantize, fct_lump}
+            offenders = sorted(
+                {
+                    getattr(fn, "__name__", repr(fn))
+                    for fn in transformations_origin.values()
+                    if fn in data_dependent_helpers
+                }
+            )
+            if offenders:
+                raise ValueError(
+                    "Poststratify predict_weights(data=...) is unsupported "
+                    "for models fitted with data-dependent transformations "
+                    f"({', '.join(offenders)}). These recompute bins/levels "
+                    "from the scoring data, so stored cell ratios no longer "
+                    "line up with the transformed scoring cells. To enable "
+                    "transfer scoring, replace each data-dependent helper "
+                    "with a deterministic wrapper that closes over fit-time "
+                    "parameters (e.g. partial(quantize, edges=fit_time_edges)"
+                    " or partial(fct_lump, kept_levels=fit_time_levels)) — "
+                    "the wrappers must depend only on the stored fit-time "
+                    "state, not on the scoring data — or re-fit poststratify "
+                    "on the scoring data."
+                )
+        logger.warning(
+            "Poststratify predict_weights(data=...): replaying fitted "
+            "poststratification cell ratios on a different sample is a "
+            "transfer operation, not an exact fit. The stored cell ratios "
+            "encode the *training* target's joint cell distribution; "
+            "applying them to a new sample only produces weights "
+            "calibrated to that *training* target, rescaled to the new "
+            "target's total weight. The new target's cell distribution "
+            "is NOT re-fit. Predictions are therefore only valid when "
+            "(a) the scoring sample's joint distribution over the "
+            "poststratification variables is similar to the training "
+            "sample's, AND (b) the scoring target's cell distribution is "
+            "similar to the training target's. Re-fit poststratify on "
+            "the scoring sample/target for exact cell-distribution "
+            "matching."
+        )
+
+    for column in input_variables:
+        if column not in sample_df.columns or column not in target_df.columns:
+            raise ValueError(
+                "Poststratify predict_weights() cannot find required covariate "
+                f"'{column}' in both sample and target."
+            )
+    sample_df = sample_df.loc[:, input_variables]
+    target_df = target_df.loc[:, input_variables]
+
+    na_action = cast(str, model.get("na_action", "add_indicator"))
+    if na_action == "drop":
+        sample_df, sample_weights = balance_util.drop_na_rows(
+            sample_df, sample_weights, "sample"
+        )
+        target_df, target_weights = balance_util.drop_na_rows(
+            target_df, target_weights, "target"
+        )
+    elif na_action == "add_indicator":
+        sample_df = pd.DataFrame(_safe_fillna_and_infer(sample_df, "__NaN__"))
+        target_df = pd.DataFrame(_safe_fillna_and_infer(target_df, "__NaN__"))
+    else:
+        raise ValueError(
+            "Poststratify model has invalid na_action metadata "
+            f"'{na_action}' for predict_weights()."
+        )
+
+    sample_df, _target_df = balance_adjustment.apply_transformations(
+        (sample_df, target_df),
+        transformations=model["transformations"],
+        drop=bool(model["transformations_drop"]),
+    )
+    for column in variables:
+        if column not in sample_df.columns:
+            raise ValueError(
+                "Poststratify transform output is missing stored variable "
+                f"'{column}' required for predict_weights()."
+            )
+    sample_df = sample_df.loc[:, variables]
+
+    ratio_name = "_cell_ratio"
+    while ratio_name in sample_df.columns:
+        ratio_name = f"{ratio_name}_tmp"
+    sample_with_ratio = sample_df.join(ratio_series.rename(ratio_name), on=variables)
+    missing_ratio = sample_with_ratio[ratio_name].isna()
+    if bool(missing_ratio.any()):
+        if bool(model.get("strict_matching", True)):
+            raise ValueError(
+                "Poststratify predict_weights() found sample cells missing from "
+                "stored fit-time cell ratios. Re-fit with compatible cells or "
+                "fit with strict_matching=False."
+            )
+        logger.warning(
+            "Poststratify predict_weights() encountered sample cells missing from "
+            "stored fit-time cell ratios; assigning zero weights to those rows."
+        )
+        sample_with_ratio[ratio_name] = _safe_fillna_and_infer(
+            sample_with_ratio[ratio_name], 0
+        )
+
+    raw_weights = sample_with_ratio[ratio_name] * sample_weights
+    raw_total = float(raw_weights.sum())
+    target_total = float(target_weights.sum()) if is_transfer else raw_total
+    if not np.isfinite(target_total):
+        raise ValueError(
+            "Poststratify predict_weights() cannot normalize to a non-finite "
+            "target weight total."
+        )
+    if np.isclose(raw_total, 0.0) and not np.isclose(target_total, 0.0):
+        raise ValueError(
+            "Poststratify predict_weights() produced zero total raw weights, "
+            "so it cannot normalize to the requested target total. This usually "
+            "means every scoring row fell in a missing or zero-mass fit-time cell."
+        )
+
+    trimmed = balance_adjustment.trim_weights(
+        raw_weights,
+        target_sum_weights=target_total,
+        weight_trimming_mean_ratio=model["weight_trimming_mean_ratio"],
+        weight_trimming_percentile=model["weight_trimming_percentile"],
+        keep_sum_of_weights=bool(model["keep_sum_of_weights"]),
+    )
+    if na_action == "drop":
+        predicted_full = pd.Series(
+            np.nan, index=sample_weights_full.index, dtype=float
+        ).rename(trimmed.name)
+        predicted_full.loc[trimmed.index] = trimmed.to_numpy()
+        trimmed = predicted_full
+    return trimmed
 
 
 def _variables_from_formula(

--- a/balance/weighting_methods/rake.py
+++ b/balance/weighting_methods/rake.py
@@ -540,6 +540,12 @@ def rake(
 # transfer-rejection branch and its breaking-change burden on users. The
 # helper should live alongside ``apply_transformations`` so all four
 # weighting methods (rake/cbps/poststratify/ipw) can share it.
+#
+# NOTE: this guard logic is now duplicated in
+# ``weighting_methods/poststratify.py::_predict_weights_from_model``
+# (D105128469). CBPS and IPW will need the same guard when they gain
+# transfer-mode support. Extracting the shared helper is increasingly
+# load-bearing as the duplication grows.
 def _predict_weights_from_model(
     model: dict[str, Any],
     sample_df: pd.DataFrame,

--- a/tests/test_balance_frame.py
+++ b/tests/test_balance_frame.py
@@ -3599,6 +3599,336 @@ class TestBalanceFrameSklearnLikeApi(BalanceTestCase):
             atol=1e-8,
         )
 
+    def test_predict_weights_poststratify_data_argument_scores_holdout(self) -> None:
+        train_df = pd.DataFrame(
+            {
+                "id": ["s1", "s2", "s3", "s4"],
+                "weight": [1.0, 1.0, 1.0, 1.0],
+                "age_group": ["young", "young", "old", "old"],
+            }
+        )
+        train_target_df = pd.DataFrame(
+            {
+                "id": ["t1", "t2", "t3", "t4"],
+                "weight": [1.0, 1.0, 1.0, 1.0],
+                "age_group": ["young", "old", "old", "old"],
+            }
+        )
+        holdout_df = pd.DataFrame(
+            {
+                "id": ["h1", "h2", "h3", "h4"],
+                "weight": [2.0, 1.0, 1.0, 2.0],
+                "age_group": ["young", "old", "old", "young"],
+            }
+        )
+        holdout_target_df = pd.DataFrame(
+            {
+                "id": ["u1", "u2", "u3", "u4", "u5"],
+                "weight": [2.0, 2.0, 2.0, 2.0, 2.0],
+                "age_group": ["young", "young", "old", "old", "old"],
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(train_df),
+            target=SampleFrame.from_frame(train_target_df),
+        ).fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+        )
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(holdout_df),
+            target=SampleFrame.from_frame(holdout_target_df),
+        )
+
+        with self.assertLogs("balance", level="WARNING") as cm:
+            weights = fitted.predict_weights(data=holdout)
+
+        self.assertIn("transfer operation", " ".join(cm.output))
+        self.assertEqual(list(weights.index), list(holdout._sf_sample.df.index))
+        self.assertAlmostEqual(float(weights.sum()), 10.0, places=6)
+        np.testing.assert_allclose(weights.to_numpy(), [2.0, 3.0, 3.0, 2.0])
+
+    def test_predict_weights_poststratify_data_requires_target(self) -> None:
+        df = pd.DataFrame(
+            {
+                "id": ["s1", "s2"],
+                "weight": [1.0, 1.0],
+                "age_group": ["young", "old"],
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(df.copy()),
+            target=SampleFrame.from_frame(df.copy()),
+        ).fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+        )
+        no_target = BalanceFrame(sample=SampleFrame.from_frame(df.copy()))
+
+        with self.assertRaisesRegex(ValueError, "data must have a target set"):
+            fitted.predict_weights(data=no_target)
+
+    def test_predict_weights_poststratify_data_deterministic_transform_allowed(
+        self,
+    ) -> None:
+        df = pd.DataFrame(
+            {
+                "id": [f"i{i}" for i in range(6)],
+                "weight": np.ones(6),
+                "age_group": ["young", "old", "young", "old", "young", "old"],
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(df.copy()),
+            target=SampleFrame.from_frame(df.copy()),
+        ).fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations={"age_group": _astype_str},
+        )
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(df.copy()),
+            target=SampleFrame.from_frame(df.copy()),
+        )
+
+        with self.assertLogs("balance", level="WARNING") as cm:
+            weights = fitted.predict_weights(data=holdout)
+
+        self.assertIn("transfer operation", " ".join(cm.output))
+        np.testing.assert_allclose(weights.to_numpy(), np.ones(6))
+
+    def test_predict_weights_poststratify_default_transformations_transfer_rejected(
+        self,
+    ) -> None:
+        df = pd.DataFrame(
+            {
+                "id": [f"i{i}" for i in range(8)],
+                "weight": np.ones(8),
+                "age_group": ["young", "old"] * 4,
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(df.copy()),
+            target=SampleFrame.from_frame(df.copy()),
+        ).fit(method="poststratify", variables=["age_group"])
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(df.copy()),
+            target=SampleFrame.from_frame(df.copy()),
+        )
+
+        with self.assertRaisesRegex(ValueError, "transformations='default'"):
+            fitted.predict_weights(data=holdout)
+
+    def test_predict_weights_poststratify_data_dependent_transform_rejected(
+        self,
+    ) -> None:
+        from balance.utils.data_transformation import quantize
+
+        df = pd.DataFrame(
+            {
+                "id": [f"i{i}" for i in range(8)],
+                "weight": np.ones(8),
+                "age": np.linspace(20.0, 80.0, 8),
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(df.copy()),
+            target=SampleFrame.from_frame(df.copy()),
+        ).fit(
+            method="poststratify",
+            variables=["age"],
+            transformations={"age": quantize},
+        )
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(df.copy()),
+            target=SampleFrame.from_frame(df.copy()),
+        )
+
+        with self.assertRaisesRegex(ValueError, "data-dependent transformations"):
+            fitted.predict_weights(data=holdout)
+
+    def test_predict_weights_poststratify_data_requires_transform_origin(
+        self,
+    ) -> None:
+        df = pd.DataFrame(
+            {
+                "id": ["s1", "s2"],
+                "weight": [1.0, 1.0],
+                "age_group": ["young", "old"],
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(df.copy()),
+            target=SampleFrame.from_frame(df.copy()),
+        ).fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+        )
+        model = _assert_type(fitted.model)
+        model.pop("transformations_origin", None)
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(df.copy()),
+            target=SampleFrame.from_frame(df.copy()),
+        )
+
+        with self.assertRaisesRegex(ValueError, "transformations_origin metadata"):
+            fitted.predict_weights(data=holdout)
+
+    def test_predict_weights_poststratify_data_all_missing_cells_raises(
+        self,
+    ) -> None:
+        train_df = pd.DataFrame(
+            {
+                "id": ["s1", "s2"],
+                "weight": [1.0, 1.0],
+                "age_group": ["young", "old"],
+            }
+        )
+        holdout_df = pd.DataFrame(
+            {
+                "id": ["h1", "h2"],
+                "weight": [1.0, 1.0],
+                "age_group": ["new", "new"],
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(train_df.copy()),
+            target=SampleFrame.from_frame(train_df.copy()),
+        ).fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+            strict_matching=False,
+        )
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(holdout_df),
+            target=SampleFrame.from_frame(train_df.copy()),
+        )
+
+        with self.assertRaisesRegex(ValueError, "zero total raw weights"):
+            fitted.predict_weights(data=holdout)
+
+    def test_predict_weights_poststratify_data_na_drop_reconstructs(self) -> None:
+        # Transfer-mode coverage for na_action='drop': rows with NaN
+        # covariates in the holdout must come back as NaN at the
+        # original positions; non-NaN rows must be scored normally and
+        # rescaled to the holdout target's total weight.
+        train_df = pd.DataFrame(
+            {
+                "id": ["s1", "s2", "s3", "s4"],
+                "weight": [1.0, 1.0, 1.0, 1.0],
+                "age_group": ["young", "young", "old", "old"],
+            }
+        )
+        train_target_df = pd.DataFrame(
+            {
+                "id": ["t1", "t2", "t3", "t4"],
+                "weight": [1.0, 1.0, 1.0, 1.0],
+                "age_group": ["young", "old", "old", "old"],
+            }
+        )
+        holdout_df = pd.DataFrame(
+            {
+                "id": ["h1", "h2", "h3", "h4"],
+                "weight": [2.0, 1.0, 1.0, 2.0],
+                "age_group": ["young", None, "old", "young"],
+            }
+        )
+        holdout_target_df = pd.DataFrame(
+            {
+                "id": ["u1", "u2", "u3"],
+                "weight": [2.0, 2.0, 2.0],
+                "age_group": ["young", "old", "old"],
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(train_df),
+            target=SampleFrame.from_frame(train_target_df),
+        ).fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+            na_action="drop",
+        )
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(holdout_df),
+            target=SampleFrame.from_frame(holdout_target_df),
+        )
+
+        with self.assertLogs("balance", level="WARNING"):
+            weights = fitted.predict_weights(data=holdout)
+
+        self.assertEqual(list(weights.index), list(holdout._sf_sample.df.index))
+        # The NaN holdout row (h2) should drop and come back as NaN at
+        # its original position; non-NaN rows should sum to the holdout
+        # target's total weight (6.0).
+        self.assertTrue(bool(np.isnan(weights.iloc[1])))
+        non_nan = weights.dropna()
+        self.assertAlmostEqual(float(non_nan.sum()), 6.0, places=6)
+
+    def test_predict_weights_poststratify_data_strict_matching_false_partial_missing(
+        self,
+    ) -> None:
+        # Transfer-mode coverage for the strict_matching=False + partial
+        # missing cells path: rows in cells absent from the stored ratio
+        # surface should receive zero weight (with a logged warning),
+        # while rows in present cells should be scored and rescaled.
+        train_df = pd.DataFrame(
+            {
+                "id": ["s1", "s2", "s3", "s4"],
+                "weight": [1.0, 1.0, 1.0, 1.0],
+                "age_group": ["young", "young", "old", "old"],
+            }
+        )
+        train_target_df = pd.DataFrame(
+            {
+                "id": ["t1", "t2", "t3", "t4"],
+                "weight": [1.0, 1.0, 1.0, 1.0],
+                "age_group": ["young", "old", "old", "old"],
+            }
+        )
+        holdout_df = pd.DataFrame(
+            {
+                "id": ["h1", "h2", "h3", "h4"],
+                "weight": [1.0, 1.0, 1.0, 1.0],
+                "age_group": ["young", "new_cell", "old", "old"],
+            }
+        )
+        holdout_target_df = pd.DataFrame(
+            {
+                "id": ["u1", "u2", "u3"],
+                "weight": [2.0, 2.0, 2.0],
+                "age_group": ["young", "old", "old"],
+            }
+        )
+        fitted = BalanceFrame(
+            sample=SampleFrame.from_frame(train_df),
+            target=SampleFrame.from_frame(train_target_df),
+        ).fit(
+            method="poststratify",
+            variables=["age_group"],
+            transformations=None,
+            strict_matching=False,
+        )
+        holdout = BalanceFrame(
+            sample=SampleFrame.from_frame(holdout_df),
+            target=SampleFrame.from_frame(holdout_target_df),
+        )
+
+        with self.assertLogs("balance", level="WARNING") as cm:
+            weights = fitted.predict_weights(data=holdout)
+
+        joined = " ".join(cm.output)
+        self.assertIn("assigning zero weights", joined)
+        self.assertIn("transfer operation", joined)
+        # The 'new_cell' row (h2) gets zero weight; the rest are scored
+        # and rescaled to the holdout target's total weight (6.0).
+        self.assertAlmostEqual(float(weights.iloc[1]), 0.0, places=6)
+        self.assertAlmostEqual(float(weights.sum()), 6.0, places=6)
+
     def test_predict_weights_poststratify_requires_fit_metadata(self) -> None:
         sample_df = pd.DataFrame(
             {

--- a/tests/test_poststratify.py
+++ b/tests/test_poststratify.py
@@ -22,6 +22,10 @@ from balance.util import _assert_type
 from balance.weighting_methods.poststratify import poststratify
 
 
+def _astype_str(s: pd.Series) -> pd.Series:
+    return s.astype(str)
+
+
 class Testpoststratify(
     balance.testutil.BalanceTestCase,
 ):
@@ -205,6 +209,7 @@ class Testpoststratify(
         self.assertIn("training_sample_weights", model)
         self.assertIn("training_target_weights", model)
         self.assertIn("variables", model)
+        self.assertIsNone(model.get("transformations_origin"))
         self.assertTrue(bool(model.get("store_fit_metadata")))
 
     def test_poststratify_stores_resolved_default_transformations_in_metadata(
@@ -227,6 +232,7 @@ class Testpoststratify(
         model = result["model"]
         assert isinstance(model, dict)
         self.assertIsInstance(model.get("transformations"), dict)
+        self.assertEqual(model.get("transformations_origin"), "default")
         self.assertEqual(set(model["transformations"].keys()), {"a", "b"})
 
     def test_poststratify_defaults_to_minimal_model_payload(self) -> None:
@@ -1268,3 +1274,123 @@ class Testpoststratify(
                 transformations="default",
                 strict_matching=False,
             )
+
+    def test_poststratify_stores_explicit_dict_in_transformations_origin(
+        self,
+    ) -> None:
+        # Pins the contract that transformations_origin stores the
+        # user-supplied dict verbatim — downstream transfer guards rely
+        # on this to detect data-dependent helpers (quantize / fct_lump).
+        sample_df = pd.DataFrame({"a": ["x", "y", "x"], "b": ["p", "q", "p"]})
+        target_df = pd.DataFrame({"a": ["x", "y", "x"], "b": ["p", "q", "p"]})
+        s_weights = pd.Series([1.0, 1.0, 1.0])
+        t_weights = pd.Series([1.0, 1.0, 1.0])
+        transformations = {"a": _astype_str, "b": _astype_str}
+
+        result = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            variables=["a", "b"],
+            transformations=transformations,
+            store_fit_metadata=True,
+        )
+        model = result["model"]
+        assert isinstance(model, dict)
+        self.assertEqual(model.get("transformations_origin"), transformations)
+
+    def test_predict_weights_from_model_direct_call_in_place_replay(self) -> None:
+        # Direct-call coverage for _predict_weights_from_model with
+        # is_transfer=False — pins the helper's public contract
+        # independently of the BalanceFrame wrapper.
+        from balance.weighting_methods.poststratify import _predict_weights_from_model
+
+        sample_df = pd.DataFrame(
+            {"age_group": ["young", "young", "old", "old"]},
+            index=pd.Index(["s0", "s1", "s2", "s3"]),
+        )
+        target_df = pd.DataFrame(
+            {"age_group": ["young", "old", "old", "old"]},
+            index=pd.Index(["t0", "t1", "t2", "t3"]),
+        )
+        s_weights = pd.Series([1.0, 1.0, 1.0, 1.0], index=sample_df.index)
+        t_weights = pd.Series([1.0, 1.0, 1.0, 1.0], index=target_df.index)
+        result = poststratify(
+            sample_df=sample_df,
+            sample_weights=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            variables=["age_group"],
+            transformations=None,
+            store_fit_metadata=True,
+        )
+        model = result["model"]
+        assert isinstance(model, dict)
+
+        predicted = _predict_weights_from_model(
+            model=model,
+            sample_df=sample_df,
+            sample_weights_full=s_weights,
+            target_df=target_df,
+            target_weights=t_weights,
+            is_transfer=False,
+        )
+
+        self.assertEqual(list(predicted.index), list(sample_df.index))
+        # Cell ratios: young=1/2, old=3/2. Raw=[0.5, 0.5, 1.5, 1.5],
+        # sum=4.0; in-place replay normalizes to raw sum (no rescale).
+        np.testing.assert_allclose(predicted.to_numpy(), [0.5, 0.5, 1.5, 1.5])
+
+    def test_predict_weights_from_model_direct_call_transfer(self) -> None:
+        # Direct-call coverage for _predict_weights_from_model with
+        # is_transfer=True — verifies the rescale-to-target-sum
+        # contract independently of the BalanceFrame wrapper.
+        from balance.weighting_methods.poststratify import _predict_weights_from_model
+
+        train_sample_df = pd.DataFrame(
+            {"age_group": ["young", "young", "old", "old"]},
+            index=pd.Index(["s0", "s1", "s2", "s3"]),
+        )
+        train_target_df = pd.DataFrame(
+            {"age_group": ["young", "old", "old", "old"]},
+            index=pd.Index(["t0", "t1", "t2", "t3"]),
+        )
+        train_s = pd.Series([1.0, 1.0, 1.0, 1.0], index=train_sample_df.index)
+        train_t = pd.Series([1.0, 1.0, 1.0, 1.0], index=train_target_df.index)
+        result = poststratify(
+            sample_df=train_sample_df,
+            sample_weights=train_s,
+            target_df=train_target_df,
+            target_weights=train_t,
+            variables=["age_group"],
+            transformations=None,
+            store_fit_metadata=True,
+        )
+        model = result["model"]
+        assert isinstance(model, dict)
+
+        score_sample_df = pd.DataFrame(
+            {"age_group": ["young", "old", "old", "young"]},
+            index=pd.Index(["h0", "h1", "h2", "h3"]),
+        )
+        score_target_df = pd.DataFrame(
+            {"age_group": ["young", "young", "old", "old", "old"]},
+            index=pd.Index(["u0", "u1", "u2", "u3", "u4"]),
+        )
+        score_s = pd.Series([2.0, 1.0, 1.0, 2.0], index=score_sample_df.index)
+        score_t = pd.Series([2.0, 2.0, 2.0, 2.0, 2.0], index=score_target_df.index)
+
+        predicted = _predict_weights_from_model(
+            model=model,
+            sample_df=score_sample_df,
+            sample_weights_full=score_s,
+            target_df=score_target_df,
+            target_weights=score_t,
+            is_transfer=True,
+        )
+
+        # Raw = [0.5*2, 1.5*1, 1.5*1, 0.5*2] = [1, 1.5, 1.5, 1] sum=5;
+        # rescaled to target sum 10: [2, 3, 3, 2].
+        np.testing.assert_allclose(predicted.to_numpy(), [2.0, 3.0, 3.0, 2.0])
+        self.assertAlmostEqual(float(predicted.sum()), 10.0, places=6)


### PR DESCRIPTION
Summary:
Adds `predict_weights(data=...)` (transfer scoring) for poststratify, mirroring the existing rake transfer path.

- Refactors the ~170-line inline `_predict_weights_poststratify` in `balance_frame.py` into a thin wrapper that delegates to a new `_predict_weights_from_model` helper in `weighting_methods/poststratify.py`. The helper handles both `is_transfer=True` (transfer) and `is_transfer=False` (refit) modes.
- Stores `transformations_origin` in the model dict at fit time so transfer can reject `transformations='default'` and direct `quantize`/`fct_lump` (data-dependent) for safety.
- Models pickled before this release lack `transformations_origin` and must be re-fit to use transfer scoring; in-place `predict_weights()` continues to work on older pickles.

Self-review pass addresses:
- Doc drift: updates the `predict_weights` docstring (method-list bullet + Args) so it documents poststratify `data=...` support.
- CLAUDE.md: replaces `Optional["BalanceFrame"]` with `BalanceFrame | None` per balance PEP 604 rule; drops the redundant `Optional` import.
- Wrapper symmetry with rake: drops the redundant `_require_target()` branch (the public `predict_weights()` already validates), renames `target_weights_full` → `target_weights` in the helper signature to match rake.
- Docstring depth: expands wrapper + helper docstrings to match rake's Args/Returns/Raises sections and validation-order rationale.
- Error message guidance: adds concrete `partial(quantize_with_edges, edges=...)` / `partial(fct_lump, kept_levels=...)` examples mirroring rake's wording.
- Best-effort-guard comment: ports rake's rationale block explaining what the `quantize`/`fct_lump` check catches and misses (`functools.partial`, wrappers, user-defined transforms).
- Transfer warning: expands to spell out the two-pronged validity caveat (similar joint distribution + similar target cell distribution), parallel to rake.
- `na_action` coercion: uses `cast(str, ...)` for parity with rake.
- Error message tail consistency: data-path error now ends with "Use adjust() to obtain weights directly for other methods." matching the no-data path.
- `rake.py` TODO: notes that `_predict_weights_from_model` is now duplicated in poststratify.py; extraction to a shared helper is increasingly load-bearing.

Test additions:
- `test_predict_weights_poststratify_data_na_drop_reconstructs` — transfer-mode coverage for `na_action='drop'` (NaN row reindex path).
- `test_predict_weights_poststratify_data_strict_matching_false_partial_missing` — transfer-mode coverage for `strict_matching=False` with partial missing cells (log-warn-and-zero path).
- `test_poststratify_stores_explicit_dict_in_transformations_origin` — pins the contract that the user-supplied dict is stored verbatim.
- `test_predict_weights_from_model_direct_call_in_place_replay` and `..._transfer` — direct-call coverage for the helper, symmetric with `test_rake.py`.


Test Plan:
```
bash fbcode/core_stats/balance/run_balance_tests.sh test_balance_frame.py -k "test_predict_weights_poststratify"
# 19 passed (includes 2 new transfer-mode tests)

bash fbcode/core_stats/balance/run_balance_tests.sh test_poststratify.py
# 32 passed (includes 1 new contract test + 2 new direct-call tests)

bash fbcode/core_stats/balance/run_balance_tests.sh test_balance_frame.py
# 313 passed (full file, no regressions)

bash fbcode/core_stats/balance/run_balance_tests.sh test_ascii_plots.py
# 79 passed

bash fbcode/core_stats/balance/run_balance_tests.sh test_balancedf.py
# 154 passed

arc f
# ok No lint issues.
```

Differential Revision: D105128469

Pulled By: talgalili


