### PR TITLE
Fix summary() crash when outcome model is fit without adjust()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,10 +113,12 @@ for the design rationale.
     weights are constant (`μ̂_DR` reduces to `μ̂_OM`). **Point estimate only** — no
     CI yet; see the TODOs in `balance/outcome_models/aipw.py`.
 
-- **`summary()` reports the estimator trio** when a fitted outcome model and a
-  target are both present: an "Outcome estimates" section with `μ̂_IPW` and its
-  analytic CI, plus `μ̂_OM` and `μ̂_DR` as point estimates. **With no outcome model
-  fit, `summary()` output is unchanged.** Separately,
+- **`summary()` reports outcome-model estimates** when a fitted outcome model
+  and a target are both present: an "Outcome estimates" section with `μ̂_IPW` and
+  its analytic CI, plus `μ̂_OM` as a point estimate, and `μ̂_DR` when the frame is
+  `adjust()`-calibrated (its AIPW block needs those weights; an unadjusted frame
+  with a fitted model is a supported workflow and omits it). **With no outcome
+  model fit, `summary()` output is unchanged.** Separately,
   `outcomes_hat().summary()` **scopes any doubly-robust claim to the fit weights**
   — a linear learner with an intercept fit with non-uniform weights reports
   `"doubly robust w.r.t. weights <col>"`; everything else reports plain

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -3752,6 +3752,7 @@ class BalanceFrame:
             for col in model["outcome_columns"]
             if f"{col}_hat" in target_predictions.columns
         }
+
         def _fmt_points(estimates: dict[str, float]) -> str:
             return "\n".join(
                 f"    {col}    {val:.3f}" for col, val in estimates.items()
@@ -3772,8 +3773,8 @@ class BalanceFrame:
 
         # μ̂_DR requires adjust()-calibrated responder weights on the same
         # population scale as the target (``aipw()`` enforces this). A frame
-        # with a fitted outcome model but no adjust() is a supported workflow
-        # (see the changelog), so omit the AIPW block instead of crashing.
+        # with a fitted outcome model but no adjust() is a supported workflow,
+        # so omit the AIPW block instead of crashing.
         if self.is_adjusted:
             dr_estimates = {str(col): float(v) for col, v in self.aipw().items()}
             blocks.extend(

--- a/balance/balance_frame.py
+++ b/balance/balance_frame.py
@@ -3752,8 +3752,6 @@ class BalanceFrame:
             for col in model["outcome_columns"]
             if f"{col}_hat" in target_predictions.columns
         }
-        dr_estimates = {str(col): float(v) for col, v in self.aipw().items()}
-
         def _fmt_points(estimates: dict[str, float]) -> str:
             return "\n".join(
                 f"    {col}    {val:.3f}" for col, val in estimates.items()
@@ -3770,9 +3768,20 @@ class BalanceFrame:
             "Outcome model / g-computation (mu_OM), point estimate "
             "(CI not shown; not cached):",
             _fmt_points(om_estimates),
-            "Doubly robust / AIPW (mu_DR), point estimate:",
-            _fmt_points(dr_estimates),
         ]
+
+        # μ̂_DR requires adjust()-calibrated responder weights on the same
+        # population scale as the target (``aipw()`` enforces this). A frame
+        # with a fitted outcome model but no adjust() is a supported workflow
+        # (see the changelog), so omit the AIPW block instead of crashing.
+        if self.is_adjusted:
+            dr_estimates = {str(col): float(v) for col, v in self.aipw().items()}
+            blocks.extend(
+                [
+                    "Doubly robust / AIPW (mu_DR), point estimate:",
+                    _fmt_points(dr_estimates),
+                ]
+            )
         return "Outcome estimates:\n" + "\n".join(blocks)
 
     def summary(self) -> str:

--- a/tests/test_aipw.py
+++ b/tests/test_aipw.py
@@ -315,6 +315,24 @@ class AipwTest(balance.testutil.BalanceTestCase):
         # the rich section replaces the plain "Outcome weighted means" block
         self.assertNotIn("Outcome weighted means", summary)
 
+    def test_summary_omits_dr_when_model_fit_but_unadjusted(self) -> None:
+        """summary() with a fitted outcome model but NO adjust() must not crash.
+
+        The μ̂_DR/AIPW block requires adjust()-calibrated weights, so it is
+        omitted (μ̂_IPW and μ̂_OM are still shown) rather than raising.
+        """
+        sample_df, target_df = _make_aipw_fixture()
+        s = Sample.from_frame(
+            sample_df, id_column="id", weight_column="weight", outcome_columns=["y"]
+        )
+        t = Sample.from_frame(target_df, id_column="id", weight_column="weight")
+        st = s.set_target(t).fit_outcome_model(model=LinearRegression())
+        summary = st.summary()  # previously raised ValueError from aipw()
+        self.assertIn("Outcome estimates:", summary)
+        self.assertIn("mu_IPW", summary)
+        self.assertIn("mu_OM", summary)
+        self.assertNotIn("mu_DR", summary)
+
     def test_summary_unchanged_without_outcome_model(self) -> None:
         sample_df, target_df = _make_aipw_fixture()
         s = Sample.from_frame(


### PR DESCRIPTION
## Problem

`BalanceFrame.summary()` crashed with `ValueError: aipw() requires adjust()-calibrated responder weights...` for the documented no-adjust() outcome-model workflow: a frame with a fitted outcome model, a target, and populated `outcomes_hat`, but no `adjust()` call.

Root cause: `_outcome_estimates_summary()` unconditionally called `self.aipw()` to build the doubly-robust (μ̂_DR) block, but `aipw()` correctly enforces the same-population-scale weight contract that only holds after `adjust()`.

## Fix

Guard the μ̂_DR/AIPW block on `self.is_adjusted`. Unadjusted frames still show μ̂_IPW (with CI) and μ̂_OM, and simply omit the μ̂_DR point estimate (which is undefined without calibrated weights) rather than raising.

## Test

Added `test_summary_omits_dr_when_model_fit_but_unadjusted` in `tests/test_aipw.py`: an unadjusted frame with a fitted outcome model now summarizes without raising, includes `mu_IPW` and `mu_OM`, and excludes `mu_DR`.

Full local suite: `tests/test_aipw.py` + `tests/test_outcome_model.py` → 95 passed.