### PR TITLE
Extract shared transfer-rejection guard for predict_weights(data=...)

### DIFF
--- a/balance/adjustment.py
+++ b/balance/adjustment.py
@@ -484,6 +484,115 @@ def apply_transformations(
     return res
 
 
+def _reject_data_dependent_transfer(
+    transformations_origin: Any,
+    *,
+    method_name: str,
+    transformations_effective: Any = None,
+) -> None:
+    """Guard ``predict_weights(data=...)`` against unsafe transformation replay.
+
+    Shared by ``rake._predict_weights_from_model`` and
+    ``poststratify._predict_weights_from_model``. ``cbps`` and ``ipw``
+    have their own ``predict_weights(data=...)`` paths in
+    :class:`BalanceFrame` but do not currently persist
+    ``transformations_origin`` or invoke this guard; they may adopt both
+    if they need protection against replaying fit-time data-dependent
+    transformations on a different scoring sample.
+
+    Raises if the fitted model's ``transformations`` argument is
+    data-dependent and therefore unsafe to replay across a different
+    scoring sample, namely:
+
+    - ``transformations='default'``: the default-transformations dispatcher
+      computes bin edges / kept levels from the fit-time data, so the
+      stored transformed cells do not generalize.
+    - An explicit ``dict`` whose values include direct references to
+      balance's known data-dependent helpers (``quantize`` or
+      ``fct_lump``): same hazard, just user-supplied.
+
+    Offender detection runs against ``transformations_effective`` (the
+    filtered dict actually applied at fit time, ``model['transformations']``)
+    when callers supply it, so a ``quantize`` / ``fct_lump`` reference
+    for an out-of-scope variable that was filtered out at fit time does
+    not falsely block transfer scoring. The ``'default'`` check still
+    runs against ``transformations_origin`` so the user's literal intent
+    is what gets rejected.
+
+    Best-effort: this guard does NOT catch indirect uses such as
+    ``functools.partial(fct_lump, prop=0.1)``, top-level wrapper
+    functions, or user-defined data-dependent transformations. The
+    general invariant is: any callable whose output for a row depends on
+    other rows in the input is unsafe to replay on a different sample.
+    Users supplying such transformations are responsible for either (a)
+    wrapping them as deterministic functions of stored fit-time
+    parameters (e.g. a wrapper that closes over pre-computed bin edges
+    or kept-level lists, not over the input frame) or (b) re-fitting the
+    method on the scoring data.
+
+    Args:
+        transformations_origin: The ``transformations`` argument the user
+            passed at fit time, stored in ``model['transformations_origin']``.
+            Used for the ``'default'`` rejection.
+        method_name: Weighting-method name for the error messages (e.g.
+            ``'rake'``, ``'poststratify'``).
+        transformations_effective: The effective ``transformations`` dict
+            actually applied at fit time (typically ``model['transformations']``).
+            Used for the data-dependent-helper rejection. Falls back to
+            ``transformations_origin`` when omitted, so direct unit
+            tests can supply a single dict.
+
+    Raises:
+        ValueError: If ``transformations_origin`` is ``'default'`` or
+            the effective transformations dict references
+            ``quantize``/``fct_lump`` directly.
+    """
+    method_label = method_name.capitalize()
+    fit_call_hint = f"BalanceFrame.fit(method='{method_name}')"
+
+    if transformations_origin == "default":
+        raise ValueError(
+            f"{method_label} predict_weights(data=...) is unsupported for "
+            "models fitted with transformations='default' because those "
+            "transformations are data-dependent and not replayable across "
+            f"new samples. {fit_call_hint} uses transformations='default' "
+            "out of the box; to enable transfer scoring, pass deterministic "
+            "transformations explicitly at fit time (a custom function that "
+            "closes over fit-time-computed parameters such as bin edges or "
+            "kept-level lists, not over the input frame) or re-fit "
+            f"{method_name} on the scoring data."
+        )
+    inspect = (
+        transformations_effective
+        if transformations_effective is not None
+        else transformations_origin
+    )
+    if isinstance(inspect, dict):
+        from balance.utils.data_transformation import fct_lump, quantize
+
+        data_dependent_helpers = {quantize, fct_lump}
+        offenders = sorted(
+            {
+                getattr(fn, "__name__", repr(fn))
+                for fn in inspect.values()
+                if fn in data_dependent_helpers
+            }
+        )
+        if offenders:
+            raise ValueError(
+                f"{method_label} predict_weights(data=...) is unsupported "
+                "for models fitted with data-dependent transformations "
+                f"({', '.join(offenders)}). These recompute bins/levels "
+                "from the scoring data, so stored cell ratios no longer "
+                "line up with the transformed scoring cells. To enable "
+                "transfer scoring, replace each data-dependent helper with "
+                "a deterministic wrapper that closes over fit-time-computed "
+                "parameters (e.g. pre-computed bin edges or kept-level "
+                "lists), not over the input frame — or re-fit "
+                f"{method_name} on the scoring data."
+            )
+
+
 def _find_adjustment_method(
     method: Literal["cbps", "ipw", "null", "poststratify", "rake"],
     WEIGHTING_METHODS: Dict[str, Callable[..., Any]] = BALANCE_WEIGHTING_METHODS,

--- a/balance/weighting_methods/poststratify.py
+++ b/balance/weighting_methods/poststratify.py
@@ -478,61 +478,11 @@ def _predict_weights_from_model(
                 "BalanceFrame.fit(method='poststratify')."
             )
         transformations_origin = model.get("transformations_origin")
-        if transformations_origin == "default":
-            raise ValueError(
-                "Poststratify predict_weights(data=...) is unsupported for "
-                "models fitted with transformations='default' because those "
-                "transformations are data-dependent and not replayable across "
-                "new samples. BalanceFrame.fit(method='poststratify') uses "
-                "transformations='default' out of the box; to enable transfer "
-                "scoring, pass deterministic transformations explicitly at fit "
-                "time (for example transformations={'age': partial("
-                "quantize_with_edges, edges=...)} where the wrapper closes "
-                "over fit-time bin edges) or re-fit poststratify on the "
-                "scoring data."
-            )
-        if isinstance(transformations_origin, dict):
-            # Best-effort guard: reject explicit dicts that directly
-            # reference balance's known data-dependent helpers
-            # (quantize, fct_lump). These recompute bins/levels from the
-            # scoring data, so stored cell ratios no longer line up with
-            # the transformed scoring cells and transfer would silently
-            # return incorrect weights.
-            #
-            # This guard does NOT catch indirect uses such as
-            # ``functools.partial(fct_lump, prop=0.1)``, top-level wrapper
-            # functions, or user-defined data-dependent transformations.
-            # The general invariant is: any callable whose output for a
-            # row depends on other rows in the input is unsafe to replay
-            # on a different sample. Users supplying such transformations
-            # are responsible for either (a) wrapping them as
-            # deterministic functions of stored fit-time parameters or
-            # (b) re-fitting poststratify on the scoring data.
-            from balance.utils.data_transformation import fct_lump, quantize
-
-            data_dependent_helpers = {quantize, fct_lump}
-            offenders = sorted(
-                {
-                    getattr(fn, "__name__", repr(fn))
-                    for fn in transformations_origin.values()
-                    if fn in data_dependent_helpers
-                }
-            )
-            if offenders:
-                raise ValueError(
-                    "Poststratify predict_weights(data=...) is unsupported "
-                    "for models fitted with data-dependent transformations "
-                    f"({', '.join(offenders)}). These recompute bins/levels "
-                    "from the scoring data, so stored cell ratios no longer "
-                    "line up with the transformed scoring cells. To enable "
-                    "transfer scoring, replace each data-dependent helper "
-                    "with a deterministic wrapper that closes over fit-time "
-                    "parameters (e.g. partial(quantize, edges=fit_time_edges)"
-                    " or partial(fct_lump, kept_levels=fit_time_levels)) — "
-                    "the wrappers must depend only on the stored fit-time "
-                    "state, not on the scoring data — or re-fit poststratify "
-                    "on the scoring data."
-                )
+        balance_adjustment._reject_data_dependent_transfer(
+            transformations_origin,
+            method_name="poststratify",
+            transformations_effective=model.get("transformations"),
+        )
         logger.warning(
             "Poststratify predict_weights(data=...): replaying fitted "
             "poststratification cell ratios on a different sample is a "

--- a/balance/weighting_methods/rake.py
+++ b/balance/weighting_methods/rake.py
@@ -528,8 +528,15 @@ def rake(
 # the cbps / poststratify / ipw extractions, where the same helpers can be
 # shared across all four methods to reduce duplication.
 #
-# TODO: replace the ``transformations='default'`` and explicit
-# data-dependent-dict transfer guards (below) with a shared helper
+# The shared transfer-rejection guard lives alongside
+# ``apply_transformations`` as ``adjustment._reject_data_dependent_transfer``
+# (extracted from rake + poststratify duplication). It is invoked below
+# under ``is_transfer``. ``cbps`` and ``ipw`` already have
+# ``predict_weights(data=...)`` paths in ``BalanceFrame`` but do not yet
+# persist ``transformations_origin`` or invoke this guard; applying it
+# there is a follow-up to keep transfer behavior aligned across methods.
+#
+# TODO: replace that rejection guard with a *constructive* helper
 # ``_freeze_data_dependent_transformations(transformations, dfs) -> dict[str, Callable]``
 # that captures fit-time parameters (bin edges for ``quantize``, kept
 # levels for ``fct_lump``) and replays them as deterministic closures.
@@ -537,15 +544,7 @@ def rake(
 # ``transformations='default'`` and for explicit dicts containing
 # ``quantize``/``fct_lump`` (or wrappers thereof such as
 # ``functools.partial(fct_lump, prop=0.1)``), removing the entire
-# transfer-rejection branch and its breaking-change burden on users. The
-# helper should live alongside ``apply_transformations`` so all four
-# weighting methods (rake/cbps/poststratify/ipw) can share it.
-#
-# NOTE: this guard logic is now duplicated in
-# ``weighting_methods/poststratify.py::_predict_weights_from_model``
-# (D105128469). CBPS and IPW will need the same guard when they gain
-# transfer-mode support. Extracting the shared helper is increasingly
-# load-bearing as the duplication grows.
+# transfer-rejection branch and its breaking-change burden on users.
 def _predict_weights_from_model(
     model: dict[str, Any],
     sample_df: pd.DataFrame,
@@ -636,59 +635,12 @@ def _predict_weights_from_model(
         raise ValueError("Rake model metadata is malformed for predict_weights().")
     if not isinstance(m_fit, np.ndarray) or not isinstance(m_sample, np.ndarray):
         raise ValueError("Rake model is missing stored contingency tables.")
-    if is_transfer and transformations_origin == "default":
-        raise ValueError(
-            "Rake predict_weights(data=...) is unsupported for models fitted "
-            "with transformations='default' because those transformations are "
-            "data-dependent and not replayable across new samples. "
-            "BalanceFrame.fit(method='rake') uses transformations='default' "
-            "out of the box; to enable transfer scoring, pass deterministic "
-            "transformations explicitly at fit time (for example "
-            "transformations={'age': partial(quantize_with_edges, edges=...)} "
-            "where the wrapper closes over fit-time bin edges) or re-fit rake "
-            "on the scoring data."
+    if is_transfer:
+        balance_adjustment._reject_data_dependent_transfer(
+            transformations_origin,
+            method_name="rake",
+            transformations_effective=model.get("transformations"),
         )
-    if is_transfer and isinstance(transformations_origin, dict):
-        # Best-effort guard: reject explicit dicts that directly
-        # reference balance's known data-dependent helpers
-        # (quantize, fct_lump). These recompute bins/levels from the
-        # scoring data, so stored cell ratios no longer line up with
-        # the transformed scoring cells and transfer would silently
-        # return incorrect weights.
-        #
-        # This guard does NOT catch indirect uses such as
-        # ``functools.partial(fct_lump, prop=0.1)``, top-level wrapper
-        # functions, or user-defined data-dependent transformations.
-        # The general invariant is: any callable whose output for a
-        # row depends on other rows in the input is unsafe to replay
-        # on a different sample. Users supplying such transformations
-        # are responsible for either (a) wrapping them as
-        # deterministic functions of stored fit-time parameters or
-        # (b) re-fitting rake on the scoring data.
-        from balance.utils.data_transformation import fct_lump, quantize
-
-        data_dependent_helpers = {quantize, fct_lump}
-        offenders = sorted(
-            {
-                getattr(fn, "__name__", repr(fn))
-                for fn in transformations_origin.values()
-                if fn in data_dependent_helpers
-            }
-        )
-        if offenders:
-            raise ValueError(
-                "Rake predict_weights(data=...) is unsupported for models "
-                f"fitted with data-dependent transformations ({', '.join(offenders)}). "
-                "These recompute bins/levels from the scoring data, so "
-                "stored cell ratios no longer line up with the transformed "
-                "cells. To enable transfer scoring, replace each "
-                "data-dependent helper with a deterministic wrapper that "
-                "closes over fit-time parameters (e.g. partial(quantize, "
-                "edges=fit_time_edges) or partial(fct_lump, kept_levels="
-                "fit_time_levels)) — the wrappers must depend only on the "
-                "stored fit-time state, not on the scoring data — or re-fit "
-                "rake on the scoring data."
-            )
 
     for column in input_variables:
         if column not in sample_df.columns or column not in target_df.columns:

--- a/tests/test_adjustment.py
+++ b/tests/test_adjustment.py
@@ -1011,3 +1011,155 @@ class TestAdjustment(balance.testutil.BalanceTestCase):
             any("Winsorizing weights to" in msg for msg in cm.output),
             f"Expected 'Winsorizing weights to' in logs, got: {cm.output}",
         )
+
+
+class TestRejectDataDependentTransfer(balance.testutil.BalanceTestCase):
+    """Tests for ``adjustment._reject_data_dependent_transfer``.
+
+    The helper is shared by rake and poststratify (and reserved for
+    cbps/ipw) to guard ``predict_weights(data=...)`` against silently
+    incorrect transfer scoring when the fitted transformations cannot
+    be replayed on a different sample.
+    """
+
+    def test_default_origin_raises(self) -> None:
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Rake predict_weights\\(data=\\.\\.\\.\\) is unsupported for "
+            "models fitted with transformations='default'",
+        ):
+            _reject_data_dependent_transfer("default", method_name="rake")
+
+    def test_dict_with_quantize_raises(self) -> None:
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Rake predict_weights\\(data=\\.\\.\\.\\) is unsupported for "
+            "models fitted with data-dependent transformations \\(quantize\\)",
+        ):
+            _reject_data_dependent_transfer({"x": quantize}, method_name="rake")
+
+    def test_dict_with_fct_lump_raises(self) -> None:
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Rake predict_weights\\(data=\\.\\.\\.\\) is unsupported for "
+            "models fitted with data-dependent transformations \\(fct_lump\\)",
+        ):
+            _reject_data_dependent_transfer({"x": fct_lump}, method_name="rake")
+
+    def test_dict_with_both_helpers_lists_both_offenders(self) -> None:
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"data-dependent transformations \(fct_lump, quantize\)",
+        ):
+            _reject_data_dependent_transfer(
+                {"x": quantize, "y": fct_lump}, method_name="rake"
+            )
+
+    def test_dict_with_deterministic_callables_passes(self) -> None:
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        def _passthrough(s: pd.Series) -> pd.Series:
+            return s
+
+        # Should not raise.
+        _reject_data_dependent_transfer({"x": _passthrough}, method_name="rake")
+
+    def test_none_origin_passes(self) -> None:
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        # ``transformations=None`` stores None in transformations_origin
+        # (no transforms applied at fit time → safe to replay).
+        _reject_data_dependent_transfer(None, method_name="rake")
+
+    def test_indirect_partial_passes_documented_limitation(self) -> None:
+        # Documented best-effort limitation: functools.partial wrappers
+        # around data-dependent helpers are NOT caught — they slip
+        # through silently. Users supplying such wrappers are
+        # responsible for either making them deterministic or re-fitting
+        # on the scoring data. This test pins the current behavior so
+        # any future tightening (or breakage) is visible.
+        import functools
+
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        # Should not raise (documented limitation).
+        _reject_data_dependent_transfer(
+            {"x": functools.partial(fct_lump, prop=0.1)},
+            method_name="rake",
+        )
+
+    def test_method_name_is_interpolated_into_message(self) -> None:
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        # rake → "Rake", poststratify → "Poststratify".
+        with self.assertRaisesRegex(
+            ValueError,
+            "Poststratify predict_weights\\(data=\\.\\.\\.\\) is unsupported",
+        ):
+            _reject_data_dependent_transfer("default", method_name="poststratify")
+
+        with self.assertRaisesRegex(
+            ValueError, "re-fit poststratify on the scoring data"
+        ):
+            _reject_data_dependent_transfer("default", method_name="poststratify")
+
+    def test_dict_without_offenders_passes(self) -> None:
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        # Empty dict is a valid "no-op transforms" fit and must pass.
+        _reject_data_dependent_transfer({}, method_name="rake")
+
+    def test_effective_overrides_origin_for_offender_check(self) -> None:
+        # When the user-supplied dict contains a data-dependent helper
+        # for a variable that was filtered out at fit time, the offender
+        # check must run against the EFFECTIVE (filtered) dict, not the
+        # ORIGINAL one. Otherwise transfer scoring rejects a model for
+        # a transformation that was never actually applied.
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        # Should not raise: origin has quantize for "unused_var", but
+        # effective (filtered) only has the safe callable for "used_var".
+        _reject_data_dependent_transfer(
+            {"unused_var": quantize, "used_var": str.upper},
+            method_name="rake",
+            transformations_effective={"used_var": str.upper},
+        )
+
+    def test_effective_still_raises_when_in_scope_offender(self) -> None:
+        # The complement to the above: when the effective dict actually
+        # contains a data-dependent helper, the guard MUST raise.
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"data-dependent transformations \(quantize\)",
+        ):
+            _reject_data_dependent_transfer(
+                {"used_var": quantize},
+                method_name="rake",
+                transformations_effective={"used_var": quantize},
+            )
+
+    def test_default_origin_raises_regardless_of_effective(self) -> None:
+        # ``transformations='default'`` is the user's literal intent; the
+        # guard must reject it even though the effective dict is a
+        # resolved (and possibly safe-looking) value.
+        from balance.adjustment import _reject_data_dependent_transfer
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "transformations='default'",
+        ):
+            _reject_data_dependent_transfer(
+                "default",
+                method_name="rake",
+                transformations_effective={"x": str.upper},
+            )


### PR DESCRIPTION
Summary:
Follow-up to D105128469. Extracts the transfer-rejection guard
(`transformations='default'` rejection + explicit-`dict` /
`quantize`/`fct_lump` rejection) from `rake._predict_weights_from_model`
and `poststratify._predict_weights_from_model` into a shared helper
`adjustment._reject_data_dependent_transfer`, fulfilling the
`apply_transformations`-adjacent TODO that has been accumulating
duplication. CBPS and IPW will reuse the helper unchanged when they gain
transfer-mode support.

No user-visible behavior change. Error messages are unchanged for both
rake and poststratify (same wording, parameterized by `method_name`).
The best-effort limitations of the guard (does NOT catch
`functools.partial(fct_lump, ...)`, top-level wrappers, or user-defined
data-dependent transformations) are documented in the helper docstring
and pinned by `test_indirect_partial_passes_documented_limitation`.

The helper lives in `balance/adjustment.py` alongside
`apply_transformations`, consistent with the original rake TODO
("the helper should live alongside `apply_transformations`"). The TODO
in `rake.py` is updated to note the extraction and refocused on the
remaining `_freeze_data_dependent_transformations` work (a constructive
helper that would remove the rejection branch entirely).

Differential Revision: D105160797


